### PR TITLE
feat(codegen): implement CoreExpr to Cranelift IR emitter

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,31 @@
+{
+  "mcpServers": {
+    "exomonad": {
+      "httpUrl": "http://localhost:7432/agents/dev/expr/mcp"
+    }
+  },
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exomonad hook before-tool --runtime gemini"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exomonad hook after-agent --runtime gemini"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,12 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "autocfg"
@@ -52,6 +64,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -70,6 +88,9 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "cast"
@@ -134,6 +155,20 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "codegen"
+version = "0.1.0"
+dependencies = [
+ "core-heap",
+ "core-repr",
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
+ "target-lexicon",
+]
 
 [[package]]
 name = "core-bridge"
@@ -210,6 +245,138 @@ dependencies = [
  "core-repr",
  "criterion",
  "proptest",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e15d04a0ce86cb36ead88ad68cf693ffd6cda47052b9e0ac114bc47fd9cd23c4"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6e3969a7ce267259ce244b7867c5d3bc9e65b0a87e81039588dfdeaede9f34"
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c22032c4cb42558371cf516bb47f26cdad1819d3475c133e93c49f50ebf304e"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c904bc71c61b27fc57827f4a1379f29de64fe95653b620a3db77d59655eee0b8"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40180f5497572f644ce88c255480981ae2ec1d7bb4d8e0c0136a13b87a2f2ceb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d132c6d0bd8a489563472afc171759da0707804a65ece7ceb15a8c6d7dd5ef"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d0d9618275474fbf679dd018ac6e009acbd6ae6850f6a67be33fb3b00b323"
+dependencies = [
+ "cranelift-bitset",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fac41e16729107393174b0c9e3730fb072866100e1e64e80a1a963b2e484d57"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca20d576e5070044d0a72a9effc2deacf4d6aa650403189d8ea50126483944d"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e65c42755a719b09662b00c700daaf76cc35d5ace1f5c002ad404b591ff1978"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "region",
+ "target-lexicon",
+ "wasmtime-jit-icache-coherence",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d55612bebcf16ff7306c8a6f5bdb6d45662b8aa1ee058ecce8807ad87db719b"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dee82f3f1f2c4cba9177f1cc5e350fe98764379bcd29340caa7b01f85076c7"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -298,8 +465,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -412,6 +585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +605,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -489,7 +679,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -540,6 +730,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -632,7 +831,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -762,6 +961,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,16 +1004,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -890,6 +1121,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +1144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,7 +1159,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1095,10 +1344,22 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5e8552e01692e6c2e5293171704fed8abdec79d1a6995a0870ab190e5747d1"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1117,7 +1378,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1128,12 +1389,94 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1193,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -10,3 +10,5 @@ cranelift-jit = "=0.116.1"
 cranelift-module = "=0.116.1"
 cranelift-native = "=0.116.1"
 target-lexicon = "0.13"
+core-repr = { path = "../core-repr" }
+core-heap = { path = "../core-heap" }

--- a/codegen/src/emit/expr.rs
+++ b/codegen/src/emit/expr.rs
@@ -38,7 +38,7 @@ pub fn compile_expr(
     gc_sig.params.push(AbiParam::new(types::I64));
     let gc_sig_ref = builder.import_signature(gc_sig);
 
-    let mut emit_ctx = EmitContext::new();
+    let mut emit_ctx = EmitContext::new(name.to_string());
     let result = emit_ctx.emit_node(pipeline, &mut builder, vmctx, gc_sig_ref, tree, tree.nodes.len() - 1)?;
     let ret = ensure_heap_ptr(&mut builder, vmctx, gc_sig_ref, result);
 
@@ -162,7 +162,7 @@ impl EmitContext {
                 inner_gc_sig.params.push(AbiParam::new(types::I64));
                 let inner_gc_sig_ref = inner_builder.import_signature(inner_gc_sig);
 
-                let mut inner_emit = EmitContext::new();
+                let mut inner_emit = EmitContext::new(self.prefix.clone());
                 inner_emit.lambda_counter = self.lambda_counter;
 
                 inner_emit.env.insert(*binder, SsaVal::HeapPtr(arg_param));
@@ -302,7 +302,7 @@ impl EmitContext {
                     inner_gc_sig.params.push(AbiParam::new(types::I64));
                     let inner_gc_sig_ref = inner_builder.import_signature(inner_gc_sig);
 
-                    let mut inner_emit = EmitContext::new();
+                    let mut inner_emit = EmitContext::new(self.prefix.clone());
                     inner_emit.lambda_counter = self.lambda_counter;
                     inner_emit.env.insert(lam_binder, SsaVal::HeapPtr(inner_arg));
 
@@ -365,36 +365,43 @@ fn emit_lit(
             builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
             let val = builder.ins().iconst(types::I64, *n);
             builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+            builder.declare_value_needs_stack_map(ptr);
+            Ok(SsaVal::HeapPtr(ptr))
         }
         Literal::LitWord(n) => {
             let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_WORD);
             builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
             let val = builder.ins().iconst(types::I64, *n as i64);
             builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+            builder.declare_value_needs_stack_map(ptr);
+            Ok(SsaVal::HeapPtr(ptr))
         }
         Literal::LitChar(c) => {
             let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_CHAR);
             builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
             let val = builder.ins().iconst(types::I64, *c as i64);
             builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+            builder.declare_value_needs_stack_map(ptr);
+            Ok(SsaVal::HeapPtr(ptr))
         }
         Literal::LitFloat(bits) => {
             let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_FLOAT);
             builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
             let val = builder.ins().iconst(types::I64, *bits as i64);
             builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+            builder.declare_value_needs_stack_map(ptr);
+            Ok(SsaVal::HeapPtr(ptr))
         }
         Literal::LitDouble(bits) => {
             let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_DOUBLE);
             builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
             let val = builder.ins().iconst(types::I64, *bits as i64);
             builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+            builder.declare_value_needs_stack_map(ptr);
+            Ok(SsaVal::HeapPtr(ptr))
         }
-        Literal::LitString(_) => return Err(EmitError::NotYetImplemented("LitString".into())),
+        Literal::LitString(_) => Err(EmitError::NotYetImplemented("LitString".into())),
     }
-
-    builder.declare_value_needs_stack_map(ptr);
-    Ok(SsaVal::HeapPtr(ptr))
 }
 
 fn ensure_heap_ptr(
@@ -405,15 +412,14 @@ fn ensure_heap_ptr(
 ) -> Value {
     match val {
         SsaVal::HeapPtr(v) => v,
-        SsaVal::Raw(v) => {
-            // Box as LitInt
+        SsaVal::Raw(v, lit_tag) => {
             let ptr = emit_alloc_fast_path(builder, vmctx, LIT_TOTAL_SIZE, gc_sig);
             let tag = builder.ins().iconst(types::I8, layout::TAG_LIT as i64);
             builder.ins().store(MemFlags::trusted(), tag, ptr, 0);
             let size = builder.ins().iconst(types::I16, LIT_TOTAL_SIZE as i64);
             builder.ins().store(MemFlags::trusted(), size, ptr, 1);
-            let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_INT);
-            builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
+            let lit_tag_val = builder.ins().iconst(types::I8, lit_tag);
+            builder.ins().store(MemFlags::trusted(), lit_tag_val, ptr, LIT_TAG_OFFSET);
             builder.ins().store(MemFlags::trusted(), v, ptr, LIT_VALUE_OFFSET);
             builder.declare_value_needs_stack_map(ptr);
             ptr

--- a/codegen/src/emit/expr.rs
+++ b/codegen/src/emit/expr.rs
@@ -1,0 +1,422 @@
+use crate::pipeline::CodegenPipeline;
+use crate::alloc::emit_alloc_fast_path;
+use crate::emit::*;
+use core_repr::*;
+use core_heap::layout;
+use cranelift_codegen::ir::{self, types, AbiParam, InstBuilder, MemFlags, Value, Signature, UserFuncName};
+use cranelift_codegen::Context;
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_module::{Module, Linkage, FuncId};
+
+/// Compile a CoreExpr into a JIT function. Returns the FuncId.
+/// The compiled function has signature: (vmctx: i64) -> i64
+/// It returns a heap pointer to the result.
+pub fn compile_expr(
+    pipeline: &mut CodegenPipeline,
+    tree: &CoreExpr,
+    name: &str,
+) -> Result<FuncId, EmitError> {
+    let sig = pipeline.make_func_signature();
+    let func_id = pipeline.module.declare_function(name, Linkage::Export, &sig)
+        .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+
+    let mut ctx = Context::new();
+    ctx.func.signature = sig;
+    ctx.func.name = UserFuncName::default();
+
+    let mut fb_ctx = FunctionBuilderContext::new();
+    let mut builder = FunctionBuilder::new(&mut ctx.func, &mut fb_ctx);
+
+    let entry_block = builder.create_block();
+    builder.append_block_params_for_function_params(entry_block);
+    builder.switch_to_block(entry_block);
+    builder.seal_block(entry_block);
+
+    let vmctx = builder.block_params(entry_block)[0];
+
+    let mut gc_sig = Signature::new(pipeline.isa.default_call_conv());
+    gc_sig.params.push(AbiParam::new(types::I64));
+    let gc_sig_ref = builder.import_signature(gc_sig);
+
+    let mut emit_ctx = EmitContext::new();
+    let result = emit_ctx.emit_node(pipeline, &mut builder, vmctx, gc_sig_ref, tree, tree.nodes.len() - 1)?;
+    let ret = ensure_heap_ptr(&mut builder, vmctx, gc_sig_ref, result);
+
+    builder.ins().return_(&[ret]);
+    builder.finalize();
+
+    pipeline.define_function(func_id, &mut ctx);
+
+    Ok(func_id)
+}
+
+impl EmitContext {
+    pub fn emit_node(
+        &mut self,
+        pipeline: &mut CodegenPipeline,
+        builder: &mut FunctionBuilder,
+        vmctx: Value,
+        gc_sig: ir::SigRef,
+        tree: &CoreExpr,
+        idx: usize,
+    ) -> Result<SsaVal, EmitError> {
+        match &tree.nodes[idx] {
+            CoreFrame::Lit(lit) => emit_lit(builder, vmctx, gc_sig, lit),
+            CoreFrame::Var(vid) => {
+                self.env.get(vid).copied().ok_or(EmitError::UnboundVariable(*vid))
+            }
+            CoreFrame::Con { tag, fields } => {
+                let mut field_vals = Vec::new();
+                for &f_idx in fields {
+                    let val = self.emit_node(pipeline, builder, vmctx, gc_sig, tree, f_idx)?;
+                    field_vals.push(ensure_heap_ptr(builder, vmctx, gc_sig, val));
+                }
+
+                let num_fields = field_vals.len();
+                let size = 24 + 8 * num_fields as u64;
+                let ptr = emit_alloc_fast_path(builder, vmctx, size, gc_sig);
+
+                let tag_val = builder.ins().iconst(types::I8, layout::TAG_CON as i64);
+                builder.ins().store(MemFlags::trusted(), tag_val, ptr, 0);
+                let size_val = builder.ins().iconst(types::I16, size as i64);
+                builder.ins().store(MemFlags::trusted(), size_val, ptr, 1);
+
+                let con_tag_val = builder.ins().iconst(types::I64, tag.0 as i64);
+                builder.ins().store(MemFlags::trusted(), con_tag_val, ptr, CON_TAG_OFFSET);
+                let num_fields_val = builder.ins().iconst(types::I16, num_fields as i64);
+                builder.ins().store(MemFlags::trusted(), num_fields_val, ptr, CON_NUM_FIELDS_OFFSET);
+
+                for (i, field_val) in field_vals.into_iter().enumerate() {
+                    builder.ins().store(MemFlags::trusted(), field_val, ptr, CON_FIELDS_START + 8 * i as i32);
+                }
+
+                builder.declare_value_needs_stack_map(ptr);
+                Ok(SsaVal::HeapPtr(ptr))
+            }
+            CoreFrame::PrimOp { op, args } => {
+                let mut arg_vals = Vec::new();
+                for &a_idx in args {
+                    arg_vals.push(self.emit_node(pipeline, builder, vmctx, gc_sig, tree, a_idx)?);
+                }
+                primop::emit_primop(builder, op, &arg_vals)
+            }
+            CoreFrame::App { fun, arg } => {
+                let fun_val = self.emit_node(pipeline, builder, vmctx, gc_sig, tree, *fun)?;
+                let arg_val = self.emit_node(pipeline, builder, vmctx, gc_sig, tree, *arg)?;
+                let fun_ptr = fun_val.value();
+                let arg_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, arg_val);
+
+                let code_ptr = builder.ins().load(types::I64, MemFlags::trusted(), fun_ptr, CLOSURE_CODE_PTR_OFFSET);
+
+                let mut sig = Signature::new(pipeline.isa.default_call_conv());
+                sig.params.push(AbiParam::new(types::I64)); // vmctx
+                sig.params.push(AbiParam::new(types::I64)); // self
+                sig.params.push(AbiParam::new(types::I64)); // arg
+                sig.returns.push(AbiParam::new(types::I64));
+                let call_sig = builder.import_signature(sig);
+
+                let inst = builder.ins().call_indirect(call_sig, code_ptr, &[vmctx, fun_ptr, arg_ptr]);
+                let ret_val = builder.inst_results(inst)[0];
+                builder.declare_value_needs_stack_map(ret_val);
+                Ok(SsaVal::HeapPtr(ret_val))
+            }
+            CoreFrame::Lam { binder, body } => {
+                let body_tree = tree.extract_subtree(*body);
+                let mut fvs = core_repr::free_vars::free_vars(&body_tree);
+                fvs.remove(binder);
+
+                let mut sorted_fvs: Vec<VarId> = fvs.into_iter().filter(|v| self.env.contains_key(v)).collect();
+                sorted_fvs.sort_by_key(|v| v.0);
+
+                let captures: Vec<(VarId, SsaVal)> = sorted_fvs.iter().map(|v| (*v, self.env[v])).collect();
+
+                let lambda_name = self.next_lambda_name();
+                let mut closure_sig = Signature::new(pipeline.isa.default_call_conv());
+                closure_sig.params.push(AbiParam::new(types::I64)); // vmctx
+                closure_sig.params.push(AbiParam::new(types::I64)); // self
+                closure_sig.params.push(AbiParam::new(types::I64)); // arg
+                closure_sig.returns.push(AbiParam::new(types::I64));
+
+                let lambda_func_id = pipeline.module.declare_function(&lambda_name, Linkage::Local, &closure_sig)
+                    .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+
+                let mut inner_ctx = Context::new();
+                inner_ctx.func.signature = closure_sig;
+                inner_ctx.func.name = UserFuncName::default();
+
+                let mut inner_fb_ctx = FunctionBuilderContext::new();
+                let mut inner_builder = FunctionBuilder::new(&mut inner_ctx.func, &mut inner_fb_ctx);
+                let inner_block = inner_builder.create_block();
+                inner_builder.append_block_params_for_function_params(inner_block);
+                inner_builder.switch_to_block(inner_block);
+                inner_builder.seal_block(inner_block);
+
+                let inner_vmctx = inner_builder.block_params(inner_block)[0];
+                let closure_self = inner_builder.block_params(inner_block)[1];
+                let arg_param = inner_builder.block_params(inner_block)[2];
+
+                inner_builder.declare_value_needs_stack_map(closure_self);
+                inner_builder.declare_value_needs_stack_map(arg_param);
+
+                let mut inner_gc_sig = Signature::new(pipeline.isa.default_call_conv());
+                inner_gc_sig.params.push(AbiParam::new(types::I64));
+                let inner_gc_sig_ref = inner_builder.import_signature(inner_gc_sig);
+
+                let mut inner_emit = EmitContext::new();
+                inner_emit.lambda_counter = self.lambda_counter;
+
+                inner_emit.env.insert(*binder, SsaVal::HeapPtr(arg_param));
+
+                for (i, (var_id, _)) in captures.iter().enumerate() {
+                    let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                    let val = inner_builder.ins().load(types::I64, MemFlags::trusted(), closure_self, offset);
+                    inner_builder.declare_value_needs_stack_map(val);
+                    inner_emit.env.insert(*var_id, SsaVal::HeapPtr(val));
+                }
+
+                let body_root = body_tree.nodes.len() - 1;
+                let body_result = inner_emit.emit_node(pipeline, &mut inner_builder, inner_vmctx, inner_gc_sig_ref, &body_tree, body_root)?;
+                let ret_val = ensure_heap_ptr(&mut inner_builder, inner_vmctx, inner_gc_sig_ref, body_result);
+
+                inner_builder.ins().return_(&[ret_val]);
+                inner_builder.finalize();
+
+                self.lambda_counter = inner_emit.lambda_counter;
+                pipeline.define_function(lambda_func_id, &mut inner_ctx);
+
+                let func_ref = pipeline.module.declare_func_in_func(lambda_func_id, builder.func);
+                let code_ptr = builder.ins().func_addr(types::I64, func_ref);
+
+                let num_captures = captures.len();
+                let closure_size = 24 + 8 * num_captures as u64;
+                let closure_ptr = emit_alloc_fast_path(builder, vmctx, closure_size, gc_sig);
+
+                let tag_val = builder.ins().iconst(types::I8, layout::TAG_CLOSURE as i64);
+                builder.ins().store(MemFlags::trusted(), tag_val, closure_ptr, 0);
+                let size_val = builder.ins().iconst(types::I16, closure_size as i64);
+                builder.ins().store(MemFlags::trusted(), size_val, closure_ptr, 1);
+
+                builder.ins().store(MemFlags::trusted(), code_ptr, closure_ptr, CLOSURE_CODE_PTR_OFFSET);
+                let num_cap_val = builder.ins().iconst(types::I16, num_captures as i64);
+                builder.ins().store(MemFlags::trusted(), num_cap_val, closure_ptr, CLOSURE_NUM_CAPTURED_OFFSET);
+
+                for (i, (_, ssaval)) in captures.iter().enumerate() {
+                    let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, *ssaval);
+                    let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                    builder.ins().store(MemFlags::trusted(), cap_val, closure_ptr, offset);
+                }
+
+                builder.declare_value_needs_stack_map(closure_ptr);
+                Ok(SsaVal::HeapPtr(closure_ptr))
+            }
+            CoreFrame::LetNonRec { binder, rhs, body } => {
+                let rhs_val = self.emit_node(pipeline, builder, vmctx, gc_sig, tree, *rhs)?;
+                self.env.insert(*binder, rhs_val);
+                let body_val = self.emit_node(pipeline, builder, vmctx, gc_sig, tree, *body)?;
+                self.env.remove(binder);
+                Ok(body_val)
+            }
+            CoreFrame::LetRec { bindings, body } => {
+                for (_, rhs_idx) in bindings {
+                    if !matches!(tree.nodes[*rhs_idx], CoreFrame::Lam { .. }) {
+                        return Err(EmitError::NotYetImplemented("LetRec with non-lambda RHS".into()));
+                    }
+                }
+
+                let mut pre_allocs = Vec::new();
+                for (binder, rhs_idx) in bindings {
+                    // This is Lam, we need the body subtree but let's just use it to find captures
+                    let (lam_binder, lam_body) = match &tree.nodes[*rhs_idx] {
+                        CoreFrame::Lam { binder, body } => (*binder, *body),
+                        _ => unreachable!(),
+                    };
+                    let lam_body_tree = tree.extract_subtree(lam_body);
+                    let mut fvs = core_repr::free_vars::free_vars(&lam_body_tree);
+                    fvs.remove(&lam_binder);
+                    
+                    // Captures include other letrec binders + outer env
+                    let mut sorted_fvs: Vec<VarId> = fvs.into_iter().filter(|v| {
+                        self.env.contains_key(v) || bindings.iter().any(|(b, _)| b == v)
+                    }).collect();
+                    sorted_fvs.sort_by_key(|v| v.0);
+                    
+                    let num_captures = sorted_fvs.len();
+                    let closure_size = 24 + 8 * num_captures as u64;
+                    let closure_ptr = emit_alloc_fast_path(builder, vmctx, closure_size, gc_sig);
+                    
+                    let tag_val = builder.ins().iconst(types::I8, layout::TAG_CLOSURE as i64);
+                    builder.ins().store(MemFlags::trusted(), tag_val, closure_ptr, 0);
+                    let size_val = builder.ins().iconst(types::I16, closure_size as i64);
+                    builder.ins().store(MemFlags::trusted(), size_val, closure_ptr, 1);
+                    let num_cap_val = builder.ins().iconst(types::I16, num_captures as i64);
+                    builder.ins().store(MemFlags::trusted(), num_cap_val, closure_ptr, CLOSURE_NUM_CAPTURED_OFFSET);
+                    
+                    builder.declare_value_needs_stack_map(closure_ptr);
+                    pre_allocs.push((*binder, closure_ptr, sorted_fvs, *rhs_idx));
+                }
+
+                // Bind all to their pre-allocated pointers
+                for (binder, ptr, _, _) in &pre_allocs {
+                    self.env.insert(*binder, SsaVal::HeapPtr(*ptr));
+                }
+
+                // Compile bodies and fill closures
+                for (_, closure_ptr, sorted_fvs, rhs_idx) in pre_allocs {
+                    let (lam_binder, lam_body) = match &tree.nodes[rhs_idx] {
+                        CoreFrame::Lam { binder, body } => (*binder, *body),
+                        _ => unreachable!(),
+                    };
+                    let lam_body_tree = tree.extract_subtree(lam_body);
+                    
+                    let captures: Vec<(VarId, SsaVal)> = sorted_fvs.iter().map(|v| (*v, self.env[v])).collect();
+                    
+                    let lambda_name = self.next_lambda_name();
+                    let mut closure_sig = Signature::new(pipeline.isa.default_call_conv());
+                    closure_sig.params.push(AbiParam::new(types::I64));
+                    closure_sig.params.push(AbiParam::new(types::I64));
+                    closure_sig.params.push(AbiParam::new(types::I64));
+                    closure_sig.returns.push(AbiParam::new(types::I64));
+
+                    let lambda_func_id = pipeline.module.declare_function(&lambda_name, Linkage::Local, &closure_sig)
+                        .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+
+                    let mut inner_ctx = Context::new();
+                    inner_ctx.func.signature = closure_sig;
+                    inner_ctx.func.name = UserFuncName::default();
+
+                    let mut inner_fb_ctx = FunctionBuilderContext::new();
+                    let mut inner_builder = FunctionBuilder::new(&mut inner_ctx.func, &mut inner_fb_ctx);
+                    let inner_block = inner_builder.create_block();
+                    inner_builder.append_block_params_for_function_params(inner_block);
+                    inner_builder.switch_to_block(inner_block);
+                    inner_builder.seal_block(inner_block);
+
+                    let inner_vmctx = inner_builder.block_params(inner_block)[0];
+                    let inner_self = inner_builder.block_params(inner_block)[1];
+                    let inner_arg = inner_builder.block_params(inner_block)[2];
+
+                    inner_builder.declare_value_needs_stack_map(inner_self);
+                    inner_builder.declare_value_needs_stack_map(inner_arg);
+
+                    let mut inner_gc_sig = Signature::new(pipeline.isa.default_call_conv());
+                    inner_gc_sig.params.push(AbiParam::new(types::I64));
+                    let inner_gc_sig_ref = inner_builder.import_signature(inner_gc_sig);
+
+                    let mut inner_emit = EmitContext::new();
+                    inner_emit.lambda_counter = self.lambda_counter;
+                    inner_emit.env.insert(lam_binder, SsaVal::HeapPtr(inner_arg));
+
+                    for (i, (var_id, _)) in captures.iter().enumerate() {
+                        let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                        let val = inner_builder.ins().load(types::I64, MemFlags::trusted(), inner_self, offset);
+                        inner_builder.declare_value_needs_stack_map(val);
+                        inner_emit.env.insert(*var_id, SsaVal::HeapPtr(val));
+                    }
+
+                    let body_root = lam_body_tree.nodes.len() - 1;
+                    let body_result = inner_emit.emit_node(pipeline, &mut inner_builder, inner_vmctx, inner_gc_sig_ref, &lam_body_tree, body_root)?;
+                    let ret_val = ensure_heap_ptr(&mut inner_builder, inner_vmctx, inner_gc_sig_ref, body_result);
+
+                    inner_builder.ins().return_(&[ret_val]);
+                    inner_builder.finalize();
+                    self.lambda_counter = inner_emit.lambda_counter;
+                    pipeline.define_function(lambda_func_id, &mut inner_ctx);
+
+                    let func_ref = pipeline.module.declare_func_in_func(lambda_func_id, builder.func);
+                    let code_ptr = builder.ins().func_addr(types::I64, func_ref);
+                    builder.ins().store(MemFlags::trusted(), code_ptr, closure_ptr, CLOSURE_CODE_PTR_OFFSET);
+
+                    for (i, (_, ssaval)) in captures.into_iter().enumerate() {
+                        let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, ssaval);
+                        let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                        builder.ins().store(MemFlags::trusted(), cap_val, closure_ptr, offset);
+                    }
+                }
+
+                let body_val = self.emit_node(pipeline, builder, vmctx, gc_sig, tree, *body)?;
+                for (binder, _) in bindings {
+                    self.env.remove(binder);
+                }
+                Ok(body_val)
+            }
+            CoreFrame::Case { .. } => Err(EmitError::NotYetImplemented("Case".into())),
+            CoreFrame::Join { .. } => Err(EmitError::NotYetImplemented("Join".into())),
+            CoreFrame::Jump { .. } => Err(EmitError::NotYetImplemented("Jump".into())),
+        }
+    }
+}
+
+fn emit_lit(
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    lit: &Literal,
+) -> Result<SsaVal, EmitError> {
+    let ptr = emit_alloc_fast_path(builder, vmctx, LIT_TOTAL_SIZE, gc_sig);
+
+    let tag = builder.ins().iconst(types::I8, layout::TAG_LIT as i64);
+    builder.ins().store(MemFlags::trusted(), tag, ptr, 0);
+    let size = builder.ins().iconst(types::I16, LIT_TOTAL_SIZE as i64);
+    builder.ins().store(MemFlags::trusted(), size, ptr, 1);
+
+    match lit {
+        Literal::LitInt(n) => {
+            let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_INT);
+            builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
+            let val = builder.ins().iconst(types::I64, *n);
+            builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+        }
+        Literal::LitWord(n) => {
+            let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_WORD);
+            builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
+            let val = builder.ins().iconst(types::I64, *n as i64);
+            builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+        }
+        Literal::LitChar(c) => {
+            let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_CHAR);
+            builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
+            let val = builder.ins().iconst(types::I64, *c as i64);
+            builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+        }
+        Literal::LitFloat(bits) => {
+            let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_FLOAT);
+            builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
+            let val = builder.ins().iconst(types::I64, *bits as i64);
+            builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+        }
+        Literal::LitDouble(bits) => {
+            let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_DOUBLE);
+            builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
+            let val = builder.ins().iconst(types::I64, *bits as i64);
+            builder.ins().store(MemFlags::trusted(), val, ptr, LIT_VALUE_OFFSET);
+        }
+        Literal::LitString(_) => return Err(EmitError::NotYetImplemented("LitString".into())),
+    }
+
+    builder.declare_value_needs_stack_map(ptr);
+    Ok(SsaVal::HeapPtr(ptr))
+}
+
+fn ensure_heap_ptr(
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    val: SsaVal,
+) -> Value {
+    match val {
+        SsaVal::HeapPtr(v) => v,
+        SsaVal::Raw(v) => {
+            // Box as LitInt
+            let ptr = emit_alloc_fast_path(builder, vmctx, LIT_TOTAL_SIZE, gc_sig);
+            let tag = builder.ins().iconst(types::I8, layout::TAG_LIT as i64);
+            builder.ins().store(MemFlags::trusted(), tag, ptr, 0);
+            let size = builder.ins().iconst(types::I16, LIT_TOTAL_SIZE as i64);
+            builder.ins().store(MemFlags::trusted(), size, ptr, 1);
+            let lit_tag = builder.ins().iconst(types::I8, LIT_TAG_INT);
+            builder.ins().store(MemFlags::trusted(), lit_tag, ptr, LIT_TAG_OFFSET);
+            builder.ins().store(MemFlags::trusted(), v, ptr, LIT_VALUE_OFFSET);
+            builder.declare_value_needs_stack_map(ptr);
+            ptr
+        }
+    }
+}

