### PR TITLE
Implement core-repr utilities: free_vars, subst, alpha_eq

### DIFF
--- a/core-repr/src/alpha.rs
+++ b/core-repr/src/alpha.rs
@@ -9,6 +9,7 @@ pub fn alpha_eq(lhs: &CoreExpr, rhs: &CoreExpr) -> bool {
     if lhs.nodes.is_empty() || rhs.nodes.is_empty() {
         return false;
     }
+    let mut next_canon = 0u64;
     alpha_eq_at(
         lhs,
         rhs,
@@ -16,7 +17,7 @@ pub fn alpha_eq(lhs: &CoreExpr, rhs: &CoreExpr) -> bool {
         rhs.nodes.len() - 1,
         &mut HashMap::new(),
         &mut HashMap::new(),
-        &mut 0,
+        &mut next_canon,
     )
 }
 
@@ -319,7 +320,7 @@ fn alpha_eq_at(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::RecursiveTree;
+    use crate::{RecursiveTree, JoinId};
 
     #[test]
     fn test_alpha_eq_lam() {
@@ -382,5 +383,128 @@ mod tests {
             ],
         };
         assert!(alpha_eq(&lhs, &lhs));
+    }
+
+    #[test]
+    fn test_alpha_eq_let_rec() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let a = VarId(3);
+        let b = VarId(4);
+        // LetRec [(x, x)] x
+        let lhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),
+                CoreFrame::LetRec {
+                    bindings: vec![(x, 0)],
+                    body: 0,
+                },
+            ],
+        };
+        // LetRec [(y, y)] y
+        let rhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(y),
+                CoreFrame::LetRec {
+                    bindings: vec![(y, 0)],
+                    body: 0,
+                },
+            ],
+        };
+        assert!(alpha_eq(&lhs, &rhs));
+
+        // LetRec [(a, b)] a  != LetRec [(a, a)] a
+        let lhs2 = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(b),
+                CoreFrame::Var(a),
+                CoreFrame::LetRec {
+                    bindings: vec![(a, 0)],
+                    body: 1,
+                },
+            ],
+        };
+        let rhs2 = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(a),
+                CoreFrame::LetRec {
+                    bindings: vec![(a, 0)],
+                    body: 0,
+                },
+            ],
+        };
+        assert!(!alpha_eq(&lhs2, &rhs2));
+    }
+
+    #[test]
+    fn test_alpha_eq_case() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let z = VarId(3);
+        // Case(x, y, [Default => y])
+        let lhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),
+                CoreFrame::Var(y),
+                CoreFrame::Case {
+                    scrutinee: 0,
+                    binder: y,
+                    alts: vec![crate::types::Alt {
+                        con: crate::types::AltCon::Default,
+                        binders: vec![],
+                        body: 1,
+                    }],
+                },
+            ],
+        };
+        // Case(x, z, [Default => z])
+        let rhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),
+                CoreFrame::Var(z),
+                CoreFrame::Case {
+                    scrutinee: 0,
+                    binder: z,
+                    alts: vec![crate::types::Alt {
+                        con: crate::types::AltCon::Default,
+                        binders: vec![],
+                        body: 1,
+                    }],
+                },
+            ],
+        };
+        assert!(alpha_eq(&lhs, &rhs));
+    }
+
+    #[test]
+    fn test_alpha_eq_join() {
+        let x = VarId(1);
+        let y = VarId(2);
+        // Join(j, [x], x, y)
+        let lhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),
+                CoreFrame::Var(y),
+                CoreFrame::Join {
+                    label: JoinId(1),
+                    params: vec![x],
+                    rhs: 0,
+                    body: 1,
+                },
+            ],
+        };
+        // Join(j, [y], y, y)
+        let rhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(y),
+                CoreFrame::Join {
+                    label: JoinId(1),
+                    params: vec![y],
+                    rhs: 0,
+                    body: 0,
+                },
+            ],
+        };
+        assert!(alpha_eq(&lhs, &rhs));
     }
 }

