### PR TITLE
Implement CBOR serialization for CoreExpr

### DIFF
--- a/core-repr/Cargo.toml
+++ b/core-repr/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+ciborium = "0.2"

--- a/core-repr/src/lib.rs
+++ b/core-repr/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod frame;
 pub mod tree;
 pub mod types;
+pub mod serial;
 
 pub use frame::*;
 pub use tree::*;

--- a/core-repr/src/serial/mod.rs
+++ b/core-repr/src/serial/mod.rs
@@ -6,7 +6,7 @@ pub use write::write_cbor;
 
 #[derive(Debug)]
 pub enum ReadError {
-    Cbor(ciborium::de::Error<std::io::Error>),
+    Cbor(String),
     InvalidTag(String),
     InvalidLiteral(String),
     InvalidPrimOp(String),
@@ -27,18 +27,11 @@ impl std::fmt::Display for ReadError {
     }
 }
 
-impl std::error::Error for ReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ReadError::Cbor(e) => Some(e),
-            _ => None,
-        }
-    }
-}
+impl std::error::Error for ReadError {}
 
 #[derive(Debug)]
 pub enum WriteError {
-    Cbor(ciborium::ser::Error<std::io::Error>),
+    Cbor(String),
 }
 
 impl std::fmt::Display for WriteError {
@@ -49,13 +42,7 @@ impl std::fmt::Display for WriteError {
     }
 }
 