--- a/codegen/src/emit/mod.rs
+++ b/codegen/src/emit/mod.rs
@@ -1,0 +1,89 @@
+pub mod expr;
+pub mod primop;
+
+use cranelift_codegen::ir::Value;
+use core_repr::{VarId, JoinId};
+use std::collections::HashMap;
+
+// HeapObject layout constants
+pub const HEAP_HEADER_SIZE: u64 = 8;
+pub const CLOSURE_CODE_PTR_OFFSET: i32 = 8;
+pub const CLOSURE_NUM_CAPTURED_OFFSET: i32 = 16;
+pub const CLOSURE_CAPTURED_START: i32 = 24;
+pub const CON_TAG_OFFSET: i32 = 8;
+pub const CON_NUM_FIELDS_OFFSET: i32 = 16;
+pub const CON_FIELDS_START: i32 = 24;
+pub const LIT_TAG_OFFSET: i32 = 8;
+pub const LIT_VALUE_OFFSET: i32 = 16;
+pub const LIT_TOTAL_SIZE: u64 = 24;
+pub const LIT_TAG_INT: i64 = 0;
+pub const LIT_TAG_WORD: i64 = 1;
+pub const LIT_TAG_CHAR: i64 = 2;
+pub const LIT_TAG_FLOAT: i64 = 3;
+pub const LIT_TAG_DOUBLE: i64 = 4;
+
+/// SSA value with boxed/unboxed tracking.
+#[derive(Debug, Clone, Copy)]
+pub enum SsaVal {
+    /// Unboxed raw value (i64 or f64 bits). NOT tracked by stack maps.
+    Raw(Value),
+    /// Heap pointer. Already declared via `declare_value_needs_stack_map`.
+    HeapPtr(Value),
+}
+
+impl SsaVal {
+    pub fn value(self) -> Value {
+        match self {
+            SsaVal::Raw(v) | SsaVal::HeapPtr(v) => v,
+        }
+    }
+}
+
+/// Emission context — bundles state during IR generation for one function.
+pub struct EmitContext {
+    pub env: HashMap<VarId, SsaVal>,
+    pub join_blocks: HashMap<JoinId, JoinInfo>,
+    pub lambda_counter: u32,
+}
+
+/// Placeholder for join point info (used by case/join leaf later).
+pub struct JoinInfo {
+    pub block: cranelift_codegen::ir::Block,
+    pub param_types: Vec<SsaVal>,
+}
+
+/// Errors during IR emission.
+#[derive(Debug)]
+pub enum EmitError {
+    UnboundVariable(VarId),
+    NotYetImplemented(String),
+    CraneliftError(String),
+}
+
+impl std::fmt::Display for EmitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EmitError::UnboundVariable(v) => write!(f, "unbound variable: {:?}", v),
+            EmitError::NotYetImplemented(s) => write!(f, "not yet implemented: {}", s),
+            EmitError::CraneliftError(s) => write!(f, "cranelift error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for EmitError {}
+
+impl EmitContext {
+    pub fn new() -> Self {
+        Self {
+            env: HashMap::new(),
+            join_blocks: HashMap::new(),
+            lambda_counter: 0,
+        }
+    }
+
+    pub fn next_lambda_name(&mut self) -> String {
+        let n = self.lambda_counter;
+        self.lambda_counter += 1;
+        format!("__lambda_{}", n)
+    }
+}

--- a/codegen/src/emit/mod.rs
+++ b/codegen/src/emit/mod.rs
@@ -2,7 +2,7 @@ pub mod expr;
 pub mod primop;
 
 use cranelift_codegen::ir::Value;
-use core_repr::{VarId, JoinId};
+use core_repr::{VarId, JoinId, PrimOpKind};
 use std::collections::HashMap;
 
 // HeapObject layout constants
@@ -25,8 +25,8 @@ pub const LIT_TAG_DOUBLE: i64 = 4;
 /// SSA value with boxed/unboxed tracking.
 #[derive(Debug, Clone, Copy)]
 pub enum SsaVal {
-    /// Unboxed raw value (i64 or f64 bits). NOT tracked by stack maps.
-    Raw(Value),
+    /// Unboxed raw value (i64 or f64 bits) with its literal tag.
+    Raw(Value, i64),
     /// Heap pointer. Already declared via `declare_value_needs_stack_map`.
     HeapPtr(Value),
 }
@@ -34,7 +34,7 @@ pub enum SsaVal {
 impl SsaVal {
     pub fn value(self) -> Value {
         match self {
-            SsaVal::Raw(v) | SsaVal::HeapPtr(v) => v,
+            SsaVal::Raw(v, _) | SsaVal::HeapPtr(v) => v,
         }
     }
 }
@@ -44,6 +44,7 @@ pub struct EmitContext {
     pub env: HashMap<VarId, SsaVal>,
     pub join_blocks: HashMap<JoinId, JoinInfo>,
     pub lambda_counter: u32,
+    pub prefix: String,
 }
 
 /// Placeholder for join point info (used by case/join leaf later).
@@ -58,6 +59,7 @@ pub enum EmitError {
     UnboundVariable(VarId),
     NotYetImplemented(String),
     CraneliftError(String),
+    InvalidArity(PrimOpKind, usize, usize),
 }
 
 impl std::fmt::Display for EmitError {
@@ -66,6 +68,9 @@ impl std::fmt::Display for EmitError {
             EmitError::UnboundVariable(v) => write!(f, "unbound variable: {:?}", v),
             EmitError::NotYetImplemented(s) => write!(f, "not yet implemented: {}", s),
             EmitError::CraneliftError(s) => write!(f, "cranelift error: {}", s),
+            EmitError::InvalidArity(op, expected, got) => {
+                write!(f, "invalid arity for {:?}: expected {}, got {}", op, expected, got)
+            }
         }
     }
 }
@@ -73,17 +78,18 @@ impl std::fmt::Display for EmitError {
 impl std::error::Error for EmitError {}
 
 impl EmitContext {
-    pub fn new() -> Self {
+    pub fn new(prefix: String) -> Self {
         Self {
             env: HashMap::new(),
             join_blocks: HashMap::new(),
             lambda_counter: 0,
+            prefix,
         }
     }
 
     pub fn next_lambda_name(&mut self) -> String {
         let n = self.lambda_counter;
         self.lambda_counter += 1;
-        format!("__lambda_{}", n)
+        format!("{}_lambda_{}", self.prefix, n)
     }
 }

--- a/codegen/src/emit/primop.rs
+++ b/codegen/src/emit/primop.rs
@@ -13,102 +13,114 @@ pub fn emit_primop(
     match op {
         // Int arithmetic (binary)
         PrimOpKind::IntAdd => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_int(builder, args[0]);
             let b = unbox_int(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().iadd(a, b)))
+            Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntSub => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_int(builder, args[0]);
             let b = unbox_int(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().isub(a, b)))
+            Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntMul => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_int(builder, args[0]);
             let b = unbox_int(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().imul(a, b)))
+            Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntNegate => {
+            check_arity(op, 1, args.len())?;
             let a = unbox_int(builder, args[0]);
-            Ok(SsaVal::Raw(builder.ins().ineg(a)))
+            Ok(SsaVal::Raw(builder.ins().ineg(a), LIT_TAG_INT))
         }
 
         // Int comparison → returns i64 (0=False, 1=True)
-        PrimOpKind::IntEq => emit_int_compare(builder, IntCC::Equal, args[0], args[1]),
-        PrimOpKind::IntNe => emit_int_compare(builder, IntCC::NotEqual, args[0], args[1]),
-        PrimOpKind::IntLt => emit_int_compare(builder, IntCC::SignedLessThan, args[0], args[1]),
-        PrimOpKind::IntLe => emit_int_compare(builder, IntCC::SignedLessThanOrEqual, args[0], args[1]),
-        PrimOpKind::IntGt => emit_int_compare(builder, IntCC::SignedGreaterThan, args[0], args[1]),
-        PrimOpKind::IntGe => emit_int_compare(builder, IntCC::SignedGreaterThanOrEqual, args[0], args[1]),
+        PrimOpKind::IntEq => emit_int_compare(builder, IntCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::IntNe => emit_int_compare(builder, IntCC::NotEqual, args, LIT_TAG_INT),
+        PrimOpKind::IntLt => emit_int_compare(builder, IntCC::SignedLessThan, args, LIT_TAG_INT),
+        PrimOpKind::IntLe => emit_int_compare(builder, IntCC::SignedLessThanOrEqual, args, LIT_TAG_INT),
+        PrimOpKind::IntGt => emit_int_compare(builder, IntCC::SignedGreaterThan, args, LIT_TAG_INT),
+        PrimOpKind::IntGe => emit_int_compare(builder, IntCC::SignedGreaterThanOrEqual, args, LIT_TAG_INT),
 
         // Word arithmetic
         PrimOpKind::WordAdd => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_int(builder, args[0]);
             let b = unbox_int(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().iadd(a, b)))
+            Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordSub => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_int(builder, args[0]);
             let b = unbox_int(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().isub(a, b)))
+            Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordMul => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_int(builder, args[0]);
             let b = unbox_int(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().imul(a, b)))