--- a/core-repr/src/alpha.rs
+++ b/core-repr/src/alpha.rs
@@ -1,0 +1,386 @@
+use crate::{CoreExpr, CoreFrame, VarId};
+use std::collections::HashMap;
+
+/// Check if two expressions are alpha-equivalent.
+pub fn alpha_eq(lhs: &CoreExpr, rhs: &CoreExpr) -> bool {
+    if lhs.nodes.is_empty() && rhs.nodes.is_empty() {
+        return true;
+    }
+    if lhs.nodes.is_empty() || rhs.nodes.is_empty() {
+        return false;
+    }
+    alpha_eq_at(
+        lhs,
+        rhs,
+        lhs.nodes.len() - 1,
+        rhs.nodes.len() - 1,
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        &mut 0,
+    )
+}
+
+/// Recursive helper. `env_l` maps lhs bound vars to canonical ids, `env_r` maps rhs bound vars to canonical ids.
+fn alpha_eq_at(
+    lhs: &CoreExpr,
+    rhs: &CoreExpr,
+    li: usize,
+    ri: usize,
+    env_l: &mut HashMap<VarId, u64>,
+    env_r: &mut HashMap<VarId, u64>,
+    next_canon: &mut u64,
+) -> bool {
+    match (&lhs.nodes[li], &rhs.nodes[ri]) {
+        (CoreFrame::Var(lv), CoreFrame::Var(rv)) => match (env_l.get(lv), env_r.get(rv)) {
+            (Some(lc), Some(rc)) => lc == rc,
+            (None, None) => lv == rv,
+            _ => false,
+        },
+        (CoreFrame::Lit(ll), CoreFrame::Lit(rl)) => ll == rl,
+        (CoreFrame::App { fun: lf, arg: la }, CoreFrame::App { fun: rf, arg: ra }) => {
+            alpha_eq_at(lhs, rhs, *lf, *rf, env_l, env_r, next_canon)
+                && alpha_eq_at(lhs, rhs, *la, *ra, env_l, env_r, next_canon)
+        }
+        (
+            CoreFrame::Lam {
+                binder: lb,
+                body: lbody,
+            },
+            CoreFrame::Lam {
+                binder: rb,
+                body: rbody,
+            },
+        ) => {
+            let canon = *next_canon;
+            *next_canon += 1;
+            let old_l = env_l.insert(*lb, canon);
+            let old_r = env_r.insert(*rb, canon);
+            let res = alpha_eq_at(lhs, rhs, *lbody, *rbody, env_l, env_r, next_canon);
+            if let Some(o) = old_l {
+                env_l.insert(*lb, o);
+            } else {
+                env_l.remove(lb);
+            }
+            if let Some(o) = old_r {
+                env_r.insert(*rb, o);
+            } else {
+                env_r.remove(rb);
+            }
+            res
+        }
+        (
+            CoreFrame::LetNonRec {
+                binder: lb,
+                rhs: lrhs,
+                body: lbody,
+            },
+            CoreFrame::LetNonRec {
+                binder: rb,
+                rhs: rrhs,
+                body: rbody,
+            },
+        ) => {
+            if !alpha_eq_at(lhs, rhs, *lrhs, *rrhs, env_l, env_r, next_canon) {
+                return false;
+            }
+            let canon = *next_canon;
+            *next_canon += 1;
+            let old_l = env_l.insert(*lb, canon);
+            let old_r = env_r.insert(*rb, canon);
+            let res = alpha_eq_at(lhs, rhs, *lbody, *rbody, env_l, env_r, next_canon);
+            if let Some(o) = old_l {
+                env_l.insert(*lb, o);
+            } else {
+                env_l.remove(lb);
+            }
+            if let Some(o) = old_r {
+                env_r.insert(*rb, o);
+            } else {
+                env_r.remove(rb);
+            }
+            res
+        }
+        (
+            CoreFrame::LetRec {
+                bindings: lbs,
+                body: lbody,
+            },
+            CoreFrame::LetRec {
+                bindings: rbs,
+                body: rbody,
+            },
+        ) => {
+            if lbs.len() != rbs.len() {
+                return false;
+            }
+            let mut old_ls = Vec::new();
+            let mut old_rs = Vec::new();
+            for ((lb, _), (rb, _)) in lbs.iter().zip(rbs.iter()) {
+                let canon = *next_canon;
+                *next_canon += 1;
+                old_ls.push(env_l.insert(*lb, canon));
+                old_rs.push(env_r.insert(*rb, canon));
+            }
+
+            let mut ok = true;
+            for ((_, lr), (_, rr)) in lbs.iter().zip(rbs.iter()) {
+                if !alpha_eq_at(lhs, rhs, *lr, *rr, env_l, env_r, next_canon) {
+                    ok = false;
+                    break;
+                }
+            }
+            if ok {
+                ok = alpha_eq_at(lhs, rhs, *lbody, *rbody, env_l, env_r, next_canon);
+            }
+
+            // Restore env
+            for ((lb, _), old) in lbs.iter().zip(old_ls) {
+                if let Some(o) = old {
+                    env_l.insert(*lb, o);
+                } else {
+                    env_l.remove(lb);
+                }
+            }
+            for ((rb, _), old) in rbs.iter().zip(old_rs) {
+                if let Some(o) = old {
+                    env_r.insert(*rb, o);
+                } else {
+                    env_r.remove(rb);
+                }
+            }
+            ok
+        }
+        (
+            CoreFrame::Case {
+                scrutinee: ls,
+                binder: lb,
+                alts: lalts,
+            },
+            CoreFrame::Case {
+                scrutinee: rs,
+                binder: rb,
+                alts: ralts,
+            },
+        ) => {
+            if !alpha_eq_at(lhs, rhs, *ls, *rs, env_l, env_r, next_canon) {
+                return false;
+            }
+            if lalts.len() != ralts.len() {
+                return false;
+            }
+
+            let canon = *next_canon;
+            *next_canon += 1;
+            let old_lb = env_l.insert(*lb, canon);
+            let old_rb = env_r.insert(*rb, canon);
+
+            let mut ok = true;
+            for (lalt, ralt) in lalts.iter().zip(ralts.iter()) {
+                if lalt.con != ralt.con || lalt.binders.len() != ralt.binders.len() {
+                    ok = false;
+                    break;
+                }
+                let mut old_alt_ls = Vec::new();
+                let mut old_alt_rs = Vec::new();
+                for (lab, rab) in lalt.binders.iter().zip(ralt.binders.iter()) {
+                    let c = *next_canon;
+                    *next_canon += 1;
+                    old_alt_ls.push(env_l.insert(*lab, c));
+                    old_alt_rs.push(env_r.insert(*rab, c));
+                }
+
+                if !alpha_eq_at(lhs, rhs, lalt.body, ralt.body, env_l, env_r, next_canon) {
+                    ok = false;
+                }
+
+                // Restore alt env
+                for (lab, old) in lalt.binders.iter().zip(old_alt_ls) {
+                    if let Some(o) = old {
+                        env_l.insert(*lab, o);
+                    } else {
+                        env_l.remove(lab);
+                    }
+                }
+                for (rab, old) in ralt.binders.iter().zip(old_alt_rs) {
+                    if let Some(o) = old {
+                        env_r.insert(*rab, o);
+                    } else {
+                        env_r.remove(rab);
+                    }
+                }
+
+                if !ok {
+                    break;
+                }
+            }
+
+            // Restore case binder
+            if let Some(o) = old_lb {
+                env_l.insert(*lb, o);
+            } else {
+                env_l.remove(lb);
+            }
+            if let Some(o) = old_rb {
+                env_r.insert(*rb, o);
+            } else {
+                env_r.remove(rb);
+            }
+            ok
+        }
+        (CoreFrame::Con { tag: lt, fields: lf }, CoreFrame::Con { tag: rt, fields: rf }) => {
+            if lt != rt || lf.len() != rf.len() {
+                return false;
+            }
+            for (l, r) in lf.iter().zip(rf.iter()) {
+                if !alpha_eq_at(lhs, rhs, *l, *r, env_l, env_r, next_canon) {
+                    return false;
+                }
+            }
+            true
+        }
+        (
+            CoreFrame::Join {
+                label: ll,
+                params: lp,
+                rhs: lr,
+                body: lbody,
+            },
+            CoreFrame::Join {
+                label: rl,
+                params: rp,
+                rhs: rr,
+                body: rbody,
+            },
+        ) => {
+            // Join labels must match exactly if not tracked by env (spec says JoinId is not VarId)
+            if ll != rl || lp.len() != rp.len() {
+                return false;
+            }
+
+            let mut old_lp = Vec::new();
+            let mut old_rp = Vec::new();
+            for (p_l, p_r) in lp.iter().zip(rp.iter()) {
+                let canon = *next_canon;
+                *next_canon += 1;
+                old_lp.push(env_l.insert(*p_l, canon));
+                old_rp.push(env_r.insert(*p_r, canon));
+            }
+
+            let res_rhs = alpha_eq_at(lhs, rhs, *lr, *rr, env_l, env_r, next_canon);
+
+            // Restore lp env
+            for (p_l, old) in lp.iter().zip(old_lp) {
+                if let Some(o) = old {
+                    env_l.insert(*p_l, o);
+                } else {
+                    env_l.remove(p_l);
+                }
+            }
+            for (p_r, old) in rp.iter().zip(old_rp) {
+                if let Some(o) = old {
+                    env_r.insert(*p_r, o);
+                } else {
+                    env_r.remove(p_r);
+                }
+            }
+
+            if !res_rhs {
+                return false;
+            }
+
+            alpha_eq_at(lhs, rhs, *lbody, *rbody, env_l, env_r, next_canon)
+        }
+        (CoreFrame::Jump { label: ll, args: la }, CoreFrame::Jump { label: rl, args: ra }) => {
+            if ll != rl || la.len() != ra.len() {
+                return false;
+            }
+            for (l, r) in la.iter().zip(ra.iter()) {
+                if !alpha_eq_at(lhs, rhs, *l, *r, env_l, env_r, next_canon) {
+                    return false;
+                }
+            }
+            true
+        }
+        (CoreFrame::PrimOp { op: lo, args: la }, CoreFrame::PrimOp { op: ro, args: ra }) => {
+            if lo != ro || la.len() != ra.len() {
+                return false;
+            }
+            for (l, r) in la.iter().zip(ra.iter()) {
+                if !alpha_eq_at(lhs, rhs, *l, *r, env_l, env_r, next_canon) {
+                    return false;
+                }
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RecursiveTree;
+
+    #[test]
+    fn test_alpha_eq_lam() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let lhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),                // 0
+                CoreFrame::Lam { binder: x, body: 0 }, // 1
+            ],
+        };
+        let rhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(y),                // 0
+                CoreFrame::Lam { binder: y, body: 0 }, // 1
+            ],
+        };
+        assert!(alpha_eq(&lhs, &rhs));
+    }
+
+    #[test]
+    fn test_alpha_neq_lam() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let lhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),                // 0
+                CoreFrame::Lam { binder: x, body: 0 }, // 1
+            ],
+        };
+        let rhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(y),                // 0
+                CoreFrame::Lam { binder: x, body: 0 }, // 1 (binder x, body uses y)
+            ],
+        };
+        assert!(!alpha_eq(&lhs, &rhs));
+    }
+
+    #[test]
+    fn test_alpha_neq_free() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let lhs = RecursiveTree {
+            nodes: vec![CoreFrame::Var(x)],
+        };
+        let rhs = RecursiveTree {
+            nodes: vec![CoreFrame::Var(y)],
+        };
+        assert!(!alpha_eq(&lhs, &rhs));
+    }
+
+    #[test]
+    fn test_alpha_eq_reflexive() {
+        let x = VarId(1);
+        let lhs = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),                // 0
+                CoreFrame::Lam { binder: x, body: 0 }, // 1
+            ],
+        };
+        assert!(alpha_eq(&lhs, &lhs));
+    }
+}