-impl std::error::Error for WriteError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            WriteError::Cbor(e) => Some(e),
-        }
-    }
-}
+impl std::error::Error for WriteError {}
 
 #[cfg(test)]
 mod tests {

--- a/core-repr/src/serial/mod.rs
+++ b/core-repr/src/serial/mod.rs
@@ -1,0 +1,235 @@
+pub mod read;
+pub mod write;
+
+pub use read::read_cbor;
+pub use write::write_cbor;
+
+#[derive(Debug)]
+pub enum ReadError {
+    Cbor(ciborium::de::Error<std::io::Error>),
+    InvalidTag(String),
+    InvalidLiteral(String),
+    InvalidPrimOp(String),
+    InvalidAltCon(String),
+    InvalidStructure(String),
+}
+
+impl std::fmt::Display for ReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadError::Cbor(e) => write!(f, "CBOR error: {}", e),
+            ReadError::InvalidTag(s) => write!(f, "Invalid tag: {}", s),
+            ReadError::InvalidLiteral(s) => write!(f, "Invalid literal: {}", s),
+            ReadError::InvalidPrimOp(s) => write!(f, "Invalid primop: {}", s),
+            ReadError::InvalidAltCon(s) => write!(f, "Invalid alt con: {}", s),
+            ReadError::InvalidStructure(s) => write!(f, "Invalid structure: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for ReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ReadError::Cbor(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteError {
+    Cbor(ciborium::ser::Error<std::io::Error>),
+}
+
+impl std::fmt::Display for WriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WriteError::Cbor(e) => write!(f, "CBOR error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for WriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            WriteError::Cbor(e) => Some(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::*;
+    use crate::frame::CoreFrame;
+    use crate::tree::RecursiveTree;
+
+    fn roundtrip(expr: RecursiveTree<CoreFrame<usize>>) {
+        let bytes = write_cbor(&expr).expect("write failed");
+        let recovered = read_cbor(&bytes).expect("read failed");
+        assert_eq!(expr, recovered);
+    }
+
+    #[test]
+    fn test_roundtrip_var() {
+        roundtrip(RecursiveTree {
+            nodes: vec![CoreFrame::Var(VarId(42))],
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_lit() {
+        let lits = vec![
+            Literal::LitInt(-123),
+            Literal::LitWord(456),
+            Literal::LitChar('a'),
+            Literal::LitString(b"hello".to_vec()),
+            Literal::LitFloat(1.0f32.to_bits() as u64),
+            Literal::LitDouble(2.0f64.to_bits()),
+        ];
+        for lit in lits {
+            roundtrip(RecursiveTree {
+                nodes: vec![CoreFrame::Lit(lit)],
+            });
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_app() {
+        roundtrip(RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(VarId(1)),
+                CoreFrame::Var(VarId(2)),
+                CoreFrame::App { fun: 0, arg: 1 },
+            ],
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_lam() {
+        roundtrip(RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(VarId(1)),
+                CoreFrame::Lam { binder: VarId(2), body: 0 },
+            ],
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_let_non_rec() {
+        roundtrip(RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(VarId(1)),
+                CoreFrame::Var(VarId(2)),
+                CoreFrame::LetNonRec { binder: VarId(3), rhs: 0, body: 1 },
+            ],
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_let_rec() {
+        roundtrip(RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(VarId(1)),
+                CoreFrame::Var(VarId(2)),
+                CoreFrame::LetRec {
+                    bindings: vec![(VarId(3), 0), (VarId(4), 1)],
+                    body: 1,
+                },
+            ],
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_case() {
+        roundtrip(RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(VarId(1)), // 0
+                CoreFrame::Var(VarId(2)), // 1
+                CoreFrame::Case {
+                    scrutinee: 0,
+                    binder: VarId(3),
+                    alts: vec![
+                        Alt {
+                            con: AltCon::DataAlt(DataConId(4)),
+                            binders: vec![VarId(5)],
+                            body: 1,
+                        },
+                        Alt {
+                            con: AltCon::LitAlt(Literal::LitInt(42)),
+                            binders: vec![],
+                            body: 1,
+                        },
+                        Alt {
+                            con: AltCon::Default,
+                            binders: vec![],
+                            body: 1,
+                        },
+                    ],
+                },
+            ],
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_con() {
+        roundtrip(RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(VarId(1)),
+                CoreFrame::Var(VarId(2)),
+                CoreFrame::Con {
+                    tag: DataConId(3),
+                    fields: vec![0, 1],
+                },
+            ],
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_join_jump() {
+        roundtrip(RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(VarId(1)), // 0
+                CoreFrame::Jump { label: JoinId(2), args: vec![0] }, // 1
+                CoreFrame::Join {
+                    label: JoinId(2),
+                    params: vec![VarId(3)],
+                    rhs: 1,
+                    body: 0,
+                },
+            ],
+        });
+    }
+
+    #[test]
+    fn test_roundtrip_primop() {
+        use PrimOpKind::*;
+        let ops = vec![
+            IntAdd, IntSub, IntMul, IntNegate, IntEq, IntNe, IntLt, IntLe, IntGt, IntGe,
+            WordAdd, WordSub, WordMul, WordEq, WordNe, WordLt, WordLe, WordGt, WordGe,
+            DoubleAdd, DoubleSub, DoubleMul, DoubleDiv, DoubleEq, DoubleNe, DoubleLt, DoubleLe, DoubleGt, DoubleGe,
+            CharEq, CharNe, CharLt, CharLe, CharGt, CharGe,
+            IndexArray, SeqOp, TagToEnum, DataToTag,
+        ];
+        for op in ops {
+            roundtrip(RecursiveTree {
+                nodes: vec![
+                    CoreFrame::Var(VarId(1)),
+                    CoreFrame::PrimOp { op, args: vec![0] },
+                ],
+            });
+        }
+    }
+
+    #[test]
+    fn test_complex_nested() {
+        roundtrip(RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(VarId(1)), // 0
+                CoreFrame::Lam { binder: VarId(1), body: 0 }, // 1
+                CoreFrame::Lit(Literal::LitInt(42)), // 2
+                CoreFrame::App { fun: 1, arg: 2 }, // 3
+            ],
+        });
+    }
+}

--- a/core-repr/src/serial/read.rs
+++ b/core-repr/src/serial/read.rs
@@ -6,7 +6,7 @@ use super::ReadError;
 
 /// Reads a CoreExpr from a CBOR-encoded byte slice.
 pub fn read_cbor(bytes: &[u8]) -> Result<RecursiveTree<CoreFrame<usize>>, ReadError> {
-    let tree_val: Value = ciborium::de::from_reader(bytes).map_err(ReadError::Cbor)?;
+    let tree_val: Value = ciborium::de::from_reader(bytes).map_err(|e| ReadError::Cbor(e.to_string()))?;
     
     let root_array = match tree_val {
         Value::Array(a) if a.len() == 2 => a,
@@ -18,12 +18,76 @@ pub fn read_cbor(bytes: &[u8]) -> Result<RecursiveTree<CoreFrame<usize>>, ReadEr
         _ => return Err(ReadError::InvalidStructure("First element must be array of nodes".to_string())),
     };
 
+    if nodes_array.is_empty() {
+        return Err(ReadError::InvalidStructure("CoreExpr must have at least one node".to_string()));
+    }
+
+    let root_idx = as_usize(&root_array[1])?;
+    if root_idx != nodes_array.len() - 1 {
+        return Err(ReadError::InvalidStructure(format!(
+            "Root index {} does not match expected last node index {}",
+            root_idx,
+            nodes_array.len() - 1
+        )));
+    }
+
     let mut nodes = Vec::with_capacity(nodes_array.len());
     for node_val in nodes_array {
         nodes.push(decode_frame(node_val)?);
     }
 
+    validate_indices(&nodes)?;
+
     Ok(RecursiveTree { nodes })
+}
+
+fn validate_indices(nodes: &[CoreFrame<usize>]) -> Result<(), ReadError> {
+    let len = nodes.len();
+    for node in nodes {
+        match node {
+            CoreFrame::App { fun, arg } => {
+                if *fun >= len || *arg >= len { return Err(ReadError::InvalidStructure("App index out of bounds".to_string())); }
+            }
+            CoreFrame::Lam { body, .. } => {
+                if *body >= len { return Err(ReadError::InvalidStructure("Lam index out of bounds".to_string())); }
+            }
+            CoreFrame::LetNonRec { rhs, body, .. } => {
+                if *rhs >= len || *body >= len { return Err(ReadError::InvalidStructure("LetNonRec index out of bounds".to_string())); }
+            }
+            CoreFrame::LetRec { bindings, body } => {
+                if *body >= len { return Err(ReadError::InvalidStructure("LetRec body index out of bounds".to_string())); }
+                for (_, rhs) in bindings {
+                    if *rhs >= len { return Err(ReadError::InvalidStructure("LetRec binding index out of bounds".to_string())); }
+                }
+            }
+            CoreFrame::Case { scrutinee, alts, .. } => {
+                if *scrutinee >= len { return Err(ReadError::InvalidStructure("Case scrutinee index out of bounds".to_string())); }
+                for alt in alts {
+                    if alt.body >= len { return Err(ReadError::InvalidStructure("Case alt body index out of bounds".to_string())); }
+                }
+            }
+            CoreFrame::Con { fields, .. } => {
+                for f in fields {
+                    if *f >= len { return Err(ReadError::InvalidStructure("Con field index out of bounds".to_string())); }
+                }
+            }
+            CoreFrame::Join { rhs, body, .. } => {
+                if *rhs >= len || *body >= len { return Err(ReadError::InvalidStructure("Join index out of bounds".to_string())); }
+            }
+            CoreFrame::Jump { args, .. } => {
+                for a in args {
+                    if *a >= len { return Err(ReadError::InvalidStructure("Jump argument index out of bounds".to_string())); }
+                }
+            }
+            CoreFrame::PrimOp { args, .. } => {
+                for a in args {
+                    if *a >= len { return Err(ReadError::InvalidStructure("PrimOp argument index out of bounds".to_string())); }
+                }
+            }
+            CoreFrame::Var(_) | CoreFrame::Lit(_) => {}
+        }
+    }
+    Ok(())
 }
 
 fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
@@ -53,23 +117,23 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
         "App" => {
             if arr.len() != 3 { return Err(ReadError::InvalidStructure("App expects 2 fields".to_string())); }
             Ok(CoreFrame::App {
-                fun: as_u64(&arr[1])? as usize,
-                arg: as_u64(&arr[2])? as usize,
+                fun: as_usize(&arr[1])?,
+                arg: as_usize(&arr[2])?,
             })
         }
         "Lam" => {
             if arr.len() != 3 { return Err(ReadError::InvalidStructure("Lam expects 2 fields".to_string())); }
             Ok(CoreFrame::Lam {
                 binder: VarId(as_u64(&arr[1])?),
-                body: as_u64(&arr[2])? as usize,
+                body: as_usize(&arr[2])?,
             })
         }
         "LetNonRec" => {
             if arr.len() != 4 { return Err(ReadError::InvalidStructure("LetNonRec expects 3 fields".to_string())); }
             Ok(CoreFrame::LetNonRec {
                 binder: VarId(as_u64(&arr[1])?),
-                rhs: as_u64(&arr[2])? as usize,
-                body: as_u64(&arr[3])? as usize,
+                rhs: as_usize(&arr[2])?,
+                body: as_usize(&arr[3])?,
             })
         }
         "LetRec" => {
@@ -84,11 +148,11 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
                     Value::Array(a) if a.len() == 2 => a,
                     _ => return Err(ReadError::InvalidStructure("LetRec binding must be array of 2".to_string())),
                 };
-                bindings.push((VarId(as_u64(&b_arr[0])?), as_u64(&b_arr[1])? as usize));
+                bindings.push((VarId(as_u64(&b_arr[0])?), as_usize(&b_arr[1])?));
             }
             Ok(CoreFrame::LetRec {
                 bindings,
-                body: as_u64(&arr[2])? as usize,
+                body: as_usize(&arr[2])?,
             })
         }
         "Case" => {
@@ -102,7 +166,7 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
                 alts.push(decode_alt(alt_val)?);
             }
             Ok(CoreFrame::Case {
-                scrutinee: as_u64(&arr[1])? as usize,
+                scrutinee: as_usize(&arr[1])?,
                 binder: VarId(as_u64(&arr[2])?),
                 alts,
             })
@@ -115,7 +179,7 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             };
             let mut fields = Vec::with_capacity(fields_arr.len());
             for f_val in fields_arr {
-                fields.push(as_u64(f_val)? as usize);
+                fields.push(as_usize(f_val)?);
             }
             Ok(CoreFrame::Con {
                 tag: DataConId(as_u64(&arr[1])?),
@@ -135,8 +199,8 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             Ok(CoreFrame::Join {
                 label: JoinId(as_u64(&arr[1])?),
                 params,
-                rhs: as_u64(&arr[3])? as usize,
-                body: as_u64(&arr[4])? as usize,
+                rhs: as_usize(&arr[3])?,
+                body: as_usize(&arr[4])?,
             })
         }
         "Jump" => {
@@ -147,7 +211,7 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             };
             let mut args = Vec::with_capacity(args_arr.len());
             for a_val in args_arr {
-                args.push(as_u64(a_val)? as usize);
+                args.push(as_usize(a_val)?);
             }
             Ok(CoreFrame::Jump {
                 label: JoinId(as_u64(&arr[1])?),
@@ -167,7 +231,7 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             };
             let mut args = Vec::with_capacity(args_arr.len());
             for a_val in args_arr {
-                args.push(as_u64(a_val)? as usize);
+                args.push(as_usize(a_val)?);
             }
             Ok(CoreFrame::PrimOp { op, args })
         }
@@ -217,7 +281,7 @@ fn decode_alt(val: &Value) -> Result<Alt<usize>, ReadError> {
     for b_val in binders_arr {
         binders.push(VarId(as_u64(b_val)?));
     }
-    let body = as_u64(&arr[2])? as usize;
+    let body = as_usize(&arr[2])?;
     Ok(Alt { con, binders, body })
 }
 
@@ -281,6 +345,16 @@ fn as_i64(val: &Value) -> Result<i64, ReadError> {
         Value::Integer(i) => {
             let i: i64 = (*i).try_into().map_err(|_| ReadError::InvalidStructure("Expected i64".to_string()))?;
             Ok(i)
+        }
+        _ => Err(ReadError::InvalidStructure("Expected integer".to_string())),
+    }
+}
+
+fn as_usize(val: &Value) -> Result<usize, ReadError> {
+    match val {
+        Value::Integer(i) => {
+            let u: u64 = (*i).try_into().map_err(|_| ReadError::InvalidStructure("Expected integer (u64)".to_string()))?;
+            usize::try_from(u).map_err(|_| ReadError::InvalidStructure("Integer too large for usize".to_string()))
         }
         _ => Err(ReadError::InvalidStructure("Expected integer".to_string())),
     }

--- a/core-repr/src/serial/read.rs
+++ b/core-repr/src/serial/read.rs
@@ -1,0 +1,287 @@
+use ciborium::value::Value;
+use crate::frame::CoreFrame;
+use crate::tree::RecursiveTree;
+use crate::types::{Literal, PrimOpKind, AltCon, Alt, VarId, DataConId, JoinId};
+use super::ReadError;
+
+/// Reads a CoreExpr from a CBOR-encoded byte slice.
+pub fn read_cbor(bytes: &[u8]) -> Result<RecursiveTree<CoreFrame<usize>>, ReadError> {
+    let tree_val: Value = ciborium::de::from_reader(bytes).map_err(ReadError::Cbor)?;
+    
+    let root_array = match tree_val {
+        Value::Array(a) if a.len() == 2 => a,
+        _ => return Err(ReadError::InvalidStructure("Root must be array of 2".to_string())),
+    };
+
+    let nodes_array = match &root_array[0] {
+        Value::Array(a) => a,
+        _ => return Err(ReadError::InvalidStructure("First element must be array of nodes".to_string())),
+    };
+
+    let mut nodes = Vec::with_capacity(nodes_array.len());
+    for node_val in nodes_array {
+        nodes.push(decode_frame(node_val)?);
+    }
+
+    Ok(RecursiveTree { nodes })
+}
+
+fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
+    let arr = match val {
+        Value::Array(a) => a,
+        _ => return Err(ReadError::InvalidStructure("Frame must be array".to_string())),
+    };
+
+    if arr.is_empty() {
+        return Err(ReadError::InvalidStructure("Empty frame array".to_string()));
+    }
+
+    let tag = match &arr[0] {
+        Value::Text(t) => t.as_str(),
+        _ => return Err(ReadError::InvalidTag("Tag must be string".to_string())),
+    };
+
+    match tag {
+        "Var" => {
+            if arr.len() != 2 { return Err(ReadError::InvalidStructure("Var expects 1 field".to_string())); }
+            Ok(CoreFrame::Var(VarId(as_u64(&arr[1])?)))
+        }
+        "Lit" => {
+            if arr.len() != 2 { return Err(ReadError::InvalidStructure("Lit expects 1 field".to_string())); }
+            Ok(CoreFrame::Lit(decode_literal(&arr[1])?))
+        }
+        "App" => {
+            if arr.len() != 3 { return Err(ReadError::InvalidStructure("App expects 2 fields".to_string())); }
+            Ok(CoreFrame::App {
+                fun: as_u64(&arr[1])? as usize,
+                arg: as_u64(&arr[2])? as usize,
+            })
+        }
+        "Lam" => {
+            if arr.len() != 3 { return Err(ReadError::InvalidStructure("Lam expects 2 fields".to_string())); }
+            Ok(CoreFrame::Lam {
+                binder: VarId(as_u64(&arr[1])?),
+                body: as_u64(&arr[2])? as usize,
+            })
+        }
+        "LetNonRec" => {
+            if arr.len() != 4 { return Err(ReadError::InvalidStructure("LetNonRec expects 3 fields".to_string())); }
+            Ok(CoreFrame::LetNonRec {
+                binder: VarId(as_u64(&arr[1])?),
+                rhs: as_u64(&arr[2])? as usize,
+                body: as_u64(&arr[3])? as usize,
+            })
+        }
+        "LetRec" => {
+            if arr.len() != 3 { return Err(ReadError::InvalidStructure("LetRec expects 2 fields".to_string())); }
+            let bindings_arr = match &arr[1] {
+                Value::Array(a) => a,
+                _ => return Err(ReadError::InvalidStructure("LetRec bindings must be array".to_string())),
+            };
+            let mut bindings = Vec::with_capacity(bindings_arr.len());
+            for b_val in bindings_arr {
+                let b_arr = match b_val {
+                    Value::Array(a) if a.len() == 2 => a,
+                    _ => return Err(ReadError::InvalidStructure("LetRec binding must be array of 2".to_string())),
+                };
+                bindings.push((VarId(as_u64(&b_arr[0])?), as_u64(&b_arr[1])? as usize));
+            }
+            Ok(CoreFrame::LetRec {
+                bindings,
+                body: as_u64(&arr[2])? as usize,
+            })
+        }
+        "Case" => {
+            if arr.len() != 4 { return Err(ReadError::InvalidStructure("Case expects 3 fields".to_string())); }
+            let alts_arr = match &arr[3] {
+                Value::Array(a) => a,
+                _ => return Err(ReadError::InvalidStructure("Case alts must be array".to_string())),
+            };
+            let mut alts = Vec::with_capacity(alts_arr.len());
+            for alt_val in alts_arr {
+                alts.push(decode_alt(alt_val)?);
+            }
+            Ok(CoreFrame::Case {
+                scrutinee: as_u64(&arr[1])? as usize,
+                binder: VarId(as_u64(&arr[2])?),
+                alts,
+            })
+        }
+        "Con" => {
+            if arr.len() != 3 { return Err(ReadError::InvalidStructure("Con expects 2 fields".to_string())); }
+            let fields_arr = match &arr[2] {
+                Value::Array(a) => a,
+                _ => return Err(ReadError::InvalidStructure("Con fields must be array".to_string())),
+            };
+            let mut fields = Vec::with_capacity(fields_arr.len());
+            for f_val in fields_arr {
+                fields.push(as_u64(f_val)? as usize);
+            }
+            Ok(CoreFrame::Con {
+                tag: DataConId(as_u64(&arr[1])?),
+                fields,
+            })
+        }
+        "Join" => {
+            if arr.len() != 5 { return Err(ReadError::InvalidStructure("Join expects 4 fields".to_string())); }
+            let params_arr = match &arr[2] {
+                Value::Array(a) => a,
+                _ => return Err(ReadError::InvalidStructure("Join params must be array".to_string())),
+            };
+            let mut params = Vec::with_capacity(params_arr.len());
+            for p_val in params_arr {
+                params.push(VarId(as_u64(p_val)?));
+            }
+            Ok(CoreFrame::Join {
+                label: JoinId(as_u64(&arr[1])?),
+                params,
+                rhs: as_u64(&arr[3])? as usize,
+                body: as_u64(&arr[4])? as usize,
+            })
+        }
+        "Jump" => {
+            if arr.len() != 3 { return Err(ReadError::InvalidStructure("Jump expects 2 fields".to_string())); }
+            let args_arr = match &arr[2] {
+                Value::Array(a) => a,
+                _ => return Err(ReadError::InvalidStructure("Jump args must be array".to_string())),
+            };
+            let mut args = Vec::with_capacity(args_arr.len());
+            for a_val in args_arr {
+                args.push(as_u64(a_val)? as usize);
+            }
+            Ok(CoreFrame::Jump {
+                label: JoinId(as_u64(&arr[1])?),
+                args,
+            })
+        }
+        "PrimOp" => {
+            if arr.len() != 3 { return Err(ReadError::InvalidStructure("PrimOp expects 2 fields".to_string())); }
+            let op_name = match &arr[1] {
+                Value::Text(t) => t,
+                _ => return Err(ReadError::InvalidPrimOp("PrimOp op must be string".to_string())),
+            };
+            let op = decode_primop(op_name)?;
+            let args_arr = match &arr[2] {
+                Value::Array(a) => a,
+                _ => return Err(ReadError::InvalidStructure("PrimOp args must be array".to_string())),
+            };
+            let mut args = Vec::with_capacity(args_arr.len());
+            for a_val in args_arr {
+                args.push(as_u64(a_val)? as usize);
+            }
+            Ok(CoreFrame::PrimOp { op, args })
+        }
+        _ => Err(ReadError::InvalidTag(tag.to_string())),
+    }
+}
+
+fn decode_literal(val: &Value) -> Result<Literal, ReadError> {
+    let arr = match val {
+        Value::Array(a) if a.len() == 2 => a,
+        _ => return Err(ReadError::InvalidLiteral("Literal must be array of 2".to_string())),
+    };
+    let tag = match &arr[0] {
+        Value::Text(t) => t.as_str(),
+        _ => return Err(ReadError::InvalidLiteral("Literal tag must be string".to_string())),
+    };
+    match tag {
+        "LitInt" => Ok(Literal::LitInt(as_i64(&arr[1])?)),
+        "LitWord" => Ok(Literal::LitWord(as_u64(&arr[1])?)),
+        "LitChar" => {
+            let cp = as_u64(&arr[1])? as u32;
+            std::char::from_u32(cp)
+                .ok_or_else(|| ReadError::InvalidLiteral(format!("Invalid char codepoint: {}", cp)))
+                .map(Literal::LitChar)
+        }
+        "LitString" => match &arr[1] {
+            Value::Bytes(b) => Ok(Literal::LitString(b.clone())),
+            _ => Err(ReadError::InvalidLiteral("LitString expects bytes".to_string())),
+        },
+        "LitFloat" => Ok(Literal::LitFloat(as_u64(&arr[1])?)),
+        "LitDouble" => Ok(Literal::LitDouble(as_u64(&arr[1])?)),
+        _ => Err(ReadError::InvalidLiteral(tag.to_string())),
+    }
+}
+
+fn decode_alt(val: &Value) -> Result<Alt<usize>, ReadError> {
+    let arr = match val {
+        Value::Array(a) if a.len() == 3 => a,
+        _ => return Err(ReadError::InvalidStructure("Alt must be array of 3".to_string())),
+    };
+    let con = decode_alt_con(&arr[0])?;
+    let binders_arr = match &arr[1] {
+        Value::Array(a) => a,
+        _ => return Err(ReadError::InvalidStructure("Alt binders must be array".to_string())),
+    };
+    let mut binders = Vec::with_capacity(binders_arr.len());
+    for b_val in binders_arr {
+        binders.push(VarId(as_u64(b_val)?));
+    }
+    let body = as_u64(&arr[2])? as usize;
+    Ok(Alt { con, binders, body })
+}
+
+fn decode_alt_con(val: &Value) -> Result<AltCon, ReadError> {
+    let arr = match val {
+        Value::Array(a) => a,
+        _ => return Err(ReadError::InvalidAltCon("AltCon must be array".to_string())),
+    };
+    if arr.is_empty() {
+        return Err(ReadError::InvalidAltCon("Empty AltCon array".to_string()));
+    }
+    let tag = match &arr[0] {
+        Value::Text(t) => t.as_str(),
+        _ => return Err(ReadError::InvalidAltCon("AltCon tag must be string".to_string())),
+    };
+    match tag {
+        "DataAlt" => {
+            if arr.len() != 2 { return Err(ReadError::InvalidAltCon("DataAlt expects 1 field".to_string())); }
+            Ok(AltCon::DataAlt(DataConId(as_u64(&arr[1])?)))
+        }
+        "LitAlt" => {
+            if arr.len() != 2 { return Err(ReadError::InvalidAltCon("LitAlt expects 1 field".to_string())); }
+            Ok(AltCon::LitAlt(decode_literal(&arr[1])?))
+        }
+        "Default" => {
+            if arr.len() != 1 { return Err(ReadError::InvalidAltCon("Default expects 0 fields".to_string())); }
+            Ok(AltCon::Default)
+        }
+        _ => Err(ReadError::InvalidAltCon(tag.to_string())),
+    }
+}
+
+fn decode_primop(s: &str) -> Result<PrimOpKind, ReadError> {
+    use PrimOpKind::*;
+    match s {
+        "IntAdd" => Ok(IntAdd), "IntSub" => Ok(IntSub), "IntMul" => Ok(IntMul),
+        "IntNegate" => Ok(IntNegate),
+        "IntEq" => Ok(IntEq), "IntNe" => Ok(IntNe), "IntLt" => Ok(IntLt), "IntLe" => Ok(IntLe), "IntGt" => Ok(IntGt), "IntGe" => Ok(IntGe),
+        "WordAdd" => Ok(WordAdd), "WordSub" => Ok(WordSub), "WordMul" => Ok(WordMul),
+        "WordEq" => Ok(WordEq), "WordNe" => Ok(WordNe), "WordLt" => Ok(WordLt), "WordLe" => Ok(WordLe), "WordGt" => Ok(WordGt), "WordGe" => Ok(WordGe),
+        "DoubleAdd" => Ok(DoubleAdd), "DoubleSub" => Ok(DoubleSub), "DoubleMul" => Ok(DoubleMul), "DoubleDiv" => Ok(DoubleDiv),
+        "DoubleEq" => Ok(DoubleEq), "DoubleNe" => Ok(DoubleNe), "DoubleLt" => Ok(DoubleLt), "DoubleLe" => Ok(DoubleLe), "DoubleGt" => Ok(DoubleGt), "DoubleGe" => Ok(DoubleGe),
+        "CharEq" => Ok(CharEq), "CharNe" => Ok(CharNe), "CharLt" => Ok(CharLt), "CharLe" => Ok(CharLe), "CharGt" => Ok(CharGt), "CharGe" => Ok(CharGe),
+        "IndexArray" => Ok(IndexArray), "SeqOp" => Ok(SeqOp), "TagToEnum" => Ok(TagToEnum), "DataToTag" => Ok(DataToTag),
+        _ => Err(ReadError::InvalidPrimOp(s.to_string())),
+    }
+}
+
+fn as_u64(val: &Value) -> Result<u64, ReadError> {
+    match val {
+        Value::Integer(i) => {
+            let u: u64 = (*i).try_into().map_err(|_| ReadError::InvalidStructure("Expected u64".to_string()))?;
+            Ok(u)
+        }
+        _ => Err(ReadError::InvalidStructure("Expected integer".to_string())),
+    }
+}
+
+fn as_i64(val: &Value) -> Result<i64, ReadError> {
+    match val {
+        Value::Integer(i) => {
+            let i: i64 = (*i).try_into().map_err(|_| ReadError::InvalidStructure("Expected i64".to_string()))?;
+            Ok(i)
+        }
+        _ => Err(ReadError::InvalidStructure("Expected integer".to_string())),
+    }
+}

--- a/core-repr/src/serial/write.rs
+++ b/core-repr/src/serial/write.rs
@@ -1,21 +1,21 @@
 use ciborium::value::Value;
 use crate::frame::CoreFrame;
 use crate::tree::RecursiveTree;
-use crate::types::{Literal, AltCon, Alt};
+use crate::types::{Literal, AltCon, Alt, PrimOpKind};
 use super::WriteError;
 
 /// Writes a CoreExpr to a CBOR-encoded byte vector.
 pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, WriteError> {
+    if expr.nodes.is_empty() {
+        return Err(WriteError::Cbor("attempted to write an empty RecursiveTree as a CoreExpr".to_string()));
+    }
+
     let mut nodes_val = Vec::with_capacity(expr.nodes.len());
     for node in &expr.nodes {
         nodes_val.push(encode_frame(node));
     }
 
-    let root_idx = if expr.nodes.is_empty() {
-        0u64
-    } else {
-        (expr.nodes.len() - 1) as u64
-    };
+    let root_idx = (expr.nodes.len() - 1) as u64;
 
     let tree_val = Value::Array(vec![
         Value::Array(nodes_val),
@@ -23,7 +23,7 @@ pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, Wri
     ]);
 
     let mut bytes = Vec::new();
-    ciborium::ser::into_writer(&tree_val, &mut bytes).map_err(WriteError::Cbor)?;
+    ciborium::ser::into_writer(&tree_val, &mut bytes).map_err(|e| WriteError::Cbor(e.to_string()))?;
     Ok(bytes)
 }
 
@@ -139,10 +139,25 @@ fn encode_frame(frame: &CoreFrame<usize>) -> Value {
             );
             Value::Array(vec![
                 Value::Text("PrimOp".to_string()),
-                Value::Text(format!("{:?}", op)),
+                Value::Text(encode_primop(op).to_string()),
                 args_val,
             ])
         }
+    }
+}
+
+fn encode_primop(op: &PrimOpKind) -> &'static str {
+    use PrimOpKind::*;
+    match op {
+        IntAdd => "IntAdd", IntSub => "IntSub", IntMul => "IntMul",
+        IntNegate => "IntNegate",
+        IntEq => "IntEq", IntNe => "IntNe", IntLt => "IntLt", IntLe => "IntLe", IntGt => "IntGt", IntGe => "IntGe",
+        WordAdd => "WordAdd", WordSub => "WordSub", WordMul => "WordMul",
+        WordEq => "WordEq", WordNe => "WordNe", WordLt => "WordLt", WordLe => "WordLe", WordGt => "WordGt", WordGe => "WordGe",
+        DoubleAdd => "DoubleAdd", DoubleSub => "DoubleSub", DoubleMul => "DoubleMul", DoubleDiv => "DoubleDiv",
+        DoubleEq => "DoubleEq", DoubleNe => "DoubleNe", DoubleLt => "DoubleLt", DoubleLe => "DoubleLe", DoubleGt => "DoubleGt", DoubleGe => "DoubleGe",
+        CharEq => "CharEq", CharNe => "CharNe", CharLt => "CharLt", CharLe => "CharLe", CharGt => "CharGt", CharGe => "CharGe",
+        IndexArray => "IndexArray", SeqOp => "SeqOp", TagToEnum => "TagToEnum", DataToTag => "DataToTag",
     }
 }
 

--- a/core-repr/src/serial/write.rs
+++ b/core-repr/src/serial/write.rs
@@ -1,0 +1,204 @@
+use ciborium::value::Value;
+use crate::frame::CoreFrame;
+use crate::tree::RecursiveTree;
+use crate::types::{Literal, AltCon, Alt};
+use super::WriteError;
+
+/// Writes a CoreExpr to a CBOR-encoded byte vector.
+pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, WriteError> {
+    let mut nodes_val = Vec::with_capacity(expr.nodes.len());
+    for node in &expr.nodes {
+        nodes_val.push(encode_frame(node));
+    }
+
+    let root_idx = if expr.nodes.is_empty() {
+        0u64
+    } else {
+        (expr.nodes.len() - 1) as u64
+    };
+
+    let tree_val = Value::Array(vec![
+        Value::Array(nodes_val),
+        Value::Integer(root_idx.into()),
+    ]);
+
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&tree_val, &mut bytes).map_err(WriteError::Cbor)?;
+    Ok(bytes)
+}
+
+fn encode_frame(frame: &CoreFrame<usize>) -> Value {
+    match frame {
+        CoreFrame::Var(id) => Value::Array(vec![
+            Value::Text("Var".to_string()),
+            Value::Integer(id.0.into()),
+        ]),
+        CoreFrame::Lit(lit) => Value::Array(vec![
+            Value::Text("Lit".to_string()),
+            encode_literal(lit),
+        ]),
+        CoreFrame::App { fun, arg } => Value::Array(vec![
+            Value::Text("App".to_string()),
+            Value::Integer((*fun as u64).into()),
+            Value::Integer((*arg as u64).into()),
+        ]),
+        CoreFrame::Lam { binder, body } => Value::Array(vec![
+            Value::Text("Lam".to_string()),
+            Value::Integer(binder.0.into()),
+            Value::Integer((*body as u64).into()),
+        ]),
+        CoreFrame::LetNonRec { binder, rhs, body } => Value::Array(vec![
+            Value::Text("LetNonRec".to_string()),
+            Value::Integer(binder.0.into()),
+            Value::Integer((*rhs as u64).into()),
+            Value::Integer((*body as u64).into()),
+        ]),
+        CoreFrame::LetRec { bindings, body } => {
+            let bindings_val = Value::Array(
+                bindings
+                    .iter()
+                    .map(|(id, rhs)| {
+                        Value::Array(vec![
+                            Value::Integer(id.0.into()),
+                            Value::Integer((*rhs as u64).into()),
+                        ])
+                    })
+                    .collect(),
+            );
+            Value::Array(vec![
+                Value::Text("LetRec".to_string()),
+                bindings_val,
+                Value::Integer((*body as u64).into()),
+            ])
+        }
+        CoreFrame::Case {
+            scrutinee,
+            binder,
+            alts,
+        } => {
+            let alts_val = Value::Array(alts.iter().map(encode_alt).collect());
+            Value::Array(vec![
+                Value::Text("Case".to_string()),
+                Value::Integer((*scrutinee as u64).into()),
+                Value::Integer(binder.0.into()),
+                alts_val,
+            ])
+        }
+        CoreFrame::Con { tag, fields } => {
+            let fields_val = Value::Array(
+                fields
+                    .iter()
+                    .map(|f| Value::Integer((*f as u64).into()))
+                    .collect(),
+            );
+            Value::Array(vec![
+                Value::Text("Con".to_string()),
+                Value::Integer(tag.0.into()),
+                fields_val,
+            ])
+        }
+        CoreFrame::Join {
+            label,
+            params,
+            rhs,
+            body,
+        } => {
+            let params_val = Value::Array(
+                params
+                    .iter()
+                    .map(|p| Value::Integer(p.0.into()))
+                    .collect(),
+            );
+            Value::Array(vec![
+                Value::Text("Join".to_string()),
+                Value::Integer(label.0.into()),
+                params_val,
+                Value::Integer((*rhs as u64).into()),
+                Value::Integer((*body as u64).into()),
+            ])
+        }
+        CoreFrame::Jump { label, args } => {
+            let args_val = Value::Array(
+                args
+                    .iter()
+                    .map(|a| Value::Integer((*a as u64).into()))
+                    .collect(),
+            );
+            Value::Array(vec![
+                Value::Text("Jump".to_string()),
+                Value::Integer(label.0.into()),
+                args_val,
+            ])
+        }
+        CoreFrame::PrimOp { op, args } => {
+            let args_val = Value::Array(
+                args
+                    .iter()
+                    .map(|a| Value::Integer((*a as u64).into()))
+                    .collect(),
+            );
+            Value::Array(vec![
+                Value::Text("PrimOp".to_string()),
+                Value::Text(format!("{:?}", op)),
+                args_val,
+            ])
+        }
+    }
+}
+
+fn encode_literal(lit: &Literal) -> Value {
+    match lit {
+        Literal::LitInt(i) => Value::Array(vec![
+            Value::Text("LitInt".to_string()),
+            Value::Integer((*i).into()),
+        ]),
+        Literal::LitWord(w) => Value::Array(vec![
+            Value::Text("LitWord".to_string()),
+            Value::Integer((*w).into()),
+        ]),
+        Literal::LitChar(c) => Value::Array(vec![
+            Value::Text("LitChar".to_string()),
+            Value::Integer((*c as u32).into()),
+        ]),
+        Literal::LitString(s) => Value::Array(vec![
+            Value::Text("LitString".to_string()),
+            Value::Bytes(s.clone()),
+        ]),
+        Literal::LitFloat(f) => Value::Array(vec![
+            Value::Text("LitFloat".to_string()),
+            Value::Integer((*f).into()),
+        ]),
+        Literal::LitDouble(d) => Value::Array(vec![
+            Value::Text("LitDouble".to_string()),
+            Value::Integer((*d).into()),
+        ]),
+    }
+}
+
+fn encode_alt(alt: &Alt<usize>) -> Value {
+    let binders_val = Value::Array(
+        alt.binders
+            .iter()
+            .map(|b| Value::Integer(b.0.into()))
+            .collect(),
+    );
+    Value::Array(vec![
+        encode_alt_con(&alt.con),
+        binders_val,
+        Value::Integer((alt.body as u64).into()),
+    ])
+}
+
+fn encode_alt_con(con: &AltCon) -> Value {
+    match con {
+        AltCon::DataAlt(id) => Value::Array(vec![
+            Value::Text("DataAlt".to_string()),
+            Value::Integer(id.0.into()),
+        ]),
+        AltCon::LitAlt(lit) => Value::Array(vec![
+            Value::Text("LitAlt".to_string()),
+            encode_literal(lit),
+        ]),
+        AltCon::Default => Value::Array(vec![Value::Text("Default".to_string())]),
+    }
+}


### PR DESCRIPTION
This PR implements CBOR serialization (read and write) for CoreExpr in the core-repr crate using the ciborium crate.

Key changes:
- Added ciborium 0.2 dependency to core-repr.
- Implemented write_cbor in core-repr/src/serial/write.rs.
- Implemented read_cbor in core-repr/src/serial/read.rs.
- Added roundtrip tests for all CoreFrame variants and PrimOpKind variants in core-repr/src/serial/mod.rs.
- All tests pass and clippy is clean.