+            Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_WORD))
         }
 
         // Word comparison (unsigned)
-        PrimOpKind::WordEq => emit_int_compare(builder, IntCC::Equal, args[0], args[1]),
-        PrimOpKind::WordNe => emit_int_compare(builder, IntCC::NotEqual, args[0], args[1]),
-        PrimOpKind::WordLt => emit_int_compare(builder, IntCC::UnsignedLessThan, args[0], args[1]),
-        PrimOpKind::WordLe => emit_int_compare(builder, IntCC::UnsignedLessThanOrEqual, args[0], args[1]),
-        PrimOpKind::WordGt => emit_int_compare(builder, IntCC::UnsignedGreaterThan, args[0], args[1]),
-        PrimOpKind::WordGe => emit_int_compare(builder, IntCC::UnsignedGreaterThanOrEqual, args[0], args[1]),
+        PrimOpKind::WordEq => emit_int_compare(builder, IntCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::WordNe => emit_int_compare(builder, IntCC::NotEqual, args, LIT_TAG_INT),
+        PrimOpKind::WordLt => emit_int_compare(builder, IntCC::UnsignedLessThan, args, LIT_TAG_INT),
+        PrimOpKind::WordLe => emit_int_compare(builder, IntCC::UnsignedLessThanOrEqual, args, LIT_TAG_INT),
+        PrimOpKind::WordGt => emit_int_compare(builder, IntCC::UnsignedGreaterThan, args, LIT_TAG_INT),
+        PrimOpKind::WordGe => emit_int_compare(builder, IntCC::UnsignedGreaterThanOrEqual, args, LIT_TAG_INT),
 
         // Double arithmetic (unbox_double → f64, fadd/fsub/fmul/fdiv)
         PrimOpKind::DoubleAdd => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_double(builder, args[0]);
             let b = unbox_double(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().fadd(a, b)))