--- a/core-repr/src/free_vars.rs
+++ b/core-repr/src/free_vars.rs
@@ -1,0 +1,205 @@
+use std::collections::HashSet;
+use crate::{CoreExpr, CoreFrame, VarId};
+
+/// Collect all free variables in the expression rooted at the given node.
+pub fn free_vars(tree: &CoreExpr) -> HashSet<VarId> {
+    if tree.nodes.is_empty() {
+        return HashSet::new();
+    }
+    free_vars_at(tree, tree.nodes.len() - 1)
+}
+
+fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
+    match &tree.nodes[idx] {
+        CoreFrame::Var(v) => {
+            let mut s = HashSet::new();
+            s.insert(*v);
+            s
+        }
+        CoreFrame::Lit(_) => HashSet::new(),
+        CoreFrame::App { fun, arg } => {
+            let mut s = free_vars_at(tree, *fun);
+            s.extend(free_vars_at(tree, *arg));
+            s
+        }
+        CoreFrame::Lam { binder, body } => {
+            let mut s = free_vars_at(tree, *body);
+            s.remove(binder);
+            s
+        }
+        CoreFrame::LetNonRec { binder, rhs, body } => {
+            let mut s = free_vars_at(tree, *rhs);
+            let mut body_fvs = free_vars_at(tree, *body);
+            body_fvs.remove(binder);
+            s.extend(body_fvs);
+            s
+        }
+        CoreFrame::LetRec { bindings, body } => {
+            let bound: HashSet<VarId> = bindings.iter().map(|(v, _)| *v).collect();
+            let mut s = HashSet::new();
+            for (_, rhs) in bindings {
+                let rhs_fvs = free_vars_at(tree, *rhs);
+                s.extend(rhs_fvs.difference(&bound));
+            }
+            let body_fvs = free_vars_at(tree, *body);
+            s.extend(body_fvs.difference(&bound));
+            s
+        }
+        CoreFrame::Case {
+            scrutinee,
+            binder,
+            alts,
+        } => {
+            let mut s = free_vars_at(tree, *scrutinee);
+            for alt in alts {
+                let mut alt_fvs = free_vars_at(tree, alt.body);
+                alt_fvs.remove(binder); // case binder
+                for b in &alt.binders {
+                    alt_fvs.remove(b); // pattern binders
+                }
+                s.extend(alt_fvs);
+            }
+            s
+        }
+        CoreFrame::Con { fields, .. } => {
+            let mut s = HashSet::new();
+            for f in fields {
+                s.extend(free_vars_at(tree, *f));
+            }
+            s
+        }
+        CoreFrame::Join {
+            label: _,
+            params,
+            rhs,
+            body,
+        } => {
+            let param_set: HashSet<VarId> = params.iter().copied().collect();
+            let mut rhs_fvs = free_vars_at(tree, *rhs);
+            for p in &param_set {
+                rhs_fvs.remove(p);
+            }
+            // Join label scopes over body (and rhs references label via Jump, not as free var)
+            let body_fvs = free_vars_at(tree, *body);
+            let mut s = rhs_fvs;
+            s.extend(body_fvs);
+            s
+        }
+        CoreFrame::Jump { args, .. } => {
+            let mut s = HashSet::new();
+            for a in args {
+                s.extend(free_vars_at(tree, *a));
+            }
+            s
+        }
+        CoreFrame::PrimOp { args, .. } => {
+            let mut s = HashSet::new();
+            for a in args {
+                s.extend(free_vars_at(tree, *a));
+            }
+            s
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::*;
+    use crate::RecursiveTree;
+
+    /// Helper to build a single-node tree
+    fn leaf(frame: CoreFrame<usize>) -> CoreExpr {
+        RecursiveTree { nodes: vec![frame] }
+    }
+
+    /// Helper to build a tree with given nodes (root is last)
+    fn tree(nodes: Vec<CoreFrame<usize>>) -> CoreExpr {
+        RecursiveTree { nodes }
+    }
+
+    #[test]
+    fn test_free_vars_var() {
+        let x = VarId(1);
+        let expr = leaf(CoreFrame::Var(x));
+        let mut expected = HashSet::new();
+        expected.insert(x);
+        assert_eq!(free_vars(&expr), expected);
+    }
+
+    #[test]
+    fn test_free_vars_lam_bound() {
+        let x = VarId(1);
+        let expr = tree(vec![
+            CoreFrame::Var(x),                // 0
+            CoreFrame::Lam { binder: x, body: 0 }, // 1
+        ]);
+        assert_eq!(free_vars(&expr), HashSet::new());
+    }
+
+    #[test]
+    fn test_free_vars_lam_free() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let expr = tree(vec![
+            CoreFrame::Var(y),                // 0
+            CoreFrame::Lam { binder: x, body: 0 }, // 1
+        ]);
+        let mut expected = HashSet::new();
+        expected.insert(y);
+        assert_eq!(free_vars(&expr), expected);
+    }
+
+    #[test]
+    fn test_free_vars_let_non_rec() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let expr = tree(vec![
+            CoreFrame::Var(y), // 0: rhs
+            CoreFrame::Var(x), // 1: body
+            CoreFrame::LetNonRec {
+                binder: x,
+                rhs: 0,
+                body: 1,
+            }, // 2
+        ]);
+        let mut expected = HashSet::new();
+        expected.insert(y);
+        assert_eq!(free_vars(&expr), expected);
+    }
+
+    #[test]
+    fn test_free_vars_let_rec() {
+        let x = VarId(1);
+        let expr = tree(vec![
+            CoreFrame::Var(x), // 0: rhs/body
+            CoreFrame::LetRec {
+                bindings: vec![(x, 0)],
+                body: 0,
+            }, // 1
+        ]);
+        assert_eq!(free_vars(&expr), HashSet::new());
+    }
+
+    #[test]
+    fn test_free_vars_case() {
+        let a = VarId(1);
+        let b = VarId(2);
+        let expr = tree(vec![
+            CoreFrame::Var(a), // 0: scrutinee
+            CoreFrame::Var(b), // 1: alt body
+            CoreFrame::Case {
+                scrutinee: 0,
+                binder: b,
+                alts: vec![Alt {
+                    con: AltCon::Default,
+                    binders: vec![],
+                    body: 1,
+                }],
+            }, // 2
+        ]);
+        let mut expected = HashSet::new();
+        expected.insert(a);
+        assert_eq!(free_vars(&expr), expected);
+    }
+}

