### PR TITLE
Implement core-repr crate scaffold

### DIFF
--- a/.exo/.gitignore
+++ b/.exo/.gitignore
@@ -1,0 +1,3 @@
+logs/*
+worktrees/*
+messages/*

--- a/core-repr/Cargo.toml
+++ b/core-repr/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "core-repr"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+# None — zero external deps for scaffold

--- a/core-repr/src/frame.rs
+++ b/core-repr/src/frame.rs
@@ -1,0 +1,106 @@
+use crate::types::*;
+
+/// One layer of a GHC Core expression tree.
+///
+/// `A` represents child expression positions. When stored in a
+/// `RecursiveTree`, `A = NodeId`. For recursion scheme intermediates,
+/// `A` may be other types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CoreFrame<A> {
+    /// Variable reference.
+    Var(VarId),
+    /// Literal value.
+    Lit(Literal),
+    /// Function application.
+    App { fun: A, arg: A },
+    /// Lambda abstraction.
+    Lam { binder: VarId, body: A },
+    /// Non-recursive let binding.
+    LetNonRec { binder: VarId, rhs: A, body: A },
+    /// Recursive let bindings (mutually recursive group).
+    LetRec { bindings: Vec<(VarId, A)>, body: A },
+    /// Case expression with scrutinee, case binder, and alternatives.
+    Case { scrutinee: A, binder: VarId, alts: Vec<Alt<A>> },
+    /// Saturated data constructor application.
+    Con { tag: DataConId, fields: Vec<A> },
+    /// Join point definition.
+    Join { label: JoinId, params: Vec<VarId>, rhs: A, body: A },
+    /// Jump to a join point.
+    Jump { label: JoinId, args: Vec<A> },
+    /// Saturated primitive operation.
+    PrimOp { op: PrimOpKind, args: Vec<A> },
+}
+
+/// Functor mapping over the child positions of a frame.
+///
+/// This is the base functor interface that enables recursion schemes
+/// (catamorphism, anamorphism, hylomorphism) over Core expressions.
+pub trait MapLayer {
+    /// The type of child references in this frame.
+    type Child;
+    /// The same frame structure but with a different child type.
+    type Mapped<B>;
+
+    /// Apply a function to every child position in the frame,
+    /// preserving the frame's structure.
+    fn map_layer<B>(self, f: impl FnMut(Self::Child) -> B) -> Self::Mapped<B>;
+}
+
+impl<A> MapLayer for CoreFrame<A> {
+    type Child = A;
+    type Mapped<B> = CoreFrame<B>;
+
+    fn map_layer<B>(self, mut f: impl FnMut(A) -> B) -> CoreFrame<B> {
+        match self {
+            CoreFrame::Var(v) => CoreFrame::Var(v),
+            CoreFrame::Lit(l) => CoreFrame::Lit(l),
+            CoreFrame::App { fun, arg } => CoreFrame::App {
+                fun: f(fun),
+                arg: f(arg),
+            },
+            CoreFrame::Lam { binder, body } => CoreFrame::Lam {
+                binder,
+                body: f(body),
+            },
+            CoreFrame::LetNonRec { binder, rhs, body } => CoreFrame::LetNonRec {
+                binder,
+                rhs: f(rhs),
+                body: f(body),
+            },
+            CoreFrame::LetRec { bindings, body } => CoreFrame::LetRec {
+                bindings: bindings.into_iter().map(|(v, a)| (v, f(a))).collect(),
+                body: f(body),
+            },
+            CoreFrame::Case { scrutinee, binder, alts } => CoreFrame::Case {
+                scrutinee: f(scrutinee),
+                binder,
+                alts: alts
+                    .into_iter()
+                    .map(|alt| Alt {
+                        con: alt.con,
+                        binders: alt.binders,
+                        body: f(alt.body),
+                    })
+                    .collect(),
+            },
+            CoreFrame::Con { tag, fields } => CoreFrame::Con {
+                tag,
+                fields: fields.into_iter().map(&mut f).collect(),
+            },
+            CoreFrame::Join { label, params, rhs, body } => CoreFrame::Join {
+                label,
+                params,
+                rhs: f(rhs),
+                body: f(body),
+            },
+            CoreFrame::Jump { label, args } => CoreFrame::Jump {
+                label,
+                args: args.into_iter().map(&mut f).collect(),
+            },
+            CoreFrame::PrimOp { op, args } => CoreFrame::PrimOp {
+                op,
+                args: args.into_iter().map(&mut f).collect(),
+            },
+        }
+    }
+}

--- a/core-repr/src/lib.rs
+++ b/core-repr/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod types;
+pub mod frame;
+pub mod tree;
+
+pub use frame::{CoreFrame, MapLayer};
+pub use tree::{RecursiveTree, hylo};
+pub use types::*;
+
+/// A complete GHC Core expression.
+pub type CoreExpr = RecursiveTree<CoreFrame<NodeId>>;

--- a/core-repr/src/tree.rs
+++ b/core-repr/src/tree.rs
@@ -1,0 +1,138 @@
+use crate::frame::{CoreFrame, MapLayer};
+use crate::types::NodeId;
+
+/// A recursive tree stored as a flat vector of frames.
+///
+/// Each frame's child positions hold `NodeId` indices into the `nodes` vec.
+/// This enables O(1) node access and cache-friendly traversal.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecursiveTree<F> {
+    nodes: Vec<F>,
+    root: NodeId,
+}
+
+impl<F> RecursiveTree<F> {
+    /// Create a tree with a single root node.
+    pub fn singleton(frame: F) -> Self {
+        RecursiveTree {
+            nodes: vec![frame],
+            root: NodeId(0),
+        }
+    }
+
+    /// Add a node to the tree, returning its NodeId.
+    pub fn add_node(&mut self, frame: F) -> NodeId {
+        let id = NodeId(self.nodes.len() as u32);
+        self.nodes.push(frame);
+        id
+    }
+
+    /// Set the root node.
+    pub fn set_root(&mut self, id: NodeId) {
+        self.root = id;
+    }
+
+    /// Get the root NodeId.
+    pub fn root(&self) -> NodeId {
+        self.root
+    }
+
+    /// Get a reference to the frame at the given NodeId.
+    pub fn node(&self, id: NodeId) -> &F {
+        &self.nodes[id.0 as usize]
+    }
+
+    /// Get a mutable reference to the frame at the given NodeId.
+    pub fn node_mut(&mut self, id: NodeId) -> &mut F {
+        &mut self.nodes[id.0 as usize]
+    }
+
+    /// Number of nodes in the tree.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether the tree is empty.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+}
+
+impl RecursiveTree<CoreFrame<NodeId>> {
+    /// Catamorphism: fold the tree bottom-up.
+    ///
+    /// Visits every node exactly once in bottom-up order, replacing
+    /// each `CoreFrame<NodeId>` with the result of the algebra `alg`.
+    pub fn cata<T: Clone>(&self, mut alg: impl FnMut(CoreFrame<T>) -> T) -> T {
+        let mut results: Vec<Option<T>> = vec![None; self.nodes.len()];
+        let mut order = Vec::with_capacity(self.nodes.len());
+        let mut visited = vec![false; self.nodes.len()];
+        let mut stack = vec![self.root.0 as usize];
+
+        // Compute post-order traversal
+        while let Some(&idx) = stack.last() {
+            if visited[idx] {
+                stack.pop();
+                order.push(idx);
+            } else {
+                visited[idx] = true;
+                // Push children onto stack
+                self.nodes[idx].clone().map_layer(|child: NodeId| {
+                    let ci = child.0 as usize;
+                    if !visited[ci] {
+                        stack.push(ci);
+                    }
+                    child
+                });
+            }
+        }
+
+        for idx in order {
+            let frame = self.nodes[idx].clone().map_layer(|child: NodeId| {
+                results[child.0 as usize].clone().expect("child not computed")
+            });
+            results[idx] = Some(alg(frame));
+        }
+
+        results[self.root.0 as usize].clone().expect("root not computed")
+    }
+
+    /// Anamorphism: unfold a tree top-down from a seed.
+    ///
+    /// The coalgebra `coalg` produces a `CoreFrame<Seed>` from a seed.
+    /// Each `Seed` in the frame becomes a child node via recursive unfolding.
+    pub fn ana<Seed>(seed: Seed, mut coalg: impl FnMut(Seed) -> CoreFrame<Seed>) -> Self {
+        let mut nodes: Vec<CoreFrame<NodeId>> = Vec::new();
+        // Use a work queue. Process seeds breadth-first so parents get lower indices.
+        let mut queue: std::collections::VecDeque<(NodeId, Seed)> = std::collections::VecDeque::new();
+
+        // Reserve root
+        nodes.push(CoreFrame::Var(crate::types::VarId(0))); // placeholder
+        queue.push_back((NodeId(0), seed));
+
+        while let Some((node_id, seed)) = queue.pop_front() {
+            let frame = coalg(seed);
+            let frame_mapped = frame.map_layer(|child_seed| {
+                let child_id = NodeId(nodes.len() as u32);
+                nodes.push(CoreFrame::Var(crate::types::VarId(0))); // placeholder
+                queue.push_back((child_id, child_seed));
+                child_id
+            });
+            nodes[node_id.0 as usize] = frame_mapped;
+        }
+
+        RecursiveTree { nodes, root: NodeId(0) }
+    }
+}
+
+/// Hylomorphism: unfold then fold without materializing the full tree.
+pub fn hylo<Seed, T: Clone>(
+    seed: Seed,
+    mut coalg: impl FnMut(Seed) -> CoreFrame<Seed>,
+    alg: impl FnMut(CoreFrame<T>) -> T,
+) -> T {
+    // Unfold into a temporary flat buffer (like ana), then fold (like cata).
+    // This allocates the intermediate tree but frees it when done.
+    let tree = RecursiveTree::ana(seed, &mut coalg);
+    tree.cata(alg)
+}

--- a/core-repr/src/types.rs
+++ b/core-repr/src/types.rs
@@ -1,0 +1,93 @@
+/// Unique identifier for a variable binding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VarId(pub u32);
+
+/// Unique identifier for a join point label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct JoinId(pub u32);
+
+/// Unique identifier for a data constructor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DataConId(pub u32);
+
+/// Index into a RecursiveTree's node array.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NodeId(pub u32);
+
+/// Literal values from GHC Core.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Literal {
+    LitInt(i64),
+    LitWord(u64),
+    LitFloat(f64),
+    LitDouble(f64),
+    LitChar(char),
+    LitString(Vec<u8>),
+}
+
+/// Primitive operation kinds corresponding to GHC.Prim operations.
+/// The Rust evaluator implements these as native hardware operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PrimOpKind {
+    // Integer arithmetic
+    IntAdd,
+    IntSub,
+    IntMul,
+    IntQuot,
+    IntRem,
+    IntNegate,
+    // Integer comparison
+    IntEq,
+    IntNe,
+    IntLt,
+    IntLe,
+    IntGt,
+    IntGe,
+    // Word arithmetic
+    WordAdd,
+    WordSub,
+    WordMul,
+    WordQuot,
+    WordRem,
+    // Double arithmetic
+    DoubleAdd,
+    DoubleSub,
+    DoubleMul,
+    DoubleDiv,
+    DoubleNegate,
+    // Double comparison
+    DoubleEq,
+    DoubleLt,
+    DoubleLe,
+    // Conversions
+    Int2Double,
+    Double2Int,
+    Int2Word,
+    Word2Int,
+    // String operations
+    UnpackCString,
+    // Tag/enum operations
+    TagToEnum,
+    DataToTag,
+    // Evaluation control
+    Seq,
+}
+
+/// Case alternative constructor pattern.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AltCon {
+    /// Match a specific data constructor.
+    DataAlt(DataConId),
+    /// Match a specific literal value.
+    LitAlt(Literal),
+    /// Default/wildcard match.
+    Default,
+}
+
+/// A case alternative: pattern, bound variables, and body expression.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Alt<A> {
+    pub con: AltCon,
+    pub binders: Vec<VarId>,
+    pub body: A,
+}

--- a/core-repr/tests/scaffold_tests.rs
+++ b/core-repr/tests/scaffold_tests.rs
@@ -1,0 +1,116 @@
+use core_repr::*;
+use core_repr::frame::CoreFrame;
+use core_repr::tree::RecursiveTree;
+
+#[test]
+fn core_frame_has_11_variants() {
+    // Construct one of each variant to verify they all exist
+    let _: CoreFrame<NodeId> = CoreFrame::Var(VarId(0));
+    let _: CoreFrame<NodeId> = CoreFrame::Lit(Literal::LitInt(42));
+    let _: CoreFrame<NodeId> = CoreFrame::App { fun: NodeId(0), arg: NodeId(1) };
+    let _: CoreFrame<NodeId> = CoreFrame::Lam { binder: VarId(0), body: NodeId(0) };
+    let _: CoreFrame<NodeId> = CoreFrame::LetNonRec { binder: VarId(0), rhs: NodeId(0), body: NodeId(1) };
+    let _: CoreFrame<NodeId> = CoreFrame::LetRec { bindings: vec![], body: NodeId(0) };
+    let _: CoreFrame<NodeId> = CoreFrame::Case { scrutinee: NodeId(0), binder: VarId(0), alts: vec![] };
+    let _: CoreFrame<NodeId> = CoreFrame::Con { tag: DataConId(0), fields: vec![] };
+    let _: CoreFrame<NodeId> = CoreFrame::Join { label: JoinId(0), params: vec![], rhs: NodeId(0), body: NodeId(1) };
+    let _: CoreFrame<NodeId> = CoreFrame::Jump { label: JoinId(0), args: vec![] };
+    let _: CoreFrame<NodeId> = CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![] };
+}
+
+#[test]
+fn map_layer_preserves_structure() {
+    let frame: CoreFrame<u32> = CoreFrame::App { fun: 1, arg: 2 };
+    let mapped: CoreFrame<u64> = frame.map_layer(|x| x as u64 * 10);
+    assert_eq!(mapped, CoreFrame::App { fun: 10, arg: 20 });
+}
+
+#[test]
+fn map_layer_identity() {
+    let frame: CoreFrame<u32> = CoreFrame::Case {
+        scrutinee: 0,
+        binder: VarId(1),
+        alts: vec![Alt { con: AltCon::Default, binders: vec![], body: 2 }],
+    };
+    let mapped = frame.clone().map_layer(|x| x);
+    assert_eq!(frame, mapped);
+}
+
+#[test]
+fn map_layer_leaves_have_no_children() {
+    let var: CoreFrame<u32> = CoreFrame::Var(VarId(0));
+    let mut called = false;
+    let _mapped: CoreFrame<u64> = var.map_layer(|_| { called = true; 0u64 });
+    assert!(!called, "Var has no children, f should not be called");
+}
+
+#[test]
+fn recursive_tree_build_and_access() {
+    // Build: (\x -> x)
+    let mut tree = RecursiveTree::singleton(CoreFrame::Var(VarId(0)));
+    let var_id = tree.root();
+    let lam_node = tree.add_node(CoreFrame::Lam { binder: VarId(0), body: var_id });
+    tree.set_root(lam_node);
+    assert_eq!(tree.len(), 2);
+    assert_eq!(tree.root(), lam_node);
+}
+
+#[test]
+fn cata_counts_nodes() {
+    // Build: App(Lit(1), Lit(2))
+    let mut tree: CoreExpr = RecursiveTree::singleton(CoreFrame::Lit(Literal::LitInt(1)));
+    let lit1 = tree.root();
+    let lit2 = tree.add_node(CoreFrame::Lit(Literal::LitInt(2)));
+    let app = tree.add_node(CoreFrame::App { fun: lit1, arg: lit2 });
+    tree.set_root(app);
+
+    let count = tree.cata(|frame: CoreFrame<usize>| -> usize {
+        match frame {
+            CoreFrame::App { fun, arg } => 1 + fun + arg,
+            _ => 1,
+        }
+    });
+    assert_eq!(count, 3);
+}
+
+#[test]
+fn ana_builds_tree() {
+    // Build a chain: Lam(x0, Lam(x1, Lam(x2, Var(x2))))
+    let tree = RecursiveTree::ana(0u32, |depth| {
+        if depth >= 3 {
+            CoreFrame::Var(VarId(depth))
+        } else {
+            CoreFrame::Lam { binder: VarId(depth), body: depth + 1 }
+        }
+    });
+    assert_eq!(tree.len(), 4); // 3 Lams + 1 Var
+}
+
+#[test]
+fn hylo_roundtrip() {
+    // hylo that counts depth of a linear chain
+    let depth = core_repr::hylo(
+        0u32,
+        |n| {
+            if n >= 5 {
+                CoreFrame::Lit(Literal::LitInt(n as i64))
+            } else {
+                CoreFrame::Lam { binder: VarId(n), body: n + 1 }
+            }
+        },
+        |frame: CoreFrame<usize>| -> usize {
+            match frame {
+                CoreFrame::Lam { body, .. } => 1 + body,
+                _ => 1,
+            }
+        },
+    );
+    assert_eq!(depth, 6); // 5 Lams + 1 Lit
+}
+
+#[test]
+fn core_expr_is_type_alias() {
+    // Verify CoreExpr is usable as RecursiveTree<CoreFrame<NodeId>>
+    let tree: CoreExpr = RecursiveTree::singleton(CoreFrame::Lit(Literal::LitInt(0)));
+    let _: &CoreFrame<NodeId> = tree.node(tree.root());
+}


### PR DESCRIPTION
This PR implements the core-repr crate scaffold as specified in phase-1/core-repr.md.

Changes:
- Created `core-repr/Cargo.toml` (edition 2024, zero dependencies).
- Implemented `core-repr/src/types.rs` with core identifiers and literals.
- Implemented `core-repr/src/frame.rs` with `CoreFrame` (11 variants) and `MapLayer` trait (GATs).
- Implemented `core-repr/src/tree.rs` with `RecursiveTree` and recursion schemes (`cata`, `ana`, `hylo`).
  - `cata` uses post-order traversal.
  - `ana` uses BFS (parents before children).
- Created `core-repr/src/lib.rs` with module exports and `CoreExpr` type alias.
- Added 9 tests in `core-repr/tests/scaffold_tests.rs` verifying all requirements.

All tests passed and clippy is clean.