### PR TITLE
feat(tidepool-macro): implement haskell_eval! proc-macro

### DIFF
--- a/tidepool-macro/src/expand.rs
+++ b/tidepool-macro/src/expand.rs
@@ -1,0 +1,25 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::LitStr;
+
+/// Expands the `haskell_eval!` macro.
+///
+/// Input must be a string literal representing the path to a CBOR-serialized Core expression.
+pub fn expand(input: TokenStream) -> TokenStream {
+    let path_lit = match syn::parse2::<LitStr>(input) {
+        Ok(lit) => lit,
+        Err(err) => return err.to_compile_error(),
+    };
+    let path = path_lit.value();
+
+    quote! {
+        {
+            static __CBOR: &[u8] = include_bytes!(#path);
+            let __expr = core_repr::serial::read::read_cbor(__CBOR)
+                .expect("failed to deserialize CBOR — re-run extraction (cargo xtask extract)");
+            let mut __heap = core_eval::heap::VecHeap::new();
+            let __env = core_eval::env::Env::new();
+            core_eval::eval::eval(&__expr, &__env, &mut __heap)
+        }
+    }
+}

--- a/tidepool-macro/src/expand.rs
+++ b/tidepool-macro/src/expand.rs
@@ -10,11 +10,10 @@ pub fn expand(input: TokenStream) -> TokenStream {
         Ok(lit) => lit,
         Err(err) => return err.to_compile_error(),
     };
-    let path = path_lit.value();
 
     quote! {
         {
-            static __CBOR: &[u8] = include_bytes!(#path);
+            static __CBOR: &[u8] = include_bytes!(#path_lit);
             let __expr = core_repr::serial::read::read_cbor(__CBOR)
                 .expect("failed to deserialize CBOR — re-run extraction (cargo xtask extract)");
             let mut __heap = core_eval::heap::VecHeap::new();

--- a/tidepool-macro/src/lib.rs
+++ b/tidepool-macro/src/lib.rs
@@ -1,1 +1,24 @@
 extern crate proc_macro;
+use proc_macro::TokenStream;
+
+mod expand;
+
+/// Embeds and evaluates a CBOR-serialized Haskell Core expression at runtime.
+///
+/// This macro embeds the contents of the file at the provided path (relative to the
+/// calling file) using `include_bytes!`. At runtime, it deserializes the CBOR
+/// data into a `CoreExpr` and evaluates it using the tree-walking interpreter.
+///
+/// # Returns
+///
+/// Returns a `Result<core_eval::Value, core_eval::error::EvalError>`.
+///
+/// # Example
+///
+/// ```ignore
+/// let val = haskell_eval!("../../haskell/test/Identity_cbor/identity.cbor").unwrap();
+/// ```
+#[proc_macro]
+pub fn haskell_eval(input: TokenStream) -> TokenStream {
+    expand::expand(input.into()).into()
+}

--- a/tidepool-macro/src/lib.rs
+++ b/tidepool-macro/src/lib.rs
@@ -9,6 +9,24 @@ mod expand;
 /// calling file) using `include_bytes!`. At runtime, it deserializes the CBOR
 /// data into a `CoreExpr` and evaluates it using the tree-walking interpreter.
 ///
+/// The expanded expression evaluates to a `Result<core_eval::Value, core_eval::error::EvalError>`.
+/// Evaluation errors are reported via this `Result`.
+///
+/// # Panics
+///
+/// The generated code will panic during CBOR deserialization if the embedded data
+/// is malformed, incompatible with the expected format, or otherwise cannot be
+/// decoded into a `CoreExpr`. Such failures typically indicate a build-system
+/// synchronization issue (e.g. stale CBOR blobs).
+///
+/// # Dependencies
+///
+/// The expansion of this macro expects the following crates to be available in the
+/// caller's scope:
+///
+/// - `core_repr`
+/// - `core_eval`
+///
 /// # Returns
 ///
 /// Returns a `Result<core_eval::Value, core_eval::error::EvalError>`.

--- a/tidepool-macro/tests/basic.rs
+++ b/tidepool-macro/tests/basic.rs
@@ -4,7 +4,7 @@ use core_eval::Value;
 #[test]
 fn test_haskell_eval_identity() {
     let res = haskell_eval!("../../haskell/test/Identity_cbor/identity.cbor");
-    assert!(res.is_ok(), "Evaluation failed: {:?}", res.err());
+    assert!(res.is_ok(), "Evaluation failed: {:?}", res.as_ref().err());
     let val = res.unwrap();
     // identity = \x -> x. In core-eval, Value::Closure is returned for lambdas.
     assert!(matches!(val, Value::Closure(_, _, _)));
@@ -13,7 +13,7 @@ fn test_haskell_eval_identity() {
 #[test]
 fn test_haskell_eval_apply() {
     let res = haskell_eval!("../../haskell/test/Identity_cbor/apply.cbor");
-    assert!(res.is_ok(), "Evaluation failed: {:?}", res.err());
+    assert!(res.is_ok(), "Evaluation failed: {:?}", res.as_ref().err());
     let val = res.unwrap();
     assert!(matches!(val, Value::Closure(_, _, _)));
 }
@@ -21,7 +21,14 @@ fn test_haskell_eval_apply() {
 #[test]
 fn test_haskell_eval_const_prime() {
     let res = haskell_eval!("../../haskell/test/Identity_cbor/const'.cbor");
-    assert!(res.is_ok(), "Evaluation failed: {:?}", res.err());
+    assert!(res.is_ok(), "Evaluation failed: {:?}", res.as_ref().err());
     let val = res.unwrap();
     assert!(matches!(val, Value::Closure(_, _, _)));
+}
+
+#[test]
+#[should_panic(expected = "failed to deserialize CBOR")]
+fn test_haskell_eval_invalid_cbor() {
+    // This should panic because the file is empty/invalid CBOR
+    let _ = haskell_eval!("../../haskell/test/invalid.cbor");
 }

--- a/tidepool-macro/tests/basic.rs
+++ b/tidepool-macro/tests/basic.rs
@@ -1,0 +1,27 @@
+use tidepool_macro::haskell_eval;
+use core_eval::Value;
+
+#[test]
+fn test_haskell_eval_identity() {
+    let res = haskell_eval!("../../haskell/test/Identity_cbor/identity.cbor");
+    assert!(res.is_ok(), "Evaluation failed: {:?}", res.err());
+    let val = res.unwrap();
+    // identity = \x -> x. In core-eval, Value::Closure is returned for lambdas.
+    assert!(matches!(val, Value::Closure(_, _, _)));
+}
+
+#[test]
+fn test_haskell_eval_apply() {
+    let res = haskell_eval!("../../haskell/test/Identity_cbor/apply.cbor");
+    assert!(res.is_ok(), "Evaluation failed: {:?}", res.err());
+    let val = res.unwrap();
+    assert!(matches!(val, Value::Closure(_, _, _)));
+}
+
+#[test]
+fn test_haskell_eval_const_prime() {
+    let res = haskell_eval!("../../haskell/test/Identity_cbor/const'.cbor");
+    assert!(res.is_ok(), "Evaluation failed: {:?}", res.err());
+    let val = res.unwrap();
+    assert!(matches!(val, Value::Closure(_, _, _)));
+}


### PR DESCRIPTION
Implement haskell_eval! proc-macro for embedding and evaluating CBOR-serialized Haskell Core.