--- a/core-repr/src/free_vars.rs
+++ b/core-repr/src/free_vars.rs
@@ -202,4 +202,63 @@ mod tests {
         expected.insert(a);
         assert_eq!(free_vars(&expr), expected);
     }
+
+    #[test]
+    fn test_free_vars_con() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let expr = tree(vec![
+            CoreFrame::Var(x),
+            CoreFrame::Var(y),
+            CoreFrame::Con {
+                tag: DataConId(1),
+                fields: vec![0, 1],
+            },
+        ]);
+        let mut expected = HashSet::new();
+        expected.insert(x);
+        expected.insert(y);
+        assert_eq!(free_vars(&expr), expected);
+    }
+
+    #[test]
+    fn test_free_vars_join_jump() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let expr = tree(vec![
+            CoreFrame::Var(y), // 0: Jump arg
+            CoreFrame::Jump {
+                label: JoinId(1),
+                args: vec![0],
+            }, // 1: rhs
+            CoreFrame::Var(x), // 2: body
+            CoreFrame::Join {
+                label: JoinId(1),
+                params: vec![x],
+                rhs: 1,
+                body: 2,
+            }, // 3
+        ]);
+        // x is bound in rhs by Join params, but NOT in body. y is free in rhs.
+        let mut expected = HashSet::new();
+        expected.insert(y);
+        expected.insert(x);
+        assert_eq!(free_vars(&expr), expected);
+    }
+
+    #[test]
+    fn test_free_vars_primop() {
+        let x = VarId(1);
+        let expr = tree(vec![
+            CoreFrame::Var(x),
+            CoreFrame::Lit(Literal::LitInt(1)),
+            CoreFrame::PrimOp {
+                op: PrimOpKind::IntAdd,
+                args: vec![0, 1],
+            },
+        ]);
+        let mut expected = HashSet::new();
+        expected.insert(x);
+        assert_eq!(free_vars(&expr), expected);
+    }
 }