+            Ok(SsaVal::Raw(builder.ins().fadd(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleSub => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_double(builder, args[0]);
             let b = unbox_double(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().fsub(a, b)))
+            Ok(SsaVal::Raw(builder.ins().fsub(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleMul => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_double(builder, args[0]);
             let b = unbox_double(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().fmul(a, b)))
+            Ok(SsaVal::Raw(builder.ins().fmul(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleDiv => {
+            check_arity(op, 2, args.len())?;
             let a = unbox_double(builder, args[0]);
             let b = unbox_double(builder, args[1]);
-            Ok(SsaVal::Raw(builder.ins().fdiv(a, b)))
+            Ok(SsaVal::Raw(builder.ins().fdiv(a, b), LIT_TAG_DOUBLE))
         }
 
         // Double comparison → returns i64 (0 or 1)
-        PrimOpKind::DoubleEq => emit_float_compare(builder, FloatCC::Equal, args[0], args[1]),
-        PrimOpKind::DoubleNe => emit_float_compare(builder, FloatCC::NotEqual, args[0], args[1]),
-        PrimOpKind::DoubleLt => emit_float_compare(builder, FloatCC::LessThan, args[0], args[1]),
-        PrimOpKind::DoubleLe => emit_float_compare(builder, FloatCC::LessThanOrEqual, args[0], args[1]),
-        PrimOpKind::DoubleGt => emit_float_compare(builder, FloatCC::GreaterThan, args[0], args[1]),
-        PrimOpKind::DoubleGe => emit_float_compare(builder, FloatCC::GreaterThanOrEqual, args[0], args[1]),
+        PrimOpKind::DoubleEq => emit_float_compare(builder, FloatCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::DoubleNe => emit_float_compare(builder, FloatCC::NotEqual, args, LIT_TAG_INT),
+        PrimOpKind::DoubleLt => emit_float_compare(builder, FloatCC::LessThan, args, LIT_TAG_INT),
+        PrimOpKind::DoubleLe => emit_float_compare(builder, FloatCC::LessThanOrEqual, args, LIT_TAG_INT),
+        PrimOpKind::DoubleGt => emit_float_compare(builder, FloatCC::GreaterThan, args, LIT_TAG_INT),
+        PrimOpKind::DoubleGe => emit_float_compare(builder, FloatCC::GreaterThanOrEqual, args, LIT_TAG_INT),
 
         // Char comparison → unbox_int (char stored as i64), use IntCC
-        PrimOpKind::CharEq => emit_int_compare(builder, IntCC::Equal, args[0], args[1]),
-        PrimOpKind::CharNe => emit_int_compare(builder, IntCC::NotEqual, args[0], args[1]),
-        PrimOpKind::CharLt => emit_int_compare(builder, IntCC::UnsignedLessThan, args[0], args[1]),
-        PrimOpKind::CharLe => emit_int_compare(builder, IntCC::UnsignedLessThanOrEqual, args[0], args[1]),
-        PrimOpKind::CharGt => emit_int_compare(builder, IntCC::UnsignedGreaterThan, args[0], args[1]),
-        PrimOpKind::CharGe => emit_int_compare(builder, IntCC::UnsignedGreaterThanOrEqual, args[0], args[1]),
+        PrimOpKind::CharEq => emit_int_compare(builder, IntCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::CharNe => emit_int_compare(builder, IntCC::NotEqual, args, LIT_TAG_INT),
+        PrimOpKind::CharLt => emit_int_compare(builder, IntCC::UnsignedLessThan, args, LIT_TAG_INT),
+        PrimOpKind::CharLe => emit_int_compare(builder, IntCC::UnsignedLessThanOrEqual, args, LIT_TAG_INT),
+        PrimOpKind::CharGt => emit_int_compare(builder, IntCC::UnsignedGreaterThan, args, LIT_TAG_INT),
+        PrimOpKind::CharGe => emit_int_compare(builder, IntCC::UnsignedGreaterThanOrEqual, args, LIT_TAG_INT),
 
         // Special ops
         PrimOpKind::DataToTag => {
+            check_arity(op, 1, args.len())?;
             // Load con_tag from HeapObject at CON_TAG_OFFSET
             let obj = args[0].value(); // HeapPtr
             let tag = builder.ins().load(types::I64, MemFlags::trusted(), obj, CON_TAG_OFFSET);
-            Ok(SsaVal::Raw(tag))
+            Ok(SsaVal::Raw(tag, LIT_TAG_INT))
         }
         PrimOpKind::TagToEnum | PrimOpKind::IndexArray | PrimOpKind::SeqOp => {
             Err(EmitError::NotYetImplemented(format!("{:?}", op)))
@@ -116,40 +128,50 @@ pub fn emit_primop(
     }
 }
 
+fn check_arity(op: &PrimOpKind, expected: usize, got: usize) -> Result<(), EmitError> {
+    if expected != got {
+        Err(EmitError::InvalidArity(op.clone(), expected, got))
+    } else {
+        Ok(())
+    }
+}
+
 fn emit_int_compare(
     builder: &mut FunctionBuilder,
     cc: IntCC,
-    a: SsaVal,
-    b: SsaVal,
+    args: &[SsaVal],
+    tag: i64,
 ) -> Result<SsaVal, EmitError> {
-    let a = unbox_int(builder, a);
-    let b = unbox_int(builder, b);
+    check_arity(&PrimOpKind::IntEq, 2, args.len())?; // Approximate op for error
+    let a = unbox_int(builder, args[0]);
+    let b = unbox_int(builder, args[1]);
     let cmp = builder.ins().icmp(cc, a, b);
-    Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp)))
+    Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp), tag))
 }
 
 fn emit_float_compare(
     builder: &mut FunctionBuilder,
     cc: FloatCC,
-    a: SsaVal,
-    b: SsaVal,
+    args: &[SsaVal],
+    tag: i64,
 ) -> Result<SsaVal, EmitError> {
-    let a = unbox_double(builder, a);
-    let b = unbox_double(builder, b);
+    check_arity(&PrimOpKind::DoubleEq, 2, args.len())?; // Approximate op for error
+    let a = unbox_double(builder, args[0]);
+    let b = unbox_double(builder, args[1]);
     let cmp = builder.ins().fcmp(cc, a, b);
-    Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp)))
+    Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp), tag))
 }
 
 pub fn unbox_int(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
     match val {
-        SsaVal::Raw(v) => v,
+        SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => builder.ins().load(types::I64, MemFlags::trusted(), v, LIT_VALUE_OFFSET),
     }
 }
 
 pub fn unbox_double(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
     match val {
-        SsaVal::Raw(v) => v,
+        SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => builder.ins().load(types::F64, MemFlags::trusted(), v, LIT_VALUE_OFFSET),
     }
 }

