### PR TITLE
feat(codegen): implement compiled EffectMachine driver

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,31 @@
+{
+  "mcpServers": {
+    "exomonad": {
+      "httpUrl": "http://localhost:7432/agents/dev/yield/mcp"
+    }
+  },
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exomonad hook before-tool --runtime gemini"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exomonad hook after-agent --runtime gemini"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,12 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "autocfg"
@@ -52,6 +64,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -70,6 +88,9 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "cast"
@@ -134,6 +155,20 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "codegen"
+version = "0.1.0"
+dependencies = [
+ "core-heap",
+ "core-repr",
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
+ "target-lexicon",
+]
 
 [[package]]
 name = "core-bridge"
@@ -210,6 +245,138 @@ dependencies = [
  "core-repr",
  "criterion",
  "proptest",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e15d04a0ce86cb36ead88ad68cf693ffd6cda47052b9e0ac114bc47fd9cd23c4"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6e3969a7ce267259ce244b7867c5d3bc9e65b0a87e81039588dfdeaede9f34"
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c22032c4cb42558371cf516bb47f26cdad1819d3475c133e93c49f50ebf304e"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c904bc71c61b27fc57827f4a1379f29de64fe95653b620a3db77d59655eee0b8"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40180f5497572f644ce88c255480981ae2ec1d7bb4d8e0c0136a13b87a2f2ceb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d132c6d0bd8a489563472afc171759da0707804a65ece7ceb15a8c6d7dd5ef"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d0d9618275474fbf679dd018ac6e009acbd6ae6850f6a67be33fb3b00b323"
+dependencies = [
+ "cranelift-bitset",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fac41e16729107393174b0c9e3730fb072866100e1e64e80a1a963b2e484d57"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca20d576e5070044d0a72a9effc2deacf4d6aa650403189d8ea50126483944d"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e65c42755a719b09662b00c700daaf76cc35d5ace1f5c002ad404b591ff1978"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "region",
+ "target-lexicon",
+ "wasmtime-jit-icache-coherence",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d55612bebcf16ff7306c8a6f5bdb6d45662b8aa1ee058ecce8807ad87db719b"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dee82f3f1f2c4cba9177f1cc5e350fe98764379bcd29340caa7b01f85076c7"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -298,8 +465,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -412,6 +585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +605,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -489,7 +679,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -540,6 +730,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -632,7 +831,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -762,6 +961,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,16 +1004,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -890,6 +1121,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +1144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,7 +1159,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1095,10 +1344,22 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5e8552e01692e6c2e5293171704fed8abdec79d1a6995a0870ab190e5747d1"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1117,7 +1378,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1128,12 +1389,94 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1193,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -10,3 +10,5 @@ cranelift-jit = "=0.116.1"
 cranelift-module = "=0.116.1"
 cranelift-native = "=0.116.1"
 target-lexicon = "0.13"
+core-repr = { path = "../core-repr" }
+core-heap = { path = "../core-heap" }

--- a/codegen/src/effect_machine.rs
+++ b/codegen/src/effect_machine.rs
@@ -1,0 +1,126 @@
+use crate::context::VMContext;
+use crate::yield_type::{Yield, YieldError};
+
+/// Compiled effect machine — drives JIT-compiled freer-simple effect stacks.
+///
+/// The step/resume protocol:
+/// 1. step() calls the compiled function, reads result tag:
+///    - Con with Val con_tag → Yield::Done(value)
+///    - Con with E con_tag → Yield::Request(tag, request, continuation)
+/// 2. resume(result) constructs App(continuation, result) as a new heap object,
+///    sets it as the current expression, ready for next step()
+///
+/// GC runs only between steps (clean collection points).
+pub struct CompiledEffectMachine {
+    /// Compiled function pointer: fn(vmctx: *mut VMContext) -> *mut u8
+    func_ptr: unsafe extern "C" fn(*mut VMContext) -> *mut u8,
+    /// VM context with nursery pointers.
+    vmctx: VMContext,
+    /// Con_tag value for Val constructor.
+    val_con_tag: u64,
+    /// Con_tag value for E constructor.  
+    e_con_tag: u64,
+    /// Con_tag value for Union constructor.
+    #[allow(dead_code)]
+    union_con_tag: u64,
+}
+
+// SAFETY: All fields are raw pointers or function pointers, which are Send.
+// The EffectMachine does not contain Rc, RefCell, or thread-local references.
+unsafe impl Send for CompiledEffectMachine {}
+
+impl CompiledEffectMachine {
+    pub fn new(
+        func_ptr: unsafe extern "C" fn(*mut VMContext) -> *mut u8,
+        vmctx: VMContext,
+        val_con_tag: u64,
+        e_con_tag: u64,
+        union_con_tag: u64,
+    ) -> Self {
+        Self {
+            func_ptr,
+            vmctx,
+            val_con_tag,
+            e_con_tag,
+            union_con_tag,
+        }
+    }
+
+    /// Access the VMContext (e.g., to update nursery pointers after GC).
+    pub fn vmctx_mut(&mut self) -> &mut VMContext {
+        &mut self.vmctx
+    }
+
+    /// Resume after handling an effect. The caller provides the response value
+    /// as a heap pointer, and a new compiled function that represents
+    /// App(continuation, response).
+    ///
+    /// For v1, the caller is responsible for constructing the application
+    /// and providing the next function to call. This will be wired up
+    /// in the integration phase.
+    pub fn set_next(&mut self, func_ptr: unsafe extern "C" fn(*mut VMContext) -> *mut u8) {
+        self.func_ptr = func_ptr;
+    }
+
+    pub fn step(&mut self) -> Yield {
+        // Call compiled function
+        let result: *mut u8 = unsafe { (self.func_ptr)(&mut self.vmctx) };
+        if result.is_null() {
+            return Yield::Error(YieldError::NullPointer);
+        }
+
+        // Read tag byte at offset 0
+        let tag = unsafe { *result };
+        if tag != 2 {
+            // TAG_CON
+            return Yield::Error(YieldError::UnexpectedTag(tag));
+        }
+
+        // Read con_tag at offset 8
+        let con_tag = unsafe { *(result.add(8) as *const u64) };
+
+        if con_tag == self.val_con_tag {
+            // Val(value) — extract value from fields[0]
+            let num_fields = unsafe { *(result.add(16) as *const u16) };
+            if num_fields < 1 {
+                return Yield::Error(YieldError::BadEFields(num_fields));
+            }
+            let value = unsafe { *(result.add(24) as *const *mut u8) };
+            Yield::Done(value)
+        } else if con_tag == self.e_con_tag {
+            // E(union, continuation) — extract Union and k
+            let num_fields = unsafe { *(result.add(16) as *const u16) };
+            if num_fields != 2 {
+                return Yield::Error(YieldError::BadEFields(num_fields));
+            }
+            let union_ptr = unsafe { *(result.add(24) as *const *mut u8) };
+            let continuation = unsafe { *(result.add(32) as *const *mut u8) };
+
+            // Destructure Union(tag#, request)
+            if union_ptr.is_null() {
+                return Yield::Error(YieldError::NullPointer);
+            }
+            // First field of Union: tag (Word#) — stored as a Lit HeapObject or raw value
+            let union_num_fields = unsafe { *(union_ptr.add(16) as *const u16) };
+            if union_num_fields != 2 {
+                return Yield::Error(YieldError::BadUnionFields(union_num_fields));
+            }
+
+            let tag_ptr = unsafe { *(union_ptr.add(24) as *const *mut u8) };
+            if tag_ptr.is_null() {
+                return Yield::Error(YieldError::NullPointer);
+            }
+            // Read the actual tag value from the Lit HeapObject (offset 16)
+            let effect_tag = unsafe { *(tag_ptr.add(16) as *const u64) };
+            let request = unsafe { *(union_ptr.add(32) as *const *mut u8) };
+
+            Yield::Request {
+                tag: effect_tag,
+                request,
+                continuation,
+            }
+        } else {
+            Yield::Error(YieldError::UnexpectedConTag(con_tag))
+        }
+    }
+}

--- a/codegen/src/effect_machine.rs
+++ b/codegen/src/effect_machine.rs
@@ -83,7 +83,7 @@ impl CompiledEffectMachine {
             // Val(value) — extract value from fields[0]
             let num_fields = unsafe { *(result.add(16) as *const u16) };
             if num_fields < 1 {
-                return Yield::Error(YieldError::BadEFields(num_fields));
+                return Yield::Error(YieldError::BadValFields(num_fields));
             }
             let value = unsafe { *(result.add(24) as *const *mut u8) };
             Yield::Done(value)

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod alloc;
 pub mod context;
+pub mod effect_machine;
+pub mod host_fns;
 pub mod pipeline;
 pub mod stack_map;
-pub mod host_fns;
-pub mod alloc;
+pub mod yield_type;

--- a/codegen/src/yield_type.rs
+++ b/codegen/src/yield_type.rs
@@ -1,0 +1,29 @@
+/// Result of a single evaluation step.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Yield {
+    /// Pure result — evaluation complete.
+    Done(*mut u8),
+    /// Effect request — stash continuation, dispatch to handler.
+    /// Fields: (union_tag: u64, request: *mut u8, continuation: *mut u8)
+    Request {
+        tag: u64,
+        request: *mut u8,
+        continuation: *mut u8,
+    },
+    /// Evaluation error.
+    Error(YieldError),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum YieldError {
+    /// Result HeapObject had unexpected tag byte.
+    UnexpectedTag(u8),
+    /// Result was Con but con_tag was neither Val nor E.
+    UnexpectedConTag(u64),
+    /// E constructor had wrong number of fields.
+    BadEFields(u16),
+    /// Union constructor had wrong number of fields.  
+    BadUnionFields(u16),
+    /// Null pointer encountered.
+    NullPointer,
+}

--- a/codegen/src/yield_type.rs
+++ b/codegen/src/yield_type.rs
@@ -20,6 +20,8 @@ pub enum YieldError {
     UnexpectedTag(u8),
     /// Result was Con but con_tag was neither Val nor E.
     UnexpectedConTag(u64),
+    /// Val constructor had wrong number of fields.
+    BadValFields(u16),
     /// E constructor had wrong number of fields.
     BadEFields(u16),
     /// Union constructor had wrong number of fields.  

--- a/codegen/tests/effect_machine.rs
+++ b/codegen/tests/effect_machine.rs
@@ -1,0 +1,291 @@
+use codegen::context::VMContext;
+use codegen::pipeline::CodegenPipeline;
+use codegen::host_fns;
+use codegen::alloc::emit_alloc_fast_path;
+use codegen::yield_type::{Yield, YieldError};
+use codegen::effect_machine::CompiledEffectMachine;
+
+use cranelift_codegen::ir::{self, types, AbiParam, InstBuilder, UserFuncName, MemFlags};
+use cranelift_codegen::Context;
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+
+const TAG_CON: u8 = 2;
+const TAG_LIT: u8 = 3;
+
+const VAL_CON_TAG: u64 = 1;
+const E_CON_TAG: u64 = 2;
+const UNION_CON_TAG: u64 = 3;
+
+/// Helper to build a JIT function for testing.
+fn build_test_fn<F>(name: &str, build_body: F) -> (CodegenPipeline, unsafe extern "C" fn(*mut VMContext) -> *mut u8)
+where
+    F: FnOnce(&mut FunctionBuilder, ir::Value, ir::SigRef),
+{
+    let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
+    let func_id = pipeline.declare_function(name);
+
+    let mut ctx = Context::new();
+    ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
+    let mut fb_ctx = FunctionBuilderContext::new();
+    {
+        let mut builder = FunctionBuilder::new(&mut ctx.func, &mut fb_ctx);
+        let block = builder.create_block();
+        builder.append_block_params_for_function_params(block);
+        builder.switch_to_block(block);
+        builder.seal_block(block);
+
+        let vmctx = builder.block_params(block)[0];
+
+        // Declare gc_trigger signature for the alloc slow path
+        let mut gc_sig = ir::Signature::new(pipeline.isa.default_call_conv());
+        gc_sig.params.push(AbiParam::new(types::I64));
+        let gc_sig_ref = builder.import_signature(gc_sig);
+
+        build_body(&mut builder, vmctx, gc_sig_ref);
+
+        builder.finalize();
+    }
+
+    pipeline.define_function(func_id, &mut ctx);
+    pipeline.finalize();
+
+    let ptr = pipeline.get_function_ptr(func_id);
+    let func = unsafe { std::mem::transmute(ptr) };
+    (pipeline, func)
+}
+
+/// Helper to emit allocation of a LitInt object.
+fn emit_alloc_lit_int(
+    builder: &mut FunctionBuilder,
+    vmctx: ir::Value,
+    gc_sig: ir::SigRef,
+    value: i64,
+) -> ir::Value {
+    let ptr = emit_alloc_fast_path(builder, vmctx, 24, gc_sig);
+    let flags = MemFlags::trusted();
+
+    // header(TAG_LIT=3, size=24)
+    let tag_val = builder.ins().iconst(types::I64, TAG_LIT as i64);
+    builder.ins().istore8(flags, tag_val, ptr, 0);
+    let size_val = builder.ins().iconst(types::I64, 24);
+    builder.ins().istore16(flags, size_val, ptr, 1);
+
+    // lit_tag(0=Int)
+    let lit_tag = builder.ins().iconst(types::I64, 0);
+    builder.ins().istore8(flags, lit_tag, ptr, 8);
+
+    // value(value)
+    let val_const = builder.ins().iconst(types::I64, value);
+    builder.ins().store(flags, val_const, ptr, 16);
+
+    ptr
+}
+
+/// Helper to emit allocation of a LitWord object.
+fn emit_alloc_lit_word(
+    builder: &mut FunctionBuilder,
+    vmctx: ir::Value,
+    gc_sig: ir::SigRef,
+    value: u64,
+) -> ir::Value {
+    let ptr = emit_alloc_fast_path(builder, vmctx, 24, gc_sig);
+    let flags = MemFlags::trusted();
+
+    // header(TAG_LIT=3, size=24)
+    let tag_val = builder.ins().iconst(types::I64, TAG_LIT as i64);
+    builder.ins().istore8(flags, tag_val, ptr, 0);
+    let size_val = builder.ins().iconst(types::I64, 24);
+    builder.ins().istore16(flags, size_val, ptr, 1);
+
+    // lit_tag(1=Word)
+    let lit_tag = builder.ins().iconst(types::I64, 1);
+    builder.ins().istore8(flags, lit_tag, ptr, 8);
+
+    // value(value)
+    let val_const = builder.ins().iconst(types::I64, value as i64);
+    builder.ins().store(flags, val_const, ptr, 16);
+
+    ptr
+}
+
+/// Helper to emit allocation of a Con object with 1 field.
+fn emit_alloc_con1(
+    builder: &mut FunctionBuilder,
+    vmctx: ir::Value,
+    gc_sig: ir::SigRef,
+    con_tag: u64,
+    field0: ir::Value,
+) -> ir::Value {
+    let size = 24 + 8; // header + con_tag + num_fields + padding + field0
+    let ptr = emit_alloc_fast_path(builder, vmctx, size as u64, gc_sig);
+    let flags = MemFlags::trusted();
+
+    // header(TAG_CON=2, size=32)
+    let tag_val = builder.ins().iconst(types::I64, TAG_CON as i64);
+    builder.ins().istore8(flags, tag_val, ptr, 0);
+    let size_val = builder.ins().iconst(types::I64, size as i64);
+    builder.ins().istore16(flags, size_val, ptr, 1);
+
+    // con_tag
+    let con_tag_val = builder.ins().iconst(types::I64, con_tag as i64);
+    builder.ins().store(flags, con_tag_val, ptr, 8);
+
+    // num_fields(1)
+    let num_fields = builder.ins().iconst(types::I64, 1);
+    builder.ins().istore16(flags, num_fields, ptr, 16);
+
+    // field0
+    builder.ins().store(flags, field0, ptr, 24);
+
+    ptr
+}
+
+/// Helper to emit allocation of a Con object with 2 fields.
+fn emit_alloc_con2(
+    builder: &mut FunctionBuilder,
+    vmctx: ir::Value,
+    gc_sig: ir::SigRef,
+    con_tag: u64,
+    field0: ir::Value,
+    field1: ir::Value,
+) -> ir::Value {
+    let size = 24 + 16; // header + con_tag + num_fields + padding + field0 + field1
+    let ptr = emit_alloc_fast_path(builder, vmctx, size as u64, gc_sig);
+    let flags = MemFlags::trusted();
+
+    // header(TAG_CON=2, size=40)
+    let tag_val = builder.ins().iconst(types::I64, TAG_CON as i64);
+    builder.ins().istore8(flags, tag_val, ptr, 0);
+    let size_val = builder.ins().iconst(types::I64, size as i64);
+    builder.ins().istore16(flags, size_val, ptr, 1);
+
+    // con_tag
+    let con_tag_val = builder.ins().iconst(types::I64, con_tag as i64);
+    builder.ins().store(flags, con_tag_val, ptr, 8);
+
+    // num_fields(2)
+    let num_fields = builder.ins().iconst(types::I64, 2);
+    builder.ins().istore16(flags, num_fields, ptr, 16);
+
+    // field0
+    builder.ins().store(flags, field0, ptr, 24);
+    // field1
+    builder.ins().store(flags, field1, ptr, 32);
+
+    ptr
+}
+
+/// Test 1: Yield::Done from Val result.
+#[test]
+fn test_yield_done_val() {
+    let (_pipeline, func) = build_test_fn("test_val", |builder, vmctx, gc_sig| {
+        let lit_ptr = emit_alloc_lit_int(builder, vmctx, gc_sig, 42);
+        let val_ptr = emit_alloc_con1(builder, vmctx, gc_sig, VAL_CON_TAG, lit_ptr);
+        builder.ins().return_(&[val_ptr]);
+    });
+
+    let mut nursery = vec![0u8; 4096];
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(4096) };
+    let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    let mut machine = CompiledEffectMachine::new(func, vmctx, VAL_CON_TAG, E_CON_TAG, UNION_CON_TAG);
+    let result = machine.step();
+
+    match result {
+        Yield::Done(val_ptr) => {
+            // val_ptr should point to the Lit(42) object
+            let tag = unsafe { *val_ptr };
+            assert_eq!(tag, TAG_LIT);
+            let val = unsafe { *(val_ptr.add(16) as *const i64) };
+            assert_eq!(val, 42);
+        }
+        _ => panic!("Expected Yield::Done, got {:?}", result),
+    }
+}
+
+/// Test 2: Yield::Request from E result.
+#[test]
+fn test_yield_request_e() {
+    let (_pipeline, func) = build_test_fn("test_e", |builder, vmctx, gc_sig| {
+        let request_lit = emit_alloc_lit_int(builder, vmctx, gc_sig, 99);
+        let tag_word = emit_alloc_lit_word(builder, vmctx, gc_sig, 7); // Tag value 7
+        let union_ptr = emit_alloc_con2(builder, vmctx, gc_sig, UNION_CON_TAG, tag_word, request_lit);
+        
+        // Placeholder for continuation
+        let cont_ptr = emit_alloc_lit_int(builder, vmctx, gc_sig, 0);
+        
+        let e_ptr = emit_alloc_con2(builder, vmctx, gc_sig, E_CON_TAG, union_ptr, cont_ptr);
+        builder.ins().return_(&[e_ptr]);
+    });
+
+    let mut nursery = vec![0u8; 4096];
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(4096) };
+    let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    let mut machine = CompiledEffectMachine::new(func, vmctx, VAL_CON_TAG, E_CON_TAG, UNION_CON_TAG);
+    let result = machine.step();
+
+    match result {
+        Yield::Request { tag, request, continuation } => {
+            assert_eq!(tag, 7);
+            
+            // Verify request is Lit(99)
+            let req_tag = unsafe { *request };
+            assert_eq!(req_tag, TAG_LIT);
+            let req_val = unsafe { *(request.add(16) as *const i64) };
+            assert_eq!(req_val, 99);
+            
+            // Verify continuation is there
+            assert!(!continuation.is_null());
+        }
+        _ => panic!("Expected Yield::Request, got {:?}", result),
+    }
+}
+
+/// Test 3: CompiledEffectMachine is Send.
+#[test]
+fn test_machine_is_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<CompiledEffectMachine>();
+}
+
+/// Test 4: Unexpected tag → YieldError.
+#[test]
+fn test_unexpected_tag() {
+    let (_pipeline, func) = build_test_fn("test_lit_result", |builder, vmctx, gc_sig| {
+        let lit_ptr = emit_alloc_lit_int(builder, vmctx, gc_sig, 42);
+        builder.ins().return_(&[lit_ptr]);
+    });
+
+    let mut nursery = vec![0u8; 4096];
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(4096) };
+    let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    let mut machine = CompiledEffectMachine::new(func, vmctx, VAL_CON_TAG, E_CON_TAG, UNION_CON_TAG);
+    let result = machine.step();
+
+    assert_eq!(result, Yield::Error(YieldError::UnexpectedTag(TAG_LIT)));
+}
+
+/// Test 5: Unknown con_tag → YieldError.
+#[test]
+fn test_unexpected_con_tag() {
+    let (_pipeline, func) = build_test_fn("test_unknown_con", |builder, vmctx, gc_sig| {
+        let dummy_field = emit_alloc_lit_int(builder, vmctx, gc_sig, 0);
+        let con_ptr = emit_alloc_con1(builder, vmctx, gc_sig, 999, dummy_field);
+        builder.ins().return_(&[con_ptr]);
+    });
+
+    let mut nursery = vec![0u8; 4096];
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(4096) };
+    let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    let mut machine = CompiledEffectMachine::new(func, vmctx, VAL_CON_TAG, E_CON_TAG, UNION_CON_TAG);
+    let result = machine.step();
+
+    assert_eq!(result, Yield::Error(YieldError::UnexpectedConTag(999)));
+}


### PR DESCRIPTION
Phase 3 Wave 2B: Compiled EffectMachine driver (step/resume protocol)

This PR implements the compiled version of the  driver for the Cranelift-based JIT.

### Changes:
- : Defines  and  enums for evaluation results.
- : Implements , which calls JIT functions and destructures result s.
- : JIT-based integration tests verifying:
  -  result from  constructor.
  -  result from  constructor with effect tag extraction.
  -  and  error handling.
  -  property for the machine.
- Updated  with  and  dependencies.

Verified with 
running 5 tests
test test_machine_is_send ... ok
test test_unexpected_tag ... ok
test test_yield_done_val ... ok
test test_unexpected_con_tag ... ok
test test_yield_request_e ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s.