--- a/core-repr/src/lib.rs
+++ b/core-repr/src/lib.rs
@@ -4,6 +4,9 @@ pub mod frame;
 pub mod tree;
 pub mod types;
 pub mod serial;
+pub mod free_vars;
+pub mod subst;
+pub mod alpha;
 
 pub use datacon::*;
 pub use datacon_table::*;

--- a/core-repr/src/subst.rs
+++ b/core-repr/src/subst.rs
@@ -234,7 +234,7 @@ fn subst_at(tree: &CoreExpr, idx: usize, ctx: &mut SubstCtx, env: &HashMap<VarId
                 let mut alt_env = case_env.clone();
                 let mut new_pattern_binders = Vec::new();
                 for b in &alt.binders {
-                    let actual_b = env.get(b).copied().unwrap_or(*b);
+                    let actual_b = case_env.get(b).copied().unwrap_or(*b);
                     if actual_b == ctx.target {
                         alt_shadow = true;
                     }
@@ -317,6 +317,9 @@ fn subst_at(tree: &CoreExpr, idx: usize, ctx: &mut SubstCtx, env: &HashMap<VarId
 }
 
 fn splice_tree(replacement: &CoreExpr, new_nodes: &mut Vec<CoreFrame<usize>>) -> usize {
+    if replacement.nodes.is_empty() {
+        panic!("Cannot splice an empty replacement tree");
+    }
     let offset = new_nodes.len();
     for node in &replacement.nodes {
         let mapped = node.clone().map_layer(|idx| idx + offset);
@@ -507,6 +510,118 @@ mod tests {
             }
         } else {
             panic!("Result should be Lam");
+        }
+    }
+
+    #[test]
+    fn test_subst_let_rec() {
+        let x = VarId(1);
+        let y = VarId(2);
+        // LetRec [(x, Var(y))] Var(x)
+        let tree = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(y), // 0: rhs
+                CoreFrame::Var(x), // 1: body
+                CoreFrame::LetRec {
+                    bindings: vec![(x, 0)],
+                    body: 1,
+                }, // 2
+            ],
+        };
+        // Var(42)
+        let replacement = leaf(CoreFrame::Lit(Literal::LitInt(42)));
+
+        // Substitute x -> 42. Since x is bound in LetRec, it should be a no-op for body.
+        // But y is free in rhs, let's substitute y -> 42.
+        let result = subst(&tree, y, &replacement);
+
+        if let CoreFrame::LetRec { bindings, .. } = &result.nodes[result.nodes.len() - 1] {
+            if let CoreFrame::Lit(Literal::LitInt(42)) = &result.nodes[bindings[0].1] {
+                // OK
+            } else {
+                panic!("rhs should be substituted");
+            }
+        } else {
+            panic!("Result should be LetRec");
+        }
+    }
+
+    #[test]
+    fn test_subst_case_capture() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let z = VarId(3);
+        // Case(x, y, [Default => z])
+        // Let's substitute z -> Var(y). Case binder y should be renamed.
+        let tree = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x), // 0: scrutinee
+                CoreFrame::Var(z), // 1: alt body
+                CoreFrame::Case {
+                    scrutinee: 0,
+                    binder: y,
+                    alts: vec![Alt {
+                        con: AltCon::Default,
+                        binders: vec![],
+                        body: 1,
+                    }],
+                }, // 2
+            ],
+        };
+        let replacement = leaf(CoreFrame::Var(y));
+
+        let result = subst(&tree, z, &replacement);
+
+        if let CoreFrame::Case { binder, alts, .. } = &result.nodes[result.nodes.len() - 1] {
+            assert_ne!(*binder, y);
+            if let CoreFrame::Var(v) = &result.nodes[alts[0].body] {
+                assert_eq!(*v, y);
+            } else {
+                panic!("Body should be Var(y)");
+            }
+        } else {
+            panic!("Result should be Case");
+        }
+    }
+
+    #[test]
+    fn test_subst_join() {
+        let x = VarId(1);
+        // Join(j, [x], x, x)
+        // Substitute x -> 42. x is bound in rhs, but NOT in body (if we follow Join scoping rules: params bound in rhs).
+        // Wait, spec says: "Join label scopes over body (and rhs references label via Jump, not as free var)".
+        // "params" are bound in RHS.
+        let tree = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x), // 0: rhs
+                CoreFrame::Var(x), // 1: body
+                CoreFrame::Join {
+                    label: JoinId(1),
+                    params: vec![x],
+                    rhs: 0,
+                    body: 1,
+                },
+            ],
+        };
+        let replacement = leaf(CoreFrame::Lit(Literal::LitInt(42)));
+
+        let result = subst(&tree, x, &replacement);
+
+        if let CoreFrame::Join { rhs, body, .. } = &result.nodes[result.nodes.len() - 1] {
+            // x in rhs is shadowed, should NOT be substituted
+            if let CoreFrame::Var(v) = &result.nodes[*rhs] {
+                assert_eq!(*v, x);
+            } else {
+                panic!("RHS x should be shadowed");
+            }
+            // x in body is NOT shadowed by params, should be substituted
+            if let CoreFrame::Lit(Literal::LitInt(42)) = &result.nodes[*body] {
+                // OK
+            } else {
+                panic!("Body x should be substituted");
+            }
+        } else {
+            panic!("Result should be Join");
         }
     }
 }

