### PR TITLE
feat(core-bridge-derive): implement #[derive(FromCore, ToCore)] for enums

### DIFF
--- a/core-bridge-derive/Cargo.toml
+++ b/core-bridge-derive/Cargo.toml
@@ -15,3 +15,4 @@ proc-macro2 = "1"
 core-bridge = { path = "../core-bridge" }
 core-repr = { path = "../core-repr" }
 core-eval = { path = "../core-eval" }
+core-testing = { path = "../core-testing" }

--- a/core-bridge-derive/src/codegen.rs
+++ b/core-bridge-derive/src/codegen.rs
@@ -1,0 +1,124 @@
+use crate::parse::EnumInfo;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse_quote;
+
+pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
+    let name = &info.name;
+    let trait_path: syn::Path = parse_quote!(core_bridge::FromCore);
+    let mut generics = info.generics.clone();
+
+    // Add trait bounds
+    for param in &mut generics.params {
+        if let syn::GenericParam::Type(type_param) = param {
+            type_param.bounds.push(parse_quote!(#trait_path));
+        }
+    }
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut match_arms = Vec::new();
+
+    for variant in &info.variants {
+        let rust_name = &variant.rust_name;
+        let core_name = &variant.core_name;
+        let arity = variant.fields.len();
+
+        let field_conversions = (0..arity).map(|i| {
+            let ty = &variant.fields[i];
+            quote! {
+                <#ty as core_bridge::FromCore>::from_value(&fields[#i], table)?
+            }
+        });
+
+        let construction = if arity == 0 {
+            quote! { #name::#rust_name }
+        } else {
+            quote! { #name::#rust_name(#(#field_conversions),*) }
+        };
+
+        match_arms.push(quote! {
+            let variant_id = table.get_by_name(#core_name)
+                .ok_or_else(|| core_bridge::BridgeError::UnknownDataConName(#core_name.to_string()))?;
+            if *id == variant_id {
+                if fields.len() != #arity {
+                    return Err(core_bridge::BridgeError::ArityMismatch {
+                        con: *id,
+                        expected: #arity,
+                        got: fields.len(),
+                    });
+                }
+                return Ok(#construction);
+            }
+        });
+    }
+
+    quote! {
+        impl #impl_generics core_bridge::FromCore for #name #ty_generics #where_clause {
+            fn from_value(value: &core_eval::Value, table: &core_repr::DataConTable) -> Result<Self, core_bridge::BridgeError> {
+                match value {
+                    core_eval::Value::Con(id, fields) => {
+                        #(#match_arms)*
+                        Err(core_bridge::BridgeError::UnknownDataCon(*id))
+                    }
+                    _ => Err(core_bridge::BridgeError::TypeMismatch {
+                        expected: "Con".to_string(),
+                        got: format!("{:?}", value),
+                    })
+                }
+            }
+        }
+    }
+}
+
+pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
+    let name = &info.name;
+    let trait_path: syn::Path = parse_quote!(core_bridge::ToCore);
+    let mut generics = info.generics.clone();
+
+    // Add trait bounds
+    for param in &mut generics.params {
+        if let syn::GenericParam::Type(type_param) = param {
+            type_param.bounds.push(parse_quote!(#trait_path));
+        }
+    }
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut match_arms = Vec::new();
+
+    for variant in &info.variants {
+        let rust_name = &variant.rust_name;
+        let core_name = &variant.core_name;
+        let arity = variant.fields.len();
+
+        let field_names: Vec<_> = (0..arity).map(|i| quote::format_ident!("f{}", i)).collect();
+        let pattern = if arity == 0 {
+            quote! { #name::#rust_name }
+        } else {
+            quote! { #name::#rust_name(#(#field_names),*) }
+        };
+
+        let field_to_values = field_names.iter().map(|f| {
+            quote! { core_bridge::ToCore::to_value(#f, table)? }
+        });
+
+        match_arms.push(quote! {
+            #pattern => {
+                let id = table.get_by_name(#core_name)
+                    .ok_or_else(|| core_bridge::BridgeError::UnknownDataConName(#core_name.to_string()))?;
+                Ok(core_eval::Value::Con(id, vec![#(#field_to_values),*]))
+            }
+        });
+    }
+
+    quote! {
+        impl #impl_generics core_bridge::ToCore for #name #ty_generics #where_clause {
+            fn to_value(&self, table: &core_repr::DataConTable) -> Result<core_eval::Value, core_bridge::BridgeError> {
+                match self {
+                    #(#match_arms)*
+                }
+            }
+        }
+    }
+}

--- a/core-bridge-derive/src/codegen.rs
+++ b/core-bridge-derive/src/codegen.rs
@@ -1,17 +1,66 @@
 use crate::parse::EnumInfo;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::parse_quote;
+use syn::{parse_quote, Type};
+use std::collections::HashSet;
+
+fn collect_type_params(ty: &Type, params: &HashSet<syn::Ident>, used: &mut HashSet<syn::Ident>) {
+    match ty {
+        Type::Path(tp) => {
+            if tp.qself.is_none() {
+                // If it's PhantomData<T>, we DON'T consider T "used" for the purpose
+                // of adding FromCore/ToCore bounds, because our PhantomData impl
+                // doesn't require T to be FromCore/ToCore.
+                if tp.path.segments.last().map_or(false, |s| s.ident == "PhantomData") {
+                    return;
+                }
+                if let Some(ident) = tp.path.get_ident() {
+                    if params.contains(ident) {
+                        used.insert(ident.clone());
+                    }
+                }
+                for segment in &tp.path.segments {
+                    if let syn::PathArguments::AngleBracketed(ab) = &segment.arguments {
+                        for arg in &ab.args {
+                            if let syn::GenericArgument::Type(inner_ty) = arg {
+                                collect_type_params(inner_ty, params, used);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Type::Tuple(tt) => {
+            for elem in &tt.elems {
+                collect_type_params(elem, params, used);
+            }
+        }
+        Type::Array(ta) => {
+            collect_type_params(&ta.elem, params, used);
+        }
+        _ => {}
+    }
+}
 
 pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
     let name = &info.name;
     let trait_path: syn::Path = parse_quote!(core_bridge::FromCore);
     let mut generics = info.generics.clone();
 
-    // Add trait bounds
+    let all_params: HashSet<_> = info.generics.type_params().map(|p| p.ident.clone()).collect();
+    let mut used_params = HashSet::new();
+    for variant in &info.variants {
+        for field_ty in &variant.fields {
+            collect_type_params(field_ty, &all_params, &mut used_params);
+        }
+    }
+
+    // Add trait bounds only for used type parameters
     for param in &mut generics.params {
         if let syn::GenericParam::Type(type_param) = param {
-            type_param.bounds.push(parse_quote!(#trait_path));
+            if used_params.contains(&type_param.ident) {
+                type_param.bounds.push(parse_quote!(#trait_path));
+            }
         }
     }
 
@@ -63,7 +112,13 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
                     }
                     _ => Err(core_bridge::BridgeError::TypeMismatch {
                         expected: "Con".to_string(),
-                        got: format!("{:?}", value),
+                        got: match value {
+                            core_eval::Value::Lit(l) => format!("Lit({:?})", l),
+                            core_eval::Value::Con(id, _) => format!("Con({:?})", id),
+                            core_eval::Value::Closure(_, _, _) => "Closure".to_string(),
+                            core_eval::Value::ThunkRef(id) => format!("ThunkRef({:?})", id),
+                            core_eval::Value::JoinCont(_, _, _) => "JoinCont".to_string(),
+                        },
                     })
                 }
             }
@@ -76,10 +131,20 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
     let trait_path: syn::Path = parse_quote!(core_bridge::ToCore);
     let mut generics = info.generics.clone();
 
-    // Add trait bounds
+    let all_params: HashSet<_> = info.generics.type_params().map(|p| p.ident.clone()).collect();
+    let mut used_params = HashSet::new();
+    for variant in &info.variants {
+        for field_ty in &variant.fields {
+            collect_type_params(field_ty, &all_params, &mut used_params);
+        }
+    }
+
+    // Add trait bounds only for used type parameters
     for param in &mut generics.params {
         if let syn::GenericParam::Type(type_param) = param {
-            type_param.bounds.push(parse_quote!(#trait_path));
+            if used_params.contains(&type_param.ident) {
+                type_param.bounds.push(parse_quote!(#trait_path));
+            }
         }
     }
 

--- a/core-bridge-derive/src/lib.rs
+++ b/core-bridge-derive/src/lib.rs
@@ -1,1 +1,25 @@
 extern crate proc_macro;
+
+mod codegen;
+mod parse;
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(FromCore, attributes(core))]
+pub fn derive_from_core(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match parse::parse_enum(&input) {
+        Ok(info) => codegen::generate_from_core(&info).into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_derive(ToCore, attributes(core))]
+pub fn derive_to_core(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match parse::parse_enum(&input) {
+        Ok(info) => codegen::generate_to_core(&info).into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}

--- a/core-bridge-derive/src/parse.rs
+++ b/core-bridge-derive/src/parse.rs
@@ -1,0 +1,82 @@
+use syn::{Attribute, Data, DeriveInput, Fields, Generics, Ident, Lit, Type};
+
+pub struct EnumInfo {
+    pub name: Ident,
+    pub generics: Generics,
+    pub variants: Vec<VariantInfo>,
+}
+
+pub struct VariantInfo {
+    pub rust_name: Ident,
+    pub core_name: String,
+    pub fields: Vec<Type>,
+}
+
+pub fn parse_enum(input: &DeriveInput) -> Result<EnumInfo, syn::Error> {
+    let data_enum = match &input.data {
+        Data::Enum(e) => e,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Only enums are supported for #[derive(FromCore, ToCore)]",
+            ))
+        }
+    };
+
+    let mut variants = Vec::new();
+    for variant in &data_enum.variants {
+        let rust_name = variant.ident.clone();
+        let core_name = get_core_name(&variant.attrs)?;
+
+        let fields = match &variant.fields {
+            Fields::Unnamed(f) => f.unnamed.iter().map(|field| field.ty.clone()).collect(),
+            Fields::Unit => Vec::new(),
+            Fields::Named(_) => {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "Named fields are not supported in variants",
+                ))
+            }
+        };
+
+        let core_name_str = core_name.unwrap_or_else(|| rust_name.to_string());
+
+        variants.push(VariantInfo {
+            rust_name,
+            core_name: core_name_str,
+            fields,
+        });
+    }
+
+    Ok(EnumInfo {
+        name: input.ident.clone(),
+        generics: input.generics.clone(),
+        variants,
+    })
+}
+
+fn get_core_name(attrs: &[Attribute]) -> Result<Option<String>, syn::Error> {
+    for attr in attrs {
+        if attr.path().is_ident("core") {
+            let mut core_name = None;
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("name") {
+                    let value = meta.value()?;
+                    let lit: Lit = value.parse()?;
+                    if let Lit::Str(s) = lit {
+                        core_name = Some(s.value());
+                        Ok(())
+                    } else {
+                        Err(meta.error("expected string literal for 'name'"))
+                    }
+                } else {
+                    Err(meta.error("unknown core attribute"))
+                }
+            })?;
+            if core_name.is_some() {
+                return Ok(core_name);
+            }
+        }
+    }
+    Ok(None)
+}

--- a/core-bridge-derive/src/parse.rs
+++ b/core-bridge-derive/src/parse.rs
@@ -18,7 +18,7 @@ pub fn parse_enum(input: &DeriveInput) -> Result<EnumInfo, syn::Error> {
         _ => {
             return Err(syn::Error::new_spanned(
                 input,
-                "Only enums are supported for #[derive(FromCore, ToCore)]",
+                "Only enums are supported",
             ))
         }
     };

--- a/core-bridge-derive/tests/derive_tests.rs
+++ b/core-bridge-derive/tests/derive_tests.rs
@@ -2,6 +2,7 @@ use core_bridge::{BridgeError, FromCore, ToCore};
 use core_bridge_derive::{FromCore, ToCore};
 use core_eval::Value;
 use core_repr::{DataCon, DataConId, DataConTable};
+use core_testing::gen::datacon_table::standard_datacon_table;
 
 #[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
 enum MyBool {
@@ -26,37 +27,16 @@ enum MultiField {
 }
 
 fn test_table() -> DataConTable {
-    let mut t = DataConTable::new();
-    t.insert(DataCon {
-        id: DataConId(0),
-        name: "True".into(),
-        tag: 1,
-        rep_arity: 0,
-        field_bangs: vec![],
-    });
-    t.insert(DataCon {
-        id: DataConId(1),
-        name: "False".into(),
-        tag: 2,
-        rep_arity: 0,
-        field_bangs: vec![],
-    });
-    t.insert(DataCon {
-        id: DataConId(2),
-        name: "Nothing".into(),
-        tag: 1,
-        rep_arity: 0,
-        field_bangs: vec![],
-    });
-    t.insert(DataCon {
-        id: DataConId(3),
-        name: "Just".into(),
-        tag: 2,
-        rep_arity: 1,
-        field_bangs: vec![],
-    });
+    let mut t = standard_datacon_table();
     t.insert(DataCon {
         id: DataConId(4),
+        name: "()".into(),
+        tag: 1,
+        rep_arity: 0,
+        field_bangs: vec![],
+    });
+    t.insert(DataCon {
+        id: DataConId(10),
         name: "Triple".into(),
         tag: 1,
         rep_arity: 3,
@@ -116,17 +96,59 @@ fn test_unknown_variant() {
     let table = test_table();
     let value = Value::Con(DataConId(100), vec![]);
     let res = MyBool::from_value(&value, &table);
-    assert!(matches!(
-        res,
-        Err(BridgeError::UnknownDataCon(DataConId(100)))
-    ));
+    assert!(matches!(res, Err(BridgeError::UnknownDataCon(DataConId(100)))));
 }
 
-#[test]
-fn test_arity_mismatch() {
-    let table = test_table();
-    let true_id = table.get_by_name("True").unwrap();
-    let value = Value::Con(true_id, vec![Value::Lit(core_repr::Literal::LitInt(1))]);
-    let res = MyBool::from_value(&value, &table);
-    assert!(matches!(res, Err(BridgeError::ArityMismatch { .. })));
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+
+enum UnusedParam<T> {
+
+    #[core(name = "True")]
+
+    Constant(std::marker::PhantomData<T>),
+
 }
+
+
+
+#[test]
+
+fn test_unused_param_derive() {
+
+    let table = test_table();
+
+    // This should compile even if T doesn't implement FromCore/ToCore
+
+    #[derive(Debug, PartialEq, Eq)]
+
+    struct NotBridgeable;
+
+    let val: UnusedParam<NotBridgeable> = UnusedParam::Constant(std::marker::PhantomData);
+
+    let value = val.to_value(&table).unwrap();
+
+    let back = UnusedParam::<NotBridgeable>::from_value(&value, &table).unwrap();
+
+    assert_eq!(val, back);
+
+}
+
+
+
+#[test]
+
+fn test_arity_mismatch() {
+
+    let table = test_table();
+
+    let true_id = table.get_by_name("True").unwrap();
+
+    let value = Value::Con(true_id, vec![Value::Lit(core_repr::Literal::LitInt(1))]);
+
+    let res = MyBool::from_value(&value, &table);
+
+    assert!(matches!(res, Err(BridgeError::ArityMismatch { .. })));
+
+}
+
+

--- a/core-bridge-derive/tests/derive_tests.rs
+++ b/core-bridge-derive/tests/derive_tests.rs
@@ -1,0 +1,132 @@
+use core_bridge::{BridgeError, FromCore, ToCore};
+use core_bridge_derive::{FromCore, ToCore};
+use core_eval::Value;
+use core_repr::{DataCon, DataConId, DataConTable};
+
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+enum MyBool {
+    #[core(name = "True")]
+    MyTrue,
+    #[core(name = "False")]
+    MyFalse,
+}
+
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+enum MyMaybe<T> {
+    #[core(name = "Nothing")]
+    MyNothing,
+    #[core(name = "Just")]
+    MyJust(T),
+}
+
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+enum MultiField {
+    #[core(name = "Triple")]
+    Triple(i64, bool, String),
+}
+
+fn test_table() -> DataConTable {
+    let mut t = DataConTable::new();
+    t.insert(DataCon {
+        id: DataConId(0),
+        name: "True".into(),
+        tag: 1,
+        rep_arity: 0,
+        field_bangs: vec![],
+    });
+    t.insert(DataCon {
+        id: DataConId(1),
+        name: "False".into(),
+        tag: 2,
+        rep_arity: 0,
+        field_bangs: vec![],
+    });
+    t.insert(DataCon {
+        id: DataConId(2),
+        name: "Nothing".into(),
+        tag: 1,
+        rep_arity: 0,
+        field_bangs: vec![],
+    });
+    t.insert(DataCon {
+        id: DataConId(3),
+        name: "Just".into(),
+        tag: 2,
+        rep_arity: 1,
+        field_bangs: vec![],
+    });
+    t.insert(DataCon {
+        id: DataConId(4),
+        name: "Triple".into(),
+        tag: 1,
+        rep_arity: 3,
+        field_bangs: vec![],
+    });
+    t
+}
+
+#[test]
+fn test_bool_derive() {
+    let table = test_table();
+    let val = MyBool::MyTrue;
+    let value = val.to_value(&table).unwrap();
+    let back = MyBool::from_value(&value, &table).unwrap();
+    assert_eq!(val, back);
+
+    let val = MyBool::MyFalse;
+    let value = val.to_value(&table).unwrap();
+    let back = MyBool::from_value(&value, &table).unwrap();
+    assert_eq!(val, back);
+}
+
+#[test]
+fn test_maybe_derive() {
+    let table = test_table();
+    let val: MyMaybe<i64> = MyMaybe::MyJust(42);
+    let value = val.to_value(&table).unwrap();
+    let back = MyMaybe::<i64>::from_value(&value, &table).unwrap();
+    assert_eq!(val, back);
+
+    let val: MyMaybe<i64> = MyMaybe::MyNothing;
+    let value = val.to_value(&table).unwrap();
+    let back = MyMaybe::<i64>::from_value(&value, &table).unwrap();
+    assert_eq!(val, back);
+}
+
+#[test]
+fn test_multi_field_derive() {
+    let table = test_table();
+    let val = MultiField::Triple(42, true, "hello".into());
+    let value = val.to_value(&table).unwrap();
+    let back = MultiField::from_value(&value, &table).unwrap();
+    assert_eq!(val, back);
+}
+
+#[test]
+fn test_generic_derive() {
+    let table = test_table();
+    let val: MyMaybe<MyMaybe<i64>> = MyMaybe::MyJust(MyMaybe::MyJust(42));
+    let value = val.to_value(&table).unwrap();
+    let back = MyMaybe::<MyMaybe<i64>>::from_value(&value, &table).unwrap();
+    assert_eq!(val, back);
+}
+
+#[test]
+fn test_unknown_variant() {
+    let table = test_table();
+    let value = Value::Con(DataConId(100), vec![]);
+    let res = MyBool::from_value(&value, &table);
+    assert!(matches!(
+        res,
+        Err(BridgeError::UnknownDataCon(DataConId(100)))
+    ));
+}
+
+#[test]
+fn test_arity_mismatch() {
+    let table = test_table();
+    let true_id = table.get_by_name("True").unwrap();
+    let value = Value::Con(true_id, vec![Value::Lit(core_repr::Literal::LitInt(1))]);
+    let res = MyBool::from_value(&value, &table);
+    assert!(matches!(res, Err(BridgeError::ArityMismatch { .. })));
+}

--- a/core-bridge/src/impls.rs
+++ b/core-bridge/src/impls.rs
@@ -18,6 +18,35 @@ fn type_mismatch(expected: &str, got: &Value) -> BridgeError {
     }
 }
 
+impl<T> FromCore for std::marker::PhantomData<T> {
+    fn from_value(value: &Value, _table: &DataConTable) -> Result<Self, BridgeError> {
+        match value {
+            Value::Con(_, fields) if fields.is_empty() => Ok(std::marker::PhantomData),
+            Value::Con(id, fields) => Err(BridgeError::ArityMismatch {
+                con: *id,
+                expected: 0,
+                got: fields.len(),
+            }),
+            _ => Err(type_mismatch("Con", value)),
+        }
+    }
+}
+
+impl<T> ToCore for std::marker::PhantomData<T> {
+    fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        // We use a dummy id since PhantomData has no representation in Core
+        // but we need some Con to represent it if it's a field.
+        // Actually, in Tidepool/Haskell, PhantomData fields shouldn't exist in Core.
+        // But for the bridge to work with derived enums, we need an impl.
+        // Let's use a unit tuple id if available, or just any unit-like.
+        let id = table
+            .get_by_name("()")
+            .or_else(|| table.iter().find(|dc| dc.rep_arity == 0).map(|dc| dc.id))
+            .ok_or_else(|| BridgeError::UnknownDataConName("()".into()))?;
+        Ok(Value::Con(id, vec![]))
+    }
+}
+
 // Primitives
 
 /// Bridges Rust `i64` to Haskell `Int#` literal.


### PR DESCRIPTION
Implement proc-macro derive for FromCore and ToCore traits in the core-bridge-derive crate. Supports unit, single-field, and multi-field enum variants, as well as generic enums. Uses #[core(name = "...")] attributes to map Rust variants to Haskell DataCons.