### PR TITLE
feat(codegen): implement Join and Jump IR emission

### DIFF
--- a/codegen/src/emit/expr.rs
+++ b/codegen/src/emit/expr.rs
@@ -340,8 +340,12 @@ impl EmitContext {
                 Ok(body_val)
             }
             CoreFrame::Case { .. } => Err(EmitError::NotYetImplemented("Case".into())),
-            CoreFrame::Join { .. } => Err(EmitError::NotYetImplemented("Join".into())),
-            CoreFrame::Jump { .. } => Err(EmitError::NotYetImplemented("Jump".into())),
+            CoreFrame::Join { label, params, rhs, body } => {
+                crate::emit::join::emit_join(self, pipeline, builder, vmctx, gc_sig, tree, label, params, *rhs, *body)
+            }
+            CoreFrame::Jump { label, args } => {
+                crate::emit::join::emit_jump(self, pipeline, builder, vmctx, gc_sig, tree, label, args)
+            }
         }
     }
 }
@@ -404,7 +408,7 @@ fn emit_lit(
     }
 }
 
-fn ensure_heap_ptr(
+pub(crate) fn ensure_heap_ptr(
     builder: &mut FunctionBuilder,
     vmctx: Value,
     gc_sig: ir::SigRef,

--- a/codegen/src/emit/join.rs
+++ b/codegen/src/emit/join.rs
@@ -1,0 +1,128 @@
+use crate::pipeline::CodegenPipeline;
+use crate::emit::*;
+use crate::emit::expr::ensure_heap_ptr;
+use core_repr::*;
+use cranelift_codegen::ir::{self, types, InstBuilder, Value};
+use cranelift_frontend::FunctionBuilder;
+
+/// Emits a Join expression.
+/// Join { label, params, rhs, body } creates a join point (a parameterized block)
+/// that can be jumped to from within the body.
+pub fn emit_join(
+    ctx: &mut EmitContext,
+    pipeline: &mut CodegenPipeline,
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    tree: &CoreExpr,
+    label: &JoinId,
+    params: &[VarId],
+    rhs_idx: usize,
+    body_idx: usize,
+) -> Result<SsaVal, EmitError> {
+    // 1. Create a new block for the join point
+    let join_block = builder.create_block();
+
+    // 2. Add block params — one I64 param per join parameter
+    for _ in params {
+        builder.append_block_param(join_block, types::I64);
+    }
+
+    // 3. Create a continuation/merge block for the result
+    let merge_block = builder.create_block();
+    builder.append_block_param(merge_block, types::I64); // result
+
+    // 4. Register the join point in ctx
+    // We use a dummy Value(0) for param_types since Jump just needs to know they are heap pointers.
+    let dummy_val = Value::from_u32(0);
+    ctx.join_blocks.insert(*label, JoinInfo {
+        block: join_block,
+        param_types: params.iter().map(|_| SsaVal::HeapPtr(dummy_val)).collect(),
+    });
+
+    // 5. Emit body (the continuation that may contain Jumps)
+    let body_result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, body_idx)?;
+    let body_val = ensure_heap_ptr(builder, vmctx, gc_sig, body_result);
+    builder.ins().jump(merge_block, &[body_val]);
+
+    // 6. Switch to join block, emit rhs
+    builder.switch_to_block(join_block);
+    
+    // Bind params to block params
+    let block_params = builder.block_params(join_block).to_vec();
+    let mut old_env_vals = Vec::new();
+    for (i, param_var) in params.iter().enumerate() {
+        let val = block_params[i];
+        builder.declare_value_needs_stack_map(val);  // CRITICAL
+        let old_val = ctx.env.insert(*param_var, SsaVal::HeapPtr(val));
+        old_env_vals.push((*param_var, old_val));
+    }
+
+    let rhs_result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, rhs_idx)?;
+    let rhs_val = ensure_heap_ptr(builder, vmctx, gc_sig, rhs_result);
+    builder.ins().jump(merge_block, &[rhs_val]);
+
+    // 7. Seal blocks
+    // Body is emitted, so all Jumps to join_block are known.
+    builder.seal_block(join_block);
+    // Both body and rhs paths to merge_block are known.
+    builder.seal_block(merge_block);
+
+    // 8. Switch to merge block, get result
+    builder.switch_to_block(merge_block);
+    let result = builder.block_params(merge_block)[0];
+    builder.declare_value_needs_stack_map(result);  // CRITICAL
+
+    // 9. Clean up
+    ctx.join_blocks.remove(label);
+    for (param_var, old_val) in old_env_vals.into_iter().rev() {
+        if let Some(v) = old_val {
+            ctx.env.insert(param_var, v);
+        } else {
+            ctx.env.remove(&param_var);
+        }
+    }
+
+    // 10. Return result
+    Ok(SsaVal::HeapPtr(result))
+}
+
+/// Emits a Jump expression.
+/// Jump { label, args } transfers control to the join point block.
+pub fn emit_jump(
+    ctx: &mut EmitContext,
+    pipeline: &mut CodegenPipeline,
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    tree: &CoreExpr,
+    label: &JoinId,
+    arg_indices: &[usize],
+) -> Result<SsaVal, EmitError> {
+    // 1. Look up label in ctx.join_blocks
+    // Note: JoinInfo must be cloned or copied out because we'll be using the builder.
+    // However, JoinInfo doesn't implement Clone. But Block and Value are Copy.
+    // Actually, JoinInfo is not needed, just the block.
+    let join_block = ctx.join_blocks.get(label)
+        .ok_or_else(|| EmitError::NotYetImplemented(format!("Jump to unknown label {:?}", label)))?.block;
+
+    // 2. Emit each arg
+    let mut arg_values = Vec::new();
+    for &arg_idx in arg_indices {
+        let val = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, arg_idx)?;
+        // 3. Ensure all args are HeapPtr
+        arg_values.push(ensure_heap_ptr(builder, vmctx, gc_sig, val));
+    }
+
+    // 4. Jump
+    builder.ins().jump(join_block, &arg_values);
+
+    // 5. After a jump, the current block is terminated.
+    // Create a new unreachable block so Cranelift doesn't complain about instructions after a terminator.
+    let unreachable_block = builder.create_block();
+    builder.switch_to_block(unreachable_block);
+    builder.seal_block(unreachable_block);
+
+    // 6. Return a dummy SsaVal (dead code)
+    Ok(SsaVal::Raw(builder.ins().iconst(types::I64, 0), LIT_TAG_INT))
+}