--- a/core-repr/src/subst.rs
+++ b/core-repr/src/subst.rs
@@ -1,0 +1,512 @@
+use crate::free_vars::free_vars;
+use crate::tree::MapLayer;
+use crate::{CoreExpr, CoreFrame, RecursiveTree, VarId};
+use std::collections::{HashMap, HashSet};
+
+/// Substitute `replacement` for `target` in `tree`. Returns a new tree.
+/// Capture-avoiding: renames binders that would capture free vars in the replacement.
+pub fn subst(tree: &CoreExpr, target: VarId, replacement: &CoreExpr) -> CoreExpr {
+    if tree.nodes.is_empty() {
+        return tree.clone();
+    }
+
+    let fvs_replacement = free_vars(replacement);
+    let max_tree = find_max_var_id(tree);
+    let max_replacement = find_max_var_id(replacement);
+    let mut max_id = VarId(max_tree.0.max(max_replacement.0));
+    let mut next_id = move || {
+        max_id.0 += 1;
+        max_id
+    };
+
+    let mut new_nodes = Vec::new();
+    let mut ctx = SubstCtx {
+        target,
+        replacement,
+        fvs_replacement: &fvs_replacement,
+        next_id: &mut next_id,
+        new_nodes: &mut new_nodes,
+    };
+
+    subst_at(tree, tree.nodes.len() - 1, &mut ctx, &HashMap::new());
+
+    RecursiveTree { nodes: new_nodes }
+}
+
+struct SubstCtx<'a> {
+    target: VarId,
+    replacement: &'a CoreExpr,
+    fvs_replacement: &'a HashSet<VarId>,
+    next_id: &'a mut dyn FnMut() -> VarId,
+    new_nodes: &'a mut Vec<CoreFrame<usize>>,
+}
+
+fn find_max_var_id(tree: &CoreExpr) -> VarId {
+    let mut max = VarId(0);
+    for node in &tree.nodes {
+        match node {
+            CoreFrame::Var(v) => max = VarId(max.0.max(v.0)),
+            CoreFrame::Lam { binder, .. } => max = VarId(max.0.max(binder.0)),
+            CoreFrame::LetNonRec { binder, .. } => max = VarId(max.0.max(binder.0)),
+            CoreFrame::LetRec { bindings, .. } => {
+                for (v, _) in bindings {
+                    max = VarId(max.0.max(v.0));
+                }
+            }
+            CoreFrame::Case { binder, alts, .. } => {
+                max = VarId(max.0.max(binder.0));
+                for alt in alts {
+                    for b in &alt.binders {
+                        max = VarId(max.0.max(b.0));
+                    }
+                }
+            }
+            CoreFrame::Join { params, .. } => {
+                for p in params {
+                    max = VarId(max.0.max(p.0));
+                }
+            }
+            _ => {}
+        }
+    }
+    max
+}
+
+/// Recursive helper for substitution.
+/// `env` maps binders that have been renamed (due to capture avoidance) to their new IDs.
+fn subst_at(tree: &CoreExpr, idx: usize, ctx: &mut SubstCtx, env: &HashMap<VarId, VarId>) -> usize {
+    match &tree.nodes[idx] {
+        CoreFrame::Var(v) => {
+            let actual_v = env.get(v).copied().unwrap_or(*v);
+            if actual_v == ctx.target {
+                // Splice replacement
+                splice_tree(ctx.replacement, ctx.new_nodes)
+            } else {
+                let new_idx = ctx.new_nodes.len();
+                ctx.new_nodes.push(CoreFrame::Var(actual_v));
+                new_idx
+            }
+        }
+        CoreFrame::Lit(l) => {
+            let new_idx = ctx.new_nodes.len();
+            ctx.new_nodes.push(CoreFrame::Lit(l.clone()));
+            new_idx
+        }
+        CoreFrame::Lam { binder, body } => {
+            let actual_binder = env.get(binder).copied().unwrap_or(*binder);
+            if actual_binder == ctx.target {
+                // target is shadowed, just copy the subtree with renamed binders (if any)
+                copy_with_env(tree, idx, ctx.new_nodes, env)
+            } else if ctx.fvs_replacement.contains(&actual_binder) {
+                // Capture would occur, rename binder
+                let fresh = (ctx.next_id)();
+                let mut new_env = env.clone();
+                new_env.insert(*binder, fresh);
+                let new_body = subst_at(tree, *body, ctx, &new_env);
+                let new_idx = ctx.new_nodes.len();
+                ctx.new_nodes.push(CoreFrame::Lam {
+                    binder: fresh,
+                    body: new_body,
+                });
+                new_idx
+            } else {
+                let new_body = subst_at(tree, *body, ctx, env);
+                let new_idx = ctx.new_nodes.len();
+                ctx.new_nodes.push(CoreFrame::Lam {
+                    binder: actual_binder,
+                    body: new_body,
+                });
+                new_idx
+            }
+        }
+        CoreFrame::LetNonRec { binder, rhs, body } => {
+            let actual_binder = env.get(binder).copied().unwrap_or(*binder);
+            let new_rhs = subst_at(tree, *rhs, ctx, env);
+
+            if actual_binder == ctx.target {
+                // target is shadowed in body
+                let new_body = copy_with_env(tree, *body, ctx.new_nodes, env);
+                let new_idx = ctx.new_nodes.len();
+                ctx.new_nodes.push(CoreFrame::LetNonRec {
+                    binder: actual_binder,
+                    rhs: new_rhs,
+                    body: new_body,
+                });
+                new_idx
+            } else if ctx.fvs_replacement.contains(&actual_binder) {
+                let fresh = (ctx.next_id)();
+                let mut new_env = env.clone();
+                new_env.insert(*binder, fresh);
+                let new_body = subst_at(tree, *body, ctx, &new_env);
+                let new_idx = ctx.new_nodes.len();
+                ctx.new_nodes.push(CoreFrame::LetNonRec {
+                    binder: fresh,
+                    rhs: new_rhs,
+                    body: new_body,
+                });
+                new_idx
+            } else {
+                let new_body = subst_at(tree, *body, ctx, env);
+                let new_idx = ctx.new_nodes.len();
+                ctx.new_nodes.push(CoreFrame::LetNonRec {
+                    binder: actual_binder,
+                    rhs: new_rhs,
+                    body: new_body,
+                });
+                new_idx
+            }
+        }
+        CoreFrame::LetRec { bindings, body } => {
+            let mut binders: Vec<VarId> = bindings.iter().map(|(v, _)| *v).collect();
+            let mut shadow = false;
+            let mut needs_rename = false;
+            let mut new_env = env.clone();
+
+            for b in &binders {
+                let actual_b = env.get(b).copied().unwrap_or(*b);
+                if actual_b == ctx.target {
+                    shadow = true;
+                }
+                if ctx.fvs_replacement.contains(&actual_b) {
+                    needs_rename = true;
+                }
+            }
+
+            if shadow {
+                // Just copy the whole LetRec with environment renaming
+                copy_with_env(tree, idx, ctx.new_nodes, env)
+            } else if needs_rename {
+                for b in &mut binders {
+                    let actual_b = env.get(b).copied().unwrap_or(*b);
+                    if ctx.fvs_replacement.contains(&actual_b) {
+                        let fresh = (ctx.next_id)();
+                        new_env.insert(*b, fresh);
+                        *b = fresh;
+                    } else {
+                        *b = actual_b;
+                    }
+                }
+                let mut new_bindings = Vec::new();
+                for (i, (_, rhs)) in bindings.iter().enumerate() {
+                    let new_rhs = subst_at(tree, *rhs, ctx, &new_env);
+                    new_bindings.push((binders[i], new_rhs));
+                }
+                let new_body = subst_at(tree, *body, ctx, &new_env);
+                let new_idx = ctx.new_nodes.len();
+                ctx.new_nodes.push(CoreFrame::LetRec {
+                    bindings: new_bindings,
+                    body: new_body,
+                });
+                new_idx
+            } else {
+                let mut new_bindings = Vec::new();
+                for (v, rhs) in bindings {
+                    let new_rhs = subst_at(tree, *rhs, ctx, env);
+                    new_bindings.push((*v, new_rhs));
+                }
+                let new_body = subst_at(tree, *body, ctx, env);
+                let new_idx = ctx.new_nodes.len();
+                ctx.new_nodes.push(CoreFrame::LetRec {
+                    bindings: new_bindings,
+                    body: new_body,
+                });
+                new_idx
+            }
+        }
+        CoreFrame::Case {
+            scrutinee,
+            binder,
+            alts,
+        } => {
+            let actual_binder = env.get(binder).copied().unwrap_or(*binder);
+            let new_scrutinee = subst_at(tree, *scrutinee, ctx, env);
+
+            let mut case_env = env.clone();
+            let mut final_case_binder = actual_binder;
+            if ctx.fvs_replacement.contains(&actual_binder) {
+                final_case_binder = (ctx.next_id)();
+                case_env.insert(*binder, final_case_binder);
+            }
+
+            let mut final_alts = Vec::new();
+            for alt in alts {
+                let mut alt_shadow = actual_binder == ctx.target;
+                let mut alt_env = case_env.clone();
+                let mut new_pattern_binders = Vec::new();
+                for b in &alt.binders {
+                    let actual_b = env.get(b).copied().unwrap_or(*b);
+                    if actual_b == ctx.target {
+                        alt_shadow = true;
+                    }
+                    if ctx.fvs_replacement.contains(&actual_b) {
+                        let fresh = (ctx.next_id)();
+                        alt_env.insert(*b, fresh);
+                        new_pattern_binders.push(fresh);
+                    } else {
+                        new_pattern_binders.push(actual_b);
+                    }
+                }
+                let new_body = if alt_shadow {
+                    copy_with_env(tree, alt.body, ctx.new_nodes, &alt_env)
+                } else {
+                    subst_at(tree, alt.body, ctx, &alt_env)
+                };
+                final_alts.push(crate::types::Alt {
+                    con: alt.con.clone(),
+                    binders: new_pattern_binders,
+                    body: new_body,
+                });
+            }
+
+            let new_idx = ctx.new_nodes.len();
+            ctx.new_nodes.push(CoreFrame::Case {
+                scrutinee: new_scrutinee,
+                binder: final_case_binder,
+                alts: final_alts,
+            });
+            new_idx
+        }
+        CoreFrame::Join {
+            label,
+            params,
+            rhs,
+            body,
+        } => {
+            let mut join_env = env.clone();
+            let mut new_params = Vec::new();
+            let mut shadow = false;
+            for p in params {
+                let actual_p = env.get(p).copied().unwrap_or(*p);
+                if actual_p == ctx.target {
+                    shadow = true;
+                }
+                if ctx.fvs_replacement.contains(&actual_p) {
+                    let fresh = (ctx.next_id)();
+                    join_env.insert(*p, fresh);
+                    new_params.push(fresh);
+                } else {
+                    new_params.push(actual_p);
+                }
+            }
+
+            let new_rhs = if shadow {
+                copy_with_env(tree, *rhs, ctx.new_nodes, &join_env)
+            } else {
+                subst_at(tree, *rhs, ctx, &join_env)
+            };
+
+            let new_body = subst_at(tree, *body, ctx, env); // label doesn't shadow target
+
+            let new_idx = ctx.new_nodes.len();
+            ctx.new_nodes.push(CoreFrame::Join {
+                label: *label,
+                params: new_params,
+                rhs: new_rhs,
+                body: new_body,
+            });
+            new_idx
+        }
+        other => {
+            // App, Con, Jump, PrimOp
+            let mapped = other.clone().map_layer(|child_idx| subst_at(tree, child_idx, ctx, env));
+            let new_idx = ctx.new_nodes.len();
+            ctx.new_nodes.push(mapped);
+            new_idx
+        }
+    }
+}
+
+fn splice_tree(replacement: &CoreExpr, new_nodes: &mut Vec<CoreFrame<usize>>) -> usize {
+    let offset = new_nodes.len();
+    for node in &replacement.nodes {
+        let mapped = node.clone().map_layer(|idx| idx + offset);
+        new_nodes.push(mapped);
+    }
+    new_nodes.len() - 1
+}
+
+fn copy_with_env(
+    tree: &CoreExpr,
+    idx: usize,
+    new_nodes: &mut Vec<CoreFrame<usize>>,
+    env: &HashMap<VarId, VarId>,
+) -> usize {
+    match &tree.nodes[idx] {
+        CoreFrame::Var(v) => {
+            let actual_v = env.get(v).copied().unwrap_or(*v);
+            let new_idx = new_nodes.len();
+            new_nodes.push(CoreFrame::Var(actual_v));
+            new_idx
+        }
+        CoreFrame::Lam { binder, body } => {
+            let actual_binder = env.get(binder).copied().unwrap_or(*binder);
+            let new_body = copy_with_env(tree, *body, new_nodes, env);
+            let new_idx = new_nodes.len();
+            new_nodes.push(CoreFrame::Lam {
+                binder: actual_binder,
+                body: new_body,
+            });
+            new_idx
+        }
+        CoreFrame::LetNonRec { binder, rhs, body } => {
+            let actual_binder = env.get(binder).copied().unwrap_or(*binder);
+            let new_rhs = copy_with_env(tree, *rhs, new_nodes, env);
+            let new_body = copy_with_env(tree, *body, new_nodes, env);
+            let new_idx = new_nodes.len();
+            new_nodes.push(CoreFrame::LetNonRec {
+                binder: actual_binder,
+                rhs: new_rhs,
+                body: new_body,
+            });
+            new_idx
+        }
+        CoreFrame::LetRec { bindings, body } => {
+            let mut new_bindings = Vec::new();
+            for (v, rhs) in bindings {
+                let actual_v = env.get(v).copied().unwrap_or(*v);
+                let new_rhs = copy_with_env(tree, *rhs, new_nodes, env);
+                new_bindings.push((actual_v, new_rhs));
+            }
+            let new_body = copy_with_env(tree, *body, new_nodes, env);
+            let new_idx = new_nodes.len();
+            new_nodes.push(CoreFrame::LetRec {
+                bindings: new_bindings,
+                body: new_body,
+            });
+            new_idx
+        }
+        CoreFrame::Case {
+            scrutinee,
+            binder,
+            alts,
+        } => {
+            let actual_binder = env.get(binder).copied().unwrap_or(*binder);
+            let new_scrutinee = copy_with_env(tree, *scrutinee, new_nodes, env);
+            let mut new_alts = Vec::new();
+            for alt in alts {
+                let mut new_pattern_binders = Vec::new();
+                for b in &alt.binders {
+                    new_pattern_binders.push(env.get(b).copied().unwrap_or(*b));
+                }
+                let new_body = copy_with_env(tree, alt.body, new_nodes, env);
+                new_alts.push(crate::types::Alt {
+                    con: alt.con.clone(),
+                    binders: new_pattern_binders,
+                    body: new_body,
+                });
+            }
+            let new_idx = new_nodes.len();
+            new_nodes.push(CoreFrame::Case {
+                scrutinee: new_scrutinee,
+                binder: actual_binder,
+                alts: new_alts,
+            });
+            new_idx
+        }
+        CoreFrame::Join {
+            label,
+            params,
+            rhs,
+            body,
+        } => {
+            let mut new_params = Vec::new();
+            for p in params {
+                new_params.push(env.get(p).copied().unwrap_or(*p));
+            }
+            let new_rhs = copy_with_env(tree, *rhs, new_nodes, env);
+            let new_body = copy_with_env(tree, *body, new_nodes, env);
+            let new_idx = new_nodes.len();
+            new_nodes.push(CoreFrame::Join {
+                label: *label,
+                params: new_params,
+                rhs: new_rhs,
+                body: new_body,
+            });
+            new_idx
+        }
+        other => {
+            let mapped = other
+                .clone()
+                .map_layer(|child_idx| copy_with_env(tree, child_idx, new_nodes, env));
+            let new_idx = new_nodes.len();
+            new_nodes.push(mapped);
+            new_idx
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::*;
+
+    fn leaf(frame: CoreFrame<usize>) -> CoreExpr {
+        RecursiveTree { nodes: vec![frame] }
+    }
+
+    #[test]
+    fn test_subst_simple() {
+        let x = VarId(1);
+        let tree = leaf(CoreFrame::Var(x));
+        let replacement = leaf(CoreFrame::Lit(Literal::LitInt(42)));
+        let result = subst(&tree, x, &replacement);
+        assert_eq!(result, replacement);
+    }
+
+    #[test]
+    fn test_subst_no_op() {
+        let x = VarId(1);
+        let y = VarId(2);
+        let tree = leaf(CoreFrame::Var(y));
+        let replacement = leaf(CoreFrame::Lit(Literal::LitInt(42)));
+        let result = subst(&tree, x, &replacement);
+        assert_eq!(result, tree);
+    }
+
+    #[test]
+    fn test_subst_shadowing() {
+        let x = VarId(1);
+        let body = leaf(CoreFrame::Var(x));
+        let mut nodes = body.nodes;
+        let body_idx = nodes.len() - 1;
+        nodes.push(CoreFrame::Lam {
+            binder: x,
+            body: body_idx,
+        });
+        let tree = RecursiveTree { nodes };
+
+        let replacement = leaf(CoreFrame::Lit(Literal::LitInt(42)));
+        let result = subst(&tree, x, &replacement);
+        assert_eq!(result, tree);
+    }
+
+    #[test]
+    fn test_subst_capture_avoiding() {
+        let x = VarId(1);
+        let y = VarId(2);
+        // Lam(y, x)
+        let tree = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),                // 0
+                CoreFrame::Lam { binder: y, body: 0 }, // 1
+            ],
+        };
+        // Var(y)
+        let replacement = leaf(CoreFrame::Var(y));
+
+        let result = subst(&tree, x, &replacement);
+
+        // Result should be Lam(y', y) where y' is fresh
+        if let CoreFrame::Lam { binder, body } = &result.nodes[result.nodes.len() - 1] {
+            assert_ne!(*binder, y);
+            assert_ne!(*binder, x);
+            if let CoreFrame::Var(v) = &result.nodes[*body] {
+                assert_eq!(*v, y);
+            } else {
+                panic!("Body should be Var(y)");
+            }
+        } else {
+            panic!("Result should be Lam");
+        }
+    }
+}


### PR DESCRIPTION
This PR implements free variable collection, capture-avoiding substitution, and alpha-equivalence for the CoreFrame and CoreExpr types in the core-repr crate.