### PR TITLE
feat(core-heap): ArenaHeap and HeapObject manual memory layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,11 +84,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-bridge"
+version = "0.1.0"
+dependencies = [
+ "core-eval",
+ "core-repr",
+]
+
+[[package]]
 name = "core-eval"
 version = "0.1.0"
 dependencies = [
  "core-repr",
  "im",
+]
+
+[[package]]
+name = "core-heap"
+version = "0.1.0"
+dependencies = [
+ "bumpalo",
+ "core-eval",
+ "core-repr",
+]
+
+[[package]]
+name = "core-optimize"
+version = "0.1.0"
+dependencies = [
+ "core-eval",
+ "core-repr",
 ]
 
 [[package]]

--- a/core-heap/src/arena.rs
+++ b/core-heap/src/arena.rs
@@ -45,14 +45,29 @@ impl ArenaHeap {
     ///
     /// The returned pointer is 8-byte aligned and valid for `size` bytes.
     pub fn alloc_raw(&self, size: usize) -> *mut u8 {
-        // Round up to 8-byte alignment.
-        let aligned_size = (size + 7) & !7;
+        // Round up to 8-byte alignment, check for overflow.
+        let aligned_size = size.checked_add(7)
+            .map(|s| s & !7)
+            .expect("Allocation size overflow");
         
-        // Check for nursery exhaustion.
-        let old_used = self.used.fetch_add(aligned_size, Ordering::SeqCst);
-        if old_used + aligned_size > self.nursery_limit {
-            // v1 behavior: panic. Later we signal GC.
-            panic!("Nursery limit exceeded: GC not yet implemented");
+        // Check for nursery exhaustion and reserve space atomically.
+        let mut prev_used = self.used.load(Ordering::SeqCst);
+        loop {
+            if prev_used.checked_add(aligned_size)
+                .map_or(true, |new_used| new_used > self.nursery_limit)
+            {
+                // v1 behavior: panic. Later we signal GC.
+                panic!("Nursery limit exceeded: GC not yet implemented");
+            }
+            match self.used.compare_exchange_weak(
+                prev_used,
+                prev_used + aligned_size,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => break,
+                Err(actual) => prev_used = actual,
+            }
         }
 
         // bumpalo::alloc_layout always returns 16-byte aligned pointer

--- a/core-heap/src/arena.rs
+++ b/core-heap/src/arena.rs
@@ -1,0 +1,192 @@
+use bumpalo::Bump;
+use core_eval::{Heap, ThunkState, ThunkId};
+use core_repr::CoreExpr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Arena-based heap for Tidepool.
+///
+/// For v1, the ArenaHeap manages thunks via Vec for the interpreter
+/// and provides a bumpalo-backed arena for raw HeapObject allocation
+/// which will be used by the codegen path.
+pub struct ArenaHeap {
+    /// Nursery for raw HeapObject allocation.
+    arena: Bump,
+    /// Thunk store: index from ThunkId -> ThunkState.
+    thunks: Vec<ThunkState>,
+    /// Capacity of the nursery in bytes.
+    nursery_limit: usize,
+    /// Bytes used for raw objects.
+    used: AtomicUsize,
+}
+
+impl ArenaHeap {
+    /// Create a new ArenaHeap with 4MB default nursery capacity.
+    pub fn new() -> Self {
+        Self::with_capacity(4 * 1024 * 1024) // 4MB default
+    }
+
+    /// Create a new ArenaHeap with specified nursery capacity in bytes.
+    pub fn with_capacity(bytes: usize) -> Self {
+        Self {
+            arena: Bump::with_capacity(bytes),
+            thunks: Vec::new(),
+            nursery_limit: bytes,
+            used: AtomicUsize::new(0),
+        }
+    }
+
+    /// Allocate raw bytes in the arena.
+    ///
+    /// # Panics
+    ///
+    /// If the allocation exceeds the nursery limit.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer is 8-byte aligned and valid for `size` bytes.
+    pub fn alloc_raw(&self, size: usize) -> *mut u8 {
+        // Round up to 8-byte alignment.
+        let aligned_size = (size + 7) & !7;
+        
+        // Check for nursery exhaustion.
+        let old_used = self.used.fetch_add(aligned_size, Ordering::SeqCst);
+        if old_used + aligned_size > self.nursery_limit {
+            // v1 behavior: panic. Later we signal GC.
+            panic!("Nursery limit exceeded: GC not yet implemented");
+        }
+
+        // bumpalo::alloc_layout always returns 16-byte aligned pointer
+        // for layouts with alignment <= 16.
+        let layout = std::alloc::Layout::from_size_align(aligned_size, 8)
+            .expect("Invalid layout for alloc_raw");
+        
+        self.arena.alloc_layout(layout).as_ptr()
+    }
+
+    /// Bytes currently used in the nursery.
+    pub fn bytes_used(&self) -> usize {
+        self.used.load(Ordering::SeqCst)
+    }
+
+    /// Nursery capacity in bytes.
+    pub fn nursery_limit(&self) -> usize {
+        self.nursery_limit
+    }
+}
+
+impl Default for ArenaHeap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Heap for ArenaHeap {
+    fn alloc(&mut self, env: core_eval::env::Env, expr: CoreExpr) -> ThunkId {
+        let id = ThunkId(self.thunks.len() as u32);
+        self.thunks.push(ThunkState::Unevaluated(env, expr));
+        id
+    }
+
+    fn read(&self, id: ThunkId) -> &ThunkState {
+        &self.thunks[id.0 as usize]
+    }
+
+    fn write(&mut self, id: ThunkId, state: ThunkState) {
+        self.thunks[id.0 as usize] = state;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_repr::{CoreFrame, RecursiveTree, Literal, VarId};
+    use core_eval::env::Env;
+    use core_eval::value::Value;
+    use crate::layout::*;
+
+    #[test]
+    fn test_heap_trait_impl() {
+        let mut heap = ArenaHeap::new();
+        let env = Env::new();
+        let expr = RecursiveTree { nodes: vec![CoreFrame::Var(VarId(0))] };
+
+        let id1 = heap.alloc(env.clone(), expr.clone());
+        let id2 = heap.alloc(env.clone(), expr.clone());
+
+        assert_eq!(id1.0, 0);
+        assert_eq!(id2.0, 1);
+
+        match heap.read(id1) {
+            ThunkState::Unevaluated(_, _) => (),
+            _ => panic!("Expected Unevaluated"),
+        }
+
+        heap.write(id1, ThunkState::BlackHole);
+        match heap.read(id1) {
+            ThunkState::BlackHole => (),
+            _ => panic!("Expected BlackHole"),
+        }
+
+        let val = Value::Lit(Literal::LitInt(100));
+        heap.write(id1, ThunkState::Evaluated(val));
+        match heap.read(id1) {
+            ThunkState::Evaluated(Value::Lit(Literal::LitInt(100))) => (),
+            _ => panic!("Expected Evaluated(100)"),
+        }
+    }
+
+    #[test]
+    fn test_alloc_raw_alignment() {
+        let heap = ArenaHeap::new();
+        
+        for _ in 0..10 {
+            let ptr = heap.alloc_raw(13);
+            assert_eq!(ptr as usize % 8, 0, "Pointer {:?} is not 8-byte aligned", ptr);
+        }
+    }
+
+    #[test]
+    fn test_alloc_raw_roundtrip() {
+        let heap = ArenaHeap::new();
+        let size = 16;
+        let ptr = heap.alloc_raw(size);
+
+        unsafe {
+            write_header(ptr, TAG_CLOSURE, size as u16);
+            assert_eq!(read_tag(ptr), TAG_CLOSURE);
+            assert_eq!(read_size(ptr), size as u16);
+        }
+    }
+
+    #[test]
+    fn test_nursery_capacity() {
+        let heap = ArenaHeap::with_capacity(1024);
+        assert_eq!(heap.nursery_limit(), 1024);
+        assert_eq!(heap.bytes_used(), 0);
+
+        heap.alloc_raw(128);
+        assert_eq!(heap.bytes_used(), 128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Nursery limit exceeded")]
+    fn test_nursery_exhaustion() {
+        let heap = ArenaHeap::with_capacity(128);
+        // Fill up to the limit (note: bumpalo might have small internal overhead per alloc but usually zero for bump-pointer)
+        // With 8-byte alignment, 128 should be exactly possible.
+        heap.alloc_raw(128);
+        // Next allocation should panic.
+        heap.alloc_raw(8);
+    }
+
+    #[test]
+    fn test_no_overlap() {
+        let heap = ArenaHeap::new();
+        let ptr1 = heap.alloc_raw(8);
+        let ptr2 = heap.alloc_raw(8);
+        
+        assert_ne!(ptr1, ptr2);
+        let diff = (ptr2 as usize).abs_diff(ptr1 as usize);
+        assert!(diff >= 8);
+    }
+}

--- a/core-heap/src/layout.rs
+++ b/core-heap/src/layout.rs
@@ -1,0 +1,82 @@
+pub const TAG_CLOSURE: u8 = 0;
+pub const TAG_THUNK: u8 = 1;
+pub const TAG_CON: u8 = 2;
+pub const TAG_LIT: u8 = 3;
+
+pub const THUNK_UNEVALUATED: u8 = 0;
+pub const THUNK_BLACKHOLE: u8 = 1;
+pub const THUNK_EVALUATED: u8 = 2;
+
+/// tag(1) + size(2) + padding(5) = 8 bytes aligned
+pub const HEADER_SIZE: usize = 8;
+
+/// Read the tag byte from a heap object pointer.
+///
+/// # Safety
+///
+/// ptr must point to a valid HeapObject.
+pub unsafe fn read_tag(ptr: *const u8) -> u8 {
+    *ptr
+}
+
+/// Read the total size from a heap object pointer.
+///
+/// # Safety
+///
+/// ptr must point to a valid HeapObject.
+pub unsafe fn read_size(ptr: *const u8) -> u16 {
+    // Size is stored at offset 1 as u16.
+    // Use read_unaligned in case the pointer itself is not perfectly aligned
+    // (though our objects should be 8-byte aligned).
+    std::ptr::read_unaligned(ptr.add(1) as *const u16)
+}
+
+/// Write tag + size header.
+///
+/// # Safety
+///
+/// ptr must point to allocated memory of at least `size` bytes.
+pub unsafe fn write_header(ptr: *mut u8, tag: u8, size: u16) {
+    *ptr = tag;
+    std::ptr::write_unaligned(ptr.add(1) as *mut u16, size);
+    // Zero the padding bytes (offset 3 to 7) for stability.
+    std::ptr::write_bytes(ptr.add(3), 0, 5);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_header_roundtrip() {
+        let mut buffer = [0u8; HEADER_SIZE];
+        let ptr = buffer.as_mut_ptr();
+
+        unsafe {
+            write_header(ptr, TAG_THUNK, 16);
+            assert_eq!(read_tag(ptr), TAG_THUNK);
+            assert_eq!(read_size(ptr), 16);
+        }
+    }
+
+    #[test]
+    fn test_alignment_roundtrip() {
+        // Test with different sizes to ensure u16 size works.
+        let sizes = [8, 16, 64, 256, 1024, 65535];
+        for &size in &sizes {
+            let mut buffer = [0u8; 8];
+            let ptr = buffer.as_mut_ptr();
+            unsafe {
+                write_header(ptr, TAG_CON, size);
+                assert_eq!(read_tag(ptr), TAG_CON);
+                assert_eq!(read_size(ptr), size);
+            }
+        }
+    }
+
+    #[test]
+    fn test_header_offset() {
+        // Header size should be 8.
+        assert_eq!(HEADER_SIZE, 8);
+    }
+}

--- a/core-heap/src/layout.rs
+++ b/core-heap/src/layout.rs
@@ -35,12 +35,21 @@ pub unsafe fn read_size(ptr: *const u8) -> u16 {
 ///
 /// # Safety
 ///
-/// ptr must point to allocated memory of at least `size` bytes.
+/// ptr must point to allocated memory of at least `HEADER_SIZE` bytes.
+/// size must be at least `HEADER_SIZE`.
 pub unsafe fn write_header(ptr: *mut u8, tag: u8, size: u16) {
     *ptr = tag;
     std::ptr::write_unaligned(ptr.add(1) as *mut u16, size);
-    // Zero the padding bytes (offset 3 to 7) for stability.
-    std::ptr::write_bytes(ptr.add(3), 0, 5);
+    // Padding bytes are from offset 3 to 7 (5 bytes).
+    // Note: decisions.md says variant-specific payload follows at offset 3,
+    // but also says all objects are 8-byte aligned.
+    // If payload starts at offset 3, we should NOT zero these bytes.
+    // However, the spec ALSO says: "tag(1) + size(2) + padding(5) = 8 bytes aligned"
+    // in the Wave 1 description. We will follow the padding description for now
+    // but only zero if size >= 8 to be safe.
+    if size >= 8 {
+        std::ptr::write_bytes(ptr.add(3), 0, 5);
+    }
 }
 
 #[cfg(test)]
@@ -61,7 +70,8 @@ mod tests {
 
     #[test]
     fn test_alignment_roundtrip() {
-        // Test with different sizes to ensure u16 size works.
+        // Only header is written, so 8-byte buffer is enough for the header.
+        // We test various logical sizes to ensure the size u16 can store them.
         let sizes = [8, 16, 64, 256, 1024, 65535];
         for &size in &sizes {
             let mut buffer = [0u8; 8];

--- a/core-heap/src/lib.rs
+++ b/core-heap/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod layout;
+pub mod arena;
+
+pub use layout::*;
+pub use arena::*;


### PR DESCRIPTION
Implement the core-heap crate with a bumpalo-backed ArenaHeap and the HeapObject manual memory layout as specified in decisions.md.

### Changes:
- **core-heap/src/layout.rs**: Defined tag constants and unsafe accessors (read_tag, read_size, write_header) for the HeapObject header (8-byte aligned).
- **core-heap/src/arena.rs**: Implemented ArenaHeap with:
  - bumpalo nursery for raw allocation.
  - Requested bytes tracking via AtomicUsize (to respect nursery_limit).
  - Heap trait implementation for thunk management (compatible with the current interpreter).
- **Tests**: Added comprehensive tests for layout roundtrips, 8-byte alignment, nursery capacity/exhaustion, and the Heap trait.

### Boundary Compliance:
- HeapObject is a manual layout (tag at 0, size at 1).
- Variable-size objects: size is always read from header.
- 8-byte alignment for all allocations.
- No HashMap for lookups (Vec indexed by ThunkId).
- Documented safety invariants for unsafe accessors.