--- a/codegen/src/emit/mod.rs
+++ b/codegen/src/emit/mod.rs
@@ -1,5 +1,6 @@
 pub mod expr;
 pub mod primop;
+pub mod join;
 
 use cranelift_codegen::ir::Value;
 use core_repr::{VarId, JoinId, PrimOpKind};

--- a/codegen/tests/emit_join.rs
+++ b/codegen/tests/emit_join.rs
@@ -1,0 +1,138 @@
+use codegen::context::VMContext;
+use codegen::pipeline::CodegenPipeline;
+use codegen::host_fns;
+use codegen::emit::expr::compile_expr;
+use core_repr::*;
+use core_heap::layout;
+
+struct TestResult {
+    result_ptr: *const u8,
+    _nursery: Vec<u8>,
+    _pipeline: CodegenPipeline,
+}
+
+/// Helper: set up pipeline + nursery, compile expr, call it, return result ptr.
+fn compile_and_run(tree: &CoreExpr) -> TestResult {
+    let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
+    let func_id = compile_expr(&mut pipeline, tree, "test_fn").expect("compile_expr failed");
+    pipeline.finalize();
+    
+    let mut nursery = vec![0u8; 65536]; // 64KB nursery
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(nursery.len()) };
+    let mut vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+    
+    let ptr = pipeline.get_function_ptr(func_id);
+    let func: unsafe extern "C" fn(*mut VMContext) -> i64 = unsafe { std::mem::transmute(ptr) };
+    let result = unsafe { func(&mut vmctx as *mut VMContext) };
+    
+    TestResult {
+        result_ptr: result as *const u8,
+        _nursery: nursery,
+        _pipeline: pipeline,
+    }
+}
+
+/// Helper: read i64 value from a LitObject.
+unsafe fn read_lit_int(ptr: *const u8) -> i64 {
+    assert_eq!(layout::read_tag(ptr), layout::TAG_LIT);
+    *(ptr.add(16) as *const i64)
+}
+
+/// Helper: read field i from a ConObject.
+unsafe fn read_con_field(ptr: *const u8, i: usize) -> *const u8 {
+    *(ptr.add(24 + 8 * i) as *const *const u8)
+}
+
+#[test]
+fn test_join_basic() {
+    // join j(x) = x in jump j(42)
+    let j = JoinId(1);
+    let x = VarId(1);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x),                                       // 0: rhs (x)
+        CoreFrame::Lit(Literal::LitInt(42)),                     // 1: jump arg
+        CoreFrame::Jump { label: j, args: vec![1] },            // 2: jump j(42) — body
+        CoreFrame::Join { label: j, params: vec![x], rhs: 0, body: 2 }, // 3: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}
+
+#[test]
+fn test_join_two_params() {
+    // join j(a, b) = a + b in jump j(10, 20)
+    let j = JoinId(1);
+    let a = VarId(1);
+    let b = VarId(2);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(a),                                       // 0
+        CoreFrame::Var(b),                                       // 1
+        CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![0, 1] }, // 2: a + b (rhs)
+        CoreFrame::Lit(Literal::LitInt(10)),                     // 3
+        CoreFrame::Lit(Literal::LitInt(20)),                     // 4
+        CoreFrame::Jump { label: j, args: vec![3, 4] },         // 5: body
+        CoreFrame::Join { label: j, params: vec![a, b], rhs: 2, body: 5 }, // 6: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 30); }
+}
+
+#[test]
+fn test_join_body_falls_through() {
+    // join j(x) = x in 99
+    // Body doesn't jump, so result is 99
+    let j = JoinId(1);
+    let x = VarId(1);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x),                                       // 0: rhs
+        CoreFrame::Lit(Literal::LitInt(99)),                     // 1: body (no jump)
+        CoreFrame::Join { label: j, params: vec![x], rhs: 0, body: 1 }, // 2: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 99); }
+}
+
+#[test]
+fn test_join_nested_inner_shadows() {
+    // join j(x) = x
+    // in join j(y) = y + 1   -- shadows outer j
+    //    in jump j(10)        -- jumps to inner j
+    // Result: 11
+    let j = JoinId(1);
+    let x = VarId(1);
+    let y = VarId(2);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x),                                       // 0: outer rhs
+        CoreFrame::Var(y),                                       // 1
+        CoreFrame::Lit(Literal::LitInt(1)),                      // 2
+        CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![1, 2] }, // 3: y + 1 (inner rhs)
+        CoreFrame::Lit(Literal::LitInt(10)),                     // 4: jump arg
+        CoreFrame::Jump { label: j, args: vec![4] },            // 5: jump j(10)
+        CoreFrame::Join { label: j, params: vec![y], rhs: 3, body: 5 }, // 6: inner join
+        CoreFrame::Join { label: j, params: vec![x], rhs: 0, body: 6 }, // 7: outer join (root)
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 11); }
+}
+
+#[test]
+fn test_join_with_heap_ptrs() {
+    // join j(x) = Con(0, [x]) in jump j(Lit(42))
+    // Verify heap pointer handling through join block params
+    let j = JoinId(1);
+    let x = VarId(1);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x),                                       // 0
+        CoreFrame::Con { tag: DataConId(0), fields: vec![0] },  // 1: rhs = Con(0, [x])
+        CoreFrame::Lit(Literal::LitInt(42)),                     // 2
+        CoreFrame::Jump { label: j, args: vec![2] },            // 3: body
+        CoreFrame::Join { label: j, params: vec![x], rhs: 1, body: 3 }, // 4: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe {
+        assert_eq!(layout::read_tag(result.result_ptr), layout::TAG_CON);
+        let field = read_con_field(result.result_ptr, 0);
+        assert_eq!(read_lit_int(field), 42);
+    }
+}


### PR DESCRIPTION
Implement Join/Jump for the CoreExpr → Cranelift IR emitter.

- Created codegen/src/emit/join.rs with emit_join and emit_jump functions.
- Wired Join/Jump arms in codegen/src/emit/expr.rs to call the new emission functions.
- Added public mod join to codegen/src/emit/mod.rs.
- Implemented integration tests in codegen/tests/emit_join.rs covering basic join, two params, fallthrough, nested joins with shadowing, and heap pointers.
- Ensured all join block parameters and merge block results are declared as stack map values.
- Verified all tests pass in codegen crate.