### PR TITLE
feat(core-heap): implement root enumeration and transitive marking for copying GC

### DIFF
--- a/core-heap/src/arena.rs
+++ b/core-heap/src/arena.rs
@@ -1,5 +1,6 @@
 use bumpalo::Bump;
 use core_eval::{Heap, ThunkState, ThunkId};
+use core_eval::value::Value;
 use core_repr::CoreExpr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -54,7 +55,7 @@ impl ArenaHeap {
         let mut prev_used = self.used.load(Ordering::SeqCst);
         loop {
             if prev_used.checked_add(aligned_size)
-                .map_or(true, |new_used| new_used > self.nursery_limit)
+                .is_none_or(|new_used| new_used > self.nursery_limit)
             {
                 // v1 behavior: panic. Later we signal GC.
                 panic!("Nursery limit exceeded: GC not yet implemented");
@@ -86,6 +87,33 @@ impl ArenaHeap {
     /// Nursery capacity in bytes.
     pub fn nursery_limit(&self) -> usize {
         self.nursery_limit
+    }
+
+    /// Return all ThunkIds directly referenced by this thunk.
+    pub fn children_of(&self, id: ThunkId) -> Vec<ThunkId> {
+        match self.read(id) {
+            ThunkState::Unevaluated(env, _) => {
+                env.values()
+                    .flat_map(Self::collect_thunk_refs)
+                    .collect()
+            }
+            ThunkState::BlackHole => vec![],
+            ThunkState::Evaluated(val) => Self::collect_thunk_refs(val),
+        }
+    }
+
+    fn collect_thunk_refs(val: &Value) -> Vec<ThunkId> {
+        match val {
+            Value::ThunkRef(id) => vec![*id],
+            Value::Con(_, fields) => fields.iter().flat_map(Self::collect_thunk_refs).collect(),
+            Value::Closure(env, _, _) => {
+                env.values().flat_map(Self::collect_thunk_refs).collect()
+            }
+            Value::JoinCont(_, _, env) => {
+                env.values().flat_map(Self::collect_thunk_refs).collect()
+            }
+            Value::Lit(_) => vec![],
+        }
     }
 }
 

--- a/core-heap/src/gc/mod.rs
+++ b/core-heap/src/gc/mod.rs
@@ -1,0 +1,2 @@
+pub mod trace;
+pub use trace::*;

--- a/core-heap/src/gc/trace.rs
+++ b/core-heap/src/gc/trace.rs
@@ -1,0 +1,209 @@
+use crate::arena::ArenaHeap;
+use core_eval::ThunkId;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// Maps old ThunkId -> new ThunkId for every reachable object.
+#[derive(Debug, Default)]
+pub struct ForwardingTable {
+    pub old_to_new: HashMap<u32, u32>,
+}
+
+impl ForwardingTable {
+    /// Check if a thunk is present in the forwarding table.
+    pub fn contains(&self, old: ThunkId) -> bool {
+        self.old_to_new.contains_key(&old.0)
+    }
+    
+    /// Get the new ThunkId for a given old ThunkId.
+    pub fn get(&self, old: ThunkId) -> Option<ThunkId> {
+        self.old_to_new.get(&old.0).map(|&n| ThunkId(n))
+    }
+    
+    /// Number of entries in the forwarding table.
+    pub fn len(&self) -> usize {
+        self.old_to_new.len()
+    }
+    
+    /// Check if the forwarding table is empty.
+    pub fn is_empty(&self) -> bool {
+        self.old_to_new.is_empty()
+    }
+}
+
+/// Trace from roots, building a forwarding table of all reachable objects.
+pub fn trace(roots: &[ThunkId], heap: &ArenaHeap) -> ForwardingTable {
+    let mut table = ForwardingTable::default();
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+    let mut next_id: u32 = 0;
+    
+    // Seed with roots
+    for &root in roots {
+        if !visited.contains(&root.0) {
+            visited.insert(root.0);
+            queue.push_back(root);
+        }
+    }
+    
+    // BFS traversal
+    while let Some(id) = queue.pop_front() {
+        // Assign new compacted id
+        table.old_to_new.insert(id.0, next_id);
+        next_id += 1;
+        
+        // Find children (ThunkIds referenced by this thunk's state)
+        for child in heap.children_of(id) {
+            if !visited.contains(&child.0) {
+                visited.insert(child.0);
+                queue.push_back(child);
+            }
+        }
+    }
+    
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_eval::{Heap, ThunkState, value::Value};
+    use core_eval::env::Env;
+    use core_repr::{CoreFrame, CoreExpr, Literal, VarId, DataConId};
+
+    fn empty_expr() -> CoreExpr {
+        CoreExpr { nodes: vec![CoreFrame::Lit(Literal::LitInt(0))] }
+    }
+
+    #[test]
+    fn test_empty_roots() {
+        let heap = ArenaHeap::new();
+        let table = trace(&[], &heap);
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn test_single_root_no_children() {
+        let mut heap = ArenaHeap::new();
+        let root = heap.alloc(Env::new(), empty_expr());
+        let table = trace(&[root], &heap);
+        assert_eq!(table.len(), 1);
+        assert!(table.contains(root));
+        assert_eq!(table.get(root), Some(ThunkId(0)));
+    }
+
+    #[test]
+    fn test_root_with_children() {
+        let mut heap = ArenaHeap::new();
+        
+        // Create child thunks
+        let child1 = heap.alloc(Env::new(), empty_expr());
+        let child2 = heap.alloc(Env::new(), empty_expr());
+        
+        // Create root referencing children
+        let mut env = Env::new();
+        env.insert(VarId(0), Value::ThunkRef(child1));
+        env.insert(VarId(1), Value::ThunkRef(child2));
+        let root = heap.alloc(env, empty_expr());
+        
+        let table = trace(&[root], &heap);
+        assert_eq!(table.len(), 3);
+        assert!(table.contains(root));
+        assert!(table.contains(child1));
+        assert!(table.contains(child2));
+    }
+
+    #[test]
+    fn test_unreachable_not_in_table() {
+        let mut heap = ArenaHeap::new();
+        let root = heap.alloc(Env::new(), empty_expr());
+        let unreachable = heap.alloc(Env::new(), empty_expr());
+        
+        let table = trace(&[root], &heap);
+        assert_eq!(table.len(), 1);
+        assert!(table.contains(root));
+        assert!(!table.contains(unreachable));
+    }
+
+    #[test]
+    fn test_diamond_pattern() {
+        let mut heap = ArenaHeap::new();
+        
+        // D
+        let d = heap.alloc(Env::new(), empty_expr());
+        
+        // B -> D
+        let mut env_b = Env::new();
+        env_b.insert(VarId(0), Value::ThunkRef(d));
+        let b = heap.alloc(env_b, empty_expr());
+        
+        // C -> D
+        let mut env_c = Env::new();
+        env_c.insert(VarId(0), Value::ThunkRef(d));
+        let c = heap.alloc(env_c, empty_expr());
+        
+        // A -> B, A -> C
+        let mut env_a = Env::new();
+        env_a.insert(VarId(0), Value::ThunkRef(b));
+        env_a.insert(VarId(1), Value::ThunkRef(c));
+        let a = heap.alloc(env_a, empty_expr());
+        
+        let table = trace(&[a], &heap);
+        assert_eq!(table.len(), 4);
+        assert!(table.contains(a));
+        assert!(table.contains(b));
+        assert!(table.contains(c));
+        assert!(table.contains(d));
+        
+        // Check that D is only assigned one new ID (implicit in ForwardingTable structure)
+    }
+
+    #[test]
+    fn test_blackhole_traced() {
+        let mut heap = ArenaHeap::new();
+        let root = heap.alloc(Env::new(), empty_expr());
+        heap.write(root, ThunkState::BlackHole);
+        
+        let table = trace(&[root], &heap);
+        assert_eq!(table.len(), 1);
+        assert!(table.contains(root));
+    }
+
+    #[test]
+    fn test_cycle() {
+        let mut heap = ArenaHeap::new();
+        
+        // Allocate placeholders
+        let a = heap.alloc(Env::new(), empty_expr());
+        let b = heap.alloc(Env::new(), empty_expr());
+        
+        // A -> B
+        let mut env_a = Env::new();
+        env_a.insert(VarId(0), Value::ThunkRef(b));
+        heap.write(a, ThunkState::Unevaluated(env_a, empty_expr()));
+        
+        // B -> A
+        let mut env_b = Env::new();
+        env_b.insert(VarId(0), Value::ThunkRef(a));
+        heap.write(b, ThunkState::Unevaluated(env_b, empty_expr()));
+        
+        let table = trace(&[a], &heap);
+        assert_eq!(table.len(), 2);
+        assert!(table.contains(a));
+        assert!(table.contains(b));
+    }
+
+    #[test]
+    fn test_evaluated_con_refs() {
+        let mut heap = ArenaHeap::new();
+        
+        let child = heap.alloc(Env::new(), empty_expr());
+        let con_val = Value::Con(DataConId(1), vec![Value::ThunkRef(child)]);
+        let root = heap.alloc(Env::new(), empty_expr());
+        heap.write(root, ThunkState::Evaluated(con_val));
+        
+        let table = trace(&[root], &heap);
+        assert_eq!(table.len(), 2);
+        assert!(table.contains(root));
+        assert!(table.contains(child));
+    }
+}

--- a/core-heap/src/gc/trace.rs
+++ b/core-heap/src/gc/trace.rs
@@ -206,4 +206,40 @@ mod tests {
         assert!(table.contains(root));
         assert!(table.contains(child));
     }
+
+    #[test]
+    fn test_evaluated_closure_refs() {
+        let mut heap = ArenaHeap::new();
+        
+        let child = heap.alloc(Env::new(), empty_expr());
+        let mut env = Env::new();
+        env.insert(VarId(0), Value::ThunkRef(child));
+        
+        let closure_val = Value::Closure(env, VarId(1), empty_expr());
+        let root = heap.alloc(Env::new(), empty_expr());
+        heap.write(root, ThunkState::Evaluated(closure_val));
+        
+        let table = trace(&[root], &heap);
+        assert_eq!(table.len(), 2);
+        assert!(table.contains(root));
+        assert!(table.contains(child));
+    }
+
+    #[test]
+    fn test_evaluated_joincont_refs() {
+        let mut heap = ArenaHeap::new();
+        
+        let child = heap.alloc(Env::new(), empty_expr());
+        let mut env = Env::new();
+        env.insert(VarId(0), Value::ThunkRef(child));
+        
+        let join_val = Value::JoinCont(vec![VarId(1)], empty_expr(), env);
+        let root = heap.alloc(Env::new(), empty_expr());
+        heap.write(root, ThunkState::Evaluated(join_val));
+        
+        let table = trace(&[root], &heap);
+        assert_eq!(table.len(), 2);
+        assert!(table.contains(root));
+        assert!(table.contains(child));
+    }
 }

--- a/core-heap/src/lib.rs
+++ b/core-heap/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod layout;
 pub mod arena;
+pub mod gc;
 
 pub use layout::*;
 pub use arena::*;


### PR DESCRIPTION
Implemented root enumeration and transitive marking for the copying GC in core-heap.

This pure implementation correctly identifies all reachable thunks from a set of roots, handling:
- Cycles
- Shared objects (diamond patterns)
- BlackHole state (GC-visible)
- Transitive trace through environments and constructor fields

Added `children_of` and `collect_thunk_refs` to `ArenaHeap` to support the trace process.
Comprehensive unit tests verify the correctness of the `ForwardingTable` and transitive closure computation.

All `core-heap` tests pass and clippy is clean.