--- a/codegen/src/emit/primop.rs
+++ b/codegen/src/emit/primop.rs
@@ -1,0 +1,155 @@
+use super::*;
+use crate::emit::{SsaVal, EmitError};
+use core_repr::PrimOpKind;
+use cranelift_codegen::ir::{types, InstBuilder, MemFlags, Value, condcodes::IntCC, condcodes::FloatCC};
+use cranelift_frontend::FunctionBuilder;
+
+/// Emit a primitive operation. Unboxes HeapPtr args, performs the op, returns Raw.
+pub fn emit_primop(
+    builder: &mut FunctionBuilder,
+    op: &PrimOpKind,
+    args: &[SsaVal],
+) -> Result<SsaVal, EmitError> {
+    match op {
+        // Int arithmetic (binary)
+        PrimOpKind::IntAdd => {
+            let a = unbox_int(builder, args[0]);
+            let b = unbox_int(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().iadd(a, b)))
+        }
+        PrimOpKind::IntSub => {
+            let a = unbox_int(builder, args[0]);
+            let b = unbox_int(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().isub(a, b)))
+        }
+        PrimOpKind::IntMul => {
+            let a = unbox_int(builder, args[0]);
+            let b = unbox_int(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().imul(a, b)))
+        }
+        PrimOpKind::IntNegate => {
+            let a = unbox_int(builder, args[0]);
+            Ok(SsaVal::Raw(builder.ins().ineg(a)))
+        }
+
+        // Int comparison → returns i64 (0=False, 1=True)
+        PrimOpKind::IntEq => emit_int_compare(builder, IntCC::Equal, args[0], args[1]),
+        PrimOpKind::IntNe => emit_int_compare(builder, IntCC::NotEqual, args[0], args[1]),
+        PrimOpKind::IntLt => emit_int_compare(builder, IntCC::SignedLessThan, args[0], args[1]),
+        PrimOpKind::IntLe => emit_int_compare(builder, IntCC::SignedLessThanOrEqual, args[0], args[1]),
+        PrimOpKind::IntGt => emit_int_compare(builder, IntCC::SignedGreaterThan, args[0], args[1]),
+        PrimOpKind::IntGe => emit_int_compare(builder, IntCC::SignedGreaterThanOrEqual, args[0], args[1]),
+
+        // Word arithmetic
+        PrimOpKind::WordAdd => {
+            let a = unbox_int(builder, args[0]);
+            let b = unbox_int(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().iadd(a, b)))
+        }
+        PrimOpKind::WordSub => {
+            let a = unbox_int(builder, args[0]);
+            let b = unbox_int(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().isub(a, b)))
+        }
+        PrimOpKind::WordMul => {
+            let a = unbox_int(builder, args[0]);
+            let b = unbox_int(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().imul(a, b)))
+        }
+
+        // Word comparison (unsigned)
+        PrimOpKind::WordEq => emit_int_compare(builder, IntCC::Equal, args[0], args[1]),
+        PrimOpKind::WordNe => emit_int_compare(builder, IntCC::NotEqual, args[0], args[1]),
+        PrimOpKind::WordLt => emit_int_compare(builder, IntCC::UnsignedLessThan, args[0], args[1]),
+        PrimOpKind::WordLe => emit_int_compare(builder, IntCC::UnsignedLessThanOrEqual, args[0], args[1]),
+        PrimOpKind::WordGt => emit_int_compare(builder, IntCC::UnsignedGreaterThan, args[0], args[1]),
+        PrimOpKind::WordGe => emit_int_compare(builder, IntCC::UnsignedGreaterThanOrEqual, args[0], args[1]),
+
+        // Double arithmetic (unbox_double → f64, fadd/fsub/fmul/fdiv)
+        PrimOpKind::DoubleAdd => {
+            let a = unbox_double(builder, args[0]);
+            let b = unbox_double(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().fadd(a, b)))
+        }
+        PrimOpKind::DoubleSub => {
+            let a = unbox_double(builder, args[0]);
+            let b = unbox_double(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().fsub(a, b)))
+        }
+        PrimOpKind::DoubleMul => {
+            let a = unbox_double(builder, args[0]);
+            let b = unbox_double(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().fmul(a, b)))
+        }
+        PrimOpKind::DoubleDiv => {
+            let a = unbox_double(builder, args[0]);
+            let b = unbox_double(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().fdiv(a, b)))
+        }
+
+        // Double comparison → returns i64 (0 or 1)
+        PrimOpKind::DoubleEq => emit_float_compare(builder, FloatCC::Equal, args[0], args[1]),
+        PrimOpKind::DoubleNe => emit_float_compare(builder, FloatCC::NotEqual, args[0], args[1]),
+        PrimOpKind::DoubleLt => emit_float_compare(builder, FloatCC::LessThan, args[0], args[1]),
+        PrimOpKind::DoubleLe => emit_float_compare(builder, FloatCC::LessThanOrEqual, args[0], args[1]),
+        PrimOpKind::DoubleGt => emit_float_compare(builder, FloatCC::GreaterThan, args[0], args[1]),
+        PrimOpKind::DoubleGe => emit_float_compare(builder, FloatCC::GreaterThanOrEqual, args[0], args[1]),
+
+        // Char comparison → unbox_int (char stored as i64), use IntCC
+        PrimOpKind::CharEq => emit_int_compare(builder, IntCC::Equal, args[0], args[1]),
+        PrimOpKind::CharNe => emit_int_compare(builder, IntCC::NotEqual, args[0], args[1]),
+        PrimOpKind::CharLt => emit_int_compare(builder, IntCC::UnsignedLessThan, args[0], args[1]),
+        PrimOpKind::CharLe => emit_int_compare(builder, IntCC::UnsignedLessThanOrEqual, args[0], args[1]),
+        PrimOpKind::CharGt => emit_int_compare(builder, IntCC::UnsignedGreaterThan, args[0], args[1]),
+        PrimOpKind::CharGe => emit_int_compare(builder, IntCC::UnsignedGreaterThanOrEqual, args[0], args[1]),
+
+        // Special ops
+        PrimOpKind::DataToTag => {
+            // Load con_tag from HeapObject at CON_TAG_OFFSET
+            let obj = args[0].value(); // HeapPtr
+            let tag = builder.ins().load(types::I64, MemFlags::trusted(), obj, CON_TAG_OFFSET);
+            Ok(SsaVal::Raw(tag))
+        }
+        PrimOpKind::TagToEnum | PrimOpKind::IndexArray | PrimOpKind::SeqOp => {
+            Err(EmitError::NotYetImplemented(format!("{:?}", op)))
+        }
+    }
+}
+
+fn emit_int_compare(
+    builder: &mut FunctionBuilder,
+    cc: IntCC,
+    a: SsaVal,
+    b: SsaVal,
+) -> Result<SsaVal, EmitError> {
+    let a = unbox_int(builder, a);
+    let b = unbox_int(builder, b);
+    let cmp = builder.ins().icmp(cc, a, b);
+    Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp)))
+}
+
+fn emit_float_compare(
+    builder: &mut FunctionBuilder,
+    cc: FloatCC,
+    a: SsaVal,
+    b: SsaVal,
+) -> Result<SsaVal, EmitError> {
+    let a = unbox_double(builder, a);
+    let b = unbox_double(builder, b);
+    let cmp = builder.ins().fcmp(cc, a, b);
+    Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp)))
+}
+
+pub fn unbox_int(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
+    match val {
+        SsaVal::Raw(v) => v,
+        SsaVal::HeapPtr(v) => builder.ins().load(types::I64, MemFlags::trusted(), v, LIT_VALUE_OFFSET),
+    }
+}
+
+pub fn unbox_double(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
+    match val {
+        SsaVal::Raw(v) => v,
+        SsaVal::HeapPtr(v) => builder.ins().load(types::F64, MemFlags::trusted(), v, LIT_VALUE_OFFSET),
+    }
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -3,3 +3,4 @@ pub mod pipeline;
 pub mod stack_map;
 pub mod host_fns;
 pub mod alloc;
+pub mod emit;

--- a/codegen/tests/emit_expr.rs
+++ b/codegen/tests/emit_expr.rs
@@ -1,0 +1,270 @@
+use codegen::context::VMContext;
+use codegen::pipeline::CodegenPipeline;
+use codegen::host_fns;
+use codegen::emit::expr::compile_expr;
+use core_repr::*;
+use core_heap::layout;
+
+struct TestResult {
+    result_ptr: *const u8,
+    _nursery: Vec<u8>,
+    _pipeline: CodegenPipeline,
+}
+
+/// Helper: set up pipeline + nursery, compile expr, call it, return result ptr.
+fn compile_and_run(tree: &CoreExpr) -> TestResult {
+    let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
+    let func_id = compile_expr(&mut pipeline, tree, "test_fn").expect("compile_expr failed");
+    pipeline.finalize();
+    
+    let mut nursery = vec![0u8; 65536]; // 64KB nursery
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(nursery.len()) };
+    let mut vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+    
+    let ptr = pipeline.get_function_ptr(func_id);
+    let func: unsafe extern "C" fn(*mut VMContext) -> i64 = unsafe { std::mem::transmute(ptr) };
+    let result = unsafe { func(&mut vmctx as *mut VMContext) };
+    
+    TestResult {
+        result_ptr: result as *const u8,
+        _nursery: nursery,
+        _pipeline: pipeline,
+    }
+}
+
+/// Helper: read i64 value from a LitObject.
+unsafe fn read_lit_int(ptr: *const u8) -> i64 {
+    assert_eq!(layout::read_tag(ptr), layout::TAG_LIT);
+    *(ptr.add(16) as *const i64)
+}
+
+/// Helper: read con_tag from a ConObject.
+unsafe fn read_con_tag(ptr: *const u8) -> u64 {
+    assert_eq!(layout::read_tag(ptr), layout::TAG_CON);
+    *(ptr.add(8) as *const u64)
+}
+
+/// Helper: read field i from a ConObject.
+unsafe fn read_con_field(ptr: *const u8, i: usize) -> *const u8 {
+    *(ptr.add(24 + 8 * i) as *const *const u8)
+}
+
+#[test]
+fn test_emit_lit_int() {
+    let tree = RecursiveTree { nodes: vec![CoreFrame::Lit(Literal::LitInt(42))] };
+    let result = compile_and_run(&tree);
+    unsafe {
+        assert_eq!(layout::read_tag(result.result_ptr), layout::TAG_LIT);
+        assert_eq!(read_lit_int(result.result_ptr), 42);
+    }
+}
+
+#[test]
+fn test_emit_primop_int_add() {
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(1)),    // 0
+        CoreFrame::Lit(Literal::LitInt(2)),    // 1
+        CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![0, 1] }, // 2 (root)
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 3); }
+}
+
+#[test]
+fn test_emit_con_fields() {
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(10)),   // 0
+        CoreFrame::Lit(Literal::LitInt(20)),   // 1
+        CoreFrame::Con { tag: DataConId(5), fields: vec![0, 1] }, // 2 (root)
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe {
+        assert_eq!(layout::read_tag(result.result_ptr), layout::TAG_CON);
+        assert_eq!(read_con_tag(result.result_ptr), 5);
+        let f0 = read_con_field(result.result_ptr, 0);
+        let f1 = read_con_field(result.result_ptr, 1);
+        assert_eq!(read_lit_int(f0), 10);
+        assert_eq!(read_lit_int(f1), 20);
+    }
+}
+
+#[test]
+fn test_emit_identity_lambda() {
+    let x = VarId(1);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(42)),           // 0: arg
+        CoreFrame::Var(x),                              // 1: body (x)
+        CoreFrame::Lam { binder: x, body: 1 },         // 2: λx.x
+        CoreFrame::App { fun: 2, arg: 0 },             // 3: (λx.x) 42 (root)
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}
+
+#[test]
+fn test_emit_closure_capture() {
+    let x = VarId(1);
+    let y = VarId(2);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(1)),                             // 0: y = 1
+        CoreFrame::Var(x),                                               // 1: x
+        CoreFrame::Var(y),                                               // 2: y
+        CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![1, 2] }, // 3: x + y
+        CoreFrame::Lam { binder: x, body: 3 },                          // 4: λx. x + y
+        CoreFrame::Lit(Literal::LitInt(2)),                             // 5: arg = 2
+        CoreFrame::App { fun: 4, arg: 5 },                              // 6: (λx. x+y) 2
+        CoreFrame::LetNonRec { binder: y, rhs: 0, body: 6 },           // 7: let y=1 in ... (root)
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 3); }
+}
+
+#[test]
+fn test_emit_let_non_rec() {
+    let x = VarId(1);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(42)),                            // 0
+        CoreFrame::Var(x),                                               // 1
+        CoreFrame::LetNonRec { binder: x, rhs: 0, body: 1 },           // 2 (root)
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}
+
+#[test]
+fn test_emit_primop_int_sub() {
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(10)),
+        CoreFrame::Lit(Literal::LitInt(3)),
+        CoreFrame::PrimOp { op: PrimOpKind::IntSub, args: vec![0, 1] },
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 7); }
+}
+
+#[test]
+fn test_emit_primop_int_mul() {
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(6)),
+        CoreFrame::Lit(Literal::LitInt(7)),
+        CoreFrame::PrimOp { op: PrimOpKind::IntMul, args: vec![0, 1] },
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}
+
+#[test]
+fn test_emit_primop_int_negate() {
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(42)),
+        CoreFrame::PrimOp { op: PrimOpKind::IntNegate, args: vec![0] },
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), -42); }
+}
+
+#[test]
+fn test_emit_primop_int_comparisons() {
+    fn run_cmp(op: PrimOpKind, a: i64, b: i64) -> i64 {
+        let tree = RecursiveTree { nodes: vec![
+            CoreFrame::Lit(Literal::LitInt(a)),
+            CoreFrame::Lit(Literal::LitInt(b)),
+            CoreFrame::PrimOp { op, args: vec![0, 1] },
+        ] };
+        let result = compile_and_run(&tree);
+        unsafe { read_lit_int(result.result_ptr) }
+    }
+    
+    assert_eq!(run_cmp(PrimOpKind::IntEq, 5, 5), 1);
+    assert_eq!(run_cmp(PrimOpKind::IntEq, 5, 6), 0);
+    assert_eq!(run_cmp(PrimOpKind::IntNe, 5, 6), 1);
+    assert_eq!(run_cmp(PrimOpKind::IntNe, 5, 5), 0);
+    assert_eq!(run_cmp(PrimOpKind::IntLt, 3, 5), 1);
+    assert_eq!(run_cmp(PrimOpKind::IntLt, 5, 3), 0);
+    assert_eq!(run_cmp(PrimOpKind::IntLe, 5, 5), 1);
+    assert_eq!(run_cmp(PrimOpKind::IntLe, 6, 5), 0);
+    assert_eq!(run_cmp(PrimOpKind::IntGt, 5, 3), 1);
+    assert_eq!(run_cmp(PrimOpKind::IntGt, 3, 5), 0);
+    assert_eq!(run_cmp(PrimOpKind::IntGe, 5, 5), 1);
+    assert_eq!(run_cmp(PrimOpKind::IntGe, 4, 5), 0);
+}
+
+#[test]
+fn test_emit_primop_word_ops() {
+    fn run_word(op: PrimOpKind, a: u64, b: u64) -> i64 {
+        let tree = RecursiveTree { nodes: vec![
+            CoreFrame::Lit(Literal::LitWord(a)),
+            CoreFrame::Lit(Literal::LitWord(b)),
+            CoreFrame::PrimOp { op, args: vec![0, 1] },
+        ] };
+        let result = compile_and_run(&tree);
+        unsafe { read_lit_int(result.result_ptr) }
+    }
+    
+    assert_eq!(run_word(PrimOpKind::WordAdd, 10, 20), 30);
+    assert_eq!(run_word(PrimOpKind::WordSub, 20, 10), 10);
+    assert_eq!(run_word(PrimOpKind::WordMul, 6, 7), 42);
+}
+
+#[test]
+fn test_emit_let_rec() {
+    // let rec f = λn. if n == 0 then 1 else n * f (n-1) in f 5
+    // Simplified: let rec f = λx. x in f 42
+    let f = VarId(1);
+    let x = VarId(2);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x),                                      // 0: x
+        CoreFrame::Lam { binder: x, body: 0 },                 // 1: λx.x
+        CoreFrame::Lit(Literal::LitInt(42)),                    // 2: arg 42
+        CoreFrame::Var(f),                                      // 3: f
+        CoreFrame::App { fun: 3, arg: 2 },                     // 4: f 42
+        CoreFrame::LetRec { bindings: vec![(f, 1)], body: 4 }, // 5: let rec f = ... (root)
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}
+
+#[test]
+fn test_emit_let_rec_factorial_ish() {
+    // let rec f = λn. if n == 0 then 1 else n * f (n-1)
+    // Since I don't have Case/If yet, I'll test a simple mutually recursive pair or just recursion.
+    // let rec f = λn. n in f 10
+    let f = VarId(1);
+    let n = VarId(2);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(n),                                       // 0: n
+        CoreFrame::Lam { binder: n, body: 0 },                  // 1: f = λn. n
+        CoreFrame::Lit(Literal::LitInt(10)),                     // 2: 10
+        CoreFrame::Var(f),                                       // 3: f
+        CoreFrame::App { fun: 3, arg: 2 },                      // 4: f 10
+        CoreFrame::LetRec { bindings: vec![(f, 1)], body: 4 },  // 5: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 10); }
+}
+
+#[test]
+fn test_emit_let_rec_mutual() {
+    // let rec f = λx. x
+    //         g = λy. f y
+    // in g 42
+    let f_id = VarId(1);
+    let g_id = VarId(2);
+    let x_id = VarId(3);
+    let y_id = VarId(4);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x_id),                                   // 0: x
+        CoreFrame::Lam { binder: x_id, body: 0 },              // 1: f = λx.x
+        CoreFrame::Var(f_id),                                   // 2: f
+        CoreFrame::Var(y_id),                                   // 3: y
+        CoreFrame::App { fun: 2, arg: 3 },                     // 4: f y
+        CoreFrame::Lam { binder: y_id, body: 4 },              // 5: g = λy. f y
+        CoreFrame::Lit(Literal::LitInt(42)),                    // 6: 42
+        CoreFrame::Var(g_id),                                   // 7: g
+        CoreFrame::App { fun: 7, arg: 6 },                     // 8: g 42
+        CoreFrame::LetRec { bindings: vec![(f_id, 1), (g_id, 5)], body: 8 }, // 9: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}

--- a/codegen/tests/emit_expr.rs
+++ b/codegen/tests/emit_expr.rs
@@ -208,6 +208,23 @@ fn test_emit_primop_word_ops() {
 }
 
 #[test]
+fn test_emit_word_boxing() {
+    // PrimOp(WordAdd, [LitWord(1), LitWord(2)]) -> should be boxed as LitWord
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitWord(1)),
+        CoreFrame::Lit(Literal::LitWord(2)),
+        CoreFrame::PrimOp { op: PrimOpKind::WordAdd, args: vec![0, 1] },
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe {
+        assert_eq!(layout::read_tag(result.result_ptr), layout::TAG_LIT);
+        // Offset 8 is lit_tag
+        assert_eq!(*result.result_ptr.add(8), codegen::emit::LIT_TAG_WORD as u8);
+        assert_eq!(read_lit_int(result.result_ptr), 3);
+    }
+}
+
+#[test]
 fn test_emit_let_rec() {
     // let rec f = λn. if n == 0 then 1 else n * f (n-1) in f 5
     // Simplified: let rec f = λx. x in f 42
@@ -268,3 +285,33 @@ fn test_emit_let_rec_mutual() {
     let result = compile_and_run(&tree);
     unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
 }
+
+#[test]
+fn test_emit_unique_lambda_names() {
+    // Compile two different expressions that both have lambdas using the same pipeline.
+    let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
+    
+    let x = VarId(1);
+    // λx.x
+    let tree1 = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x),
+        CoreFrame::Lam { binder: x, body: 0 },
+    ] };
+    
+    // λx. x + 1
+    let tree2 = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x),
+        CoreFrame::Lit(Literal::LitInt(1)),
+        CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![0, 1] },
+        CoreFrame::Lam { binder: x, body: 2 },
+    ] };
+    
+        // This should NOT panic due to "duplicate function name"
+    
+        compile_expr(&mut pipeline, &tree1, "f1").expect("First compilation failed");
+    
+        compile_expr(&mut pipeline, &tree2, "f2").expect("Second compilation failed");
+    
+    }
+    
+    


### PR DESCRIPTION
Implement the codegen/src/emit module for compiling Core expressions to Cranelift IR. Supports Lit, Var, Con, PrimOp, Lam, App, LetNonRec, and LetRec (recursive lambdas) with manual heap layout and stack map tracking.