### PR TITLE
feat(codegen): implement Case dispatch for Cranelift emitter

### DIFF
--- a/codegen/src/emit/case.rs
+++ b/codegen/src/emit/case.rs
@@ -1,0 +1,236 @@
+use crate::pipeline::CodegenPipeline;
+use crate::emit::*;
+use crate::emit::expr::ensure_heap_ptr;
+use core_repr::{VarId, Alt, AltCon, Literal, CoreExpr};
+use cranelift_codegen::ir::{self, types, InstBuilder, MemFlags, Value, condcodes::IntCC, JumpTableData, TrapCode, BlockCall};
+use cranelift_frontend::FunctionBuilder;
+use std::collections::HashMap;
+
+/// Emit Case dispatch.
+pub fn emit_case(
+    ctx: &mut EmitContext,
+    pipeline: &mut CodegenPipeline,
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    tree: &CoreExpr,
+    scrutinee_idx: usize,
+    binder: &VarId,
+    alts: &[Alt<usize>],
+) -> Result<SsaVal, EmitError> {
+    // 1. Emit scrutinee
+    let scrut = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, scrutinee_idx)?;
+    let scrut_ptr = scrut.value();
+
+    // 2. Bind case binder
+    ctx.env.insert(*binder, scrut);
+
+    // 3. Classify alts
+    let mut data_alts = Vec::new();
+    let mut lit_alts = Vec::new();
+    let mut default_alt = None;
+
+    for alt in alts {
+        match &alt.con {
+            AltCon::DataAlt(_) => data_alts.push(alt),
+            AltCon::LitAlt(_) => lit_alts.push(alt),
+            AltCon::Default => default_alt = Some(alt),
+        }
+    }
+
+    // 4. Create merge block
+    let merge_block = builder.create_block();
+    builder.append_block_param(merge_block, types::I64);
+
+    // 5. Dispatch
+    if !data_alts.is_empty() {
+        emit_data_dispatch(
+            ctx, pipeline, builder, vmctx, gc_sig, tree, scrut_ptr, &data_alts, default_alt, merge_block,
+        )?;
+    } else if !lit_alts.is_empty() {
+        emit_lit_dispatch(
+            ctx, pipeline, builder, vmctx, gc_sig, tree, scrut_ptr, &lit_alts, default_alt, merge_block,
+        )?;
+    } else if let Some(alt) = default_alt {
+        // Default only
+        let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, alt.body)?;
+        let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, result);
+        builder.ins().jump(merge_block, &[result_ptr]);
+    } else {
+        // No alts? Trap.
+        builder.ins().trap(TrapCode::unwrap_user(2));
+    }
+
+    // Seal merge block
+    builder.seal_block(merge_block);
+
+    // Switch to merge block
+    builder.switch_to_block(merge_block);
+    let result = builder.block_params(merge_block)[0];
+    builder.declare_value_needs_stack_map(result);
+
+    // 6. Clean up case binder
+    ctx.env.remove(binder);
+
+    Ok(SsaVal::HeapPtr(result))
+}
+
+fn emit_data_dispatch(
+    ctx: &mut EmitContext,
+    pipeline: &mut CodegenPipeline,
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    tree: &CoreExpr,
+    scrut_ptr: Value,
+    data_alts: &[&Alt<usize>],
+    default_alt: Option<&Alt<usize>>,
+    merge_block: ir::Block,
+) -> Result<(), EmitError> {
+    // Load con_tag: offset 8
+    let con_tag = builder.ins().load(types::I64, MemFlags::trusted(), scrut_ptr, CON_TAG_OFFSET);
+    let con_tag_i32 = builder.ins().ireduce(types::I32, con_tag);
+
+    let mut max_tag = 0;
+    let mut tag_to_alt = HashMap::new();
+    for &alt in data_alts {
+        if let AltCon::DataAlt(tag) = &alt.con {
+            tag_to_alt.insert(tag.0, alt);
+            if tag.0 > max_tag {
+                max_tag = tag.0;
+            }
+        }
+    }
+
+    let default_block = builder.create_block();
+    let mut alt_blocks = HashMap::new();
+    let mut table = Vec::new();
+
+    for tag_idx in 0..=max_tag {
+        if let Some(_alt) = tag_to_alt.get(&tag_idx) {
+            let block = *alt_blocks.entry(tag_idx).or_insert_with(|| builder.create_block());
+            table.push(BlockCall::new(block, &[], &mut builder.func.dfg.value_lists));
+        } else {
+            table.push(BlockCall::new(default_block, &[], &mut builder.func.dfg.value_lists));
+        }
+    }
+
+    let jt_data = JumpTableData::new(BlockCall::new(default_block, &[], &mut builder.func.dfg.value_lists), &table);
+    let jt = builder.create_jump_table(jt_data);
+    builder.ins().br_table(con_tag_i32, jt);
+
+    // Emit DataAlt blocks
+    for (&tag_idx, &alt) in &tag_to_alt {
+        let block = alt_blocks[&tag_idx];
+        builder.switch_to_block(block);
+        builder.seal_block(block);
+
+        // Bind pattern variables
+        let mut bound_vars = Vec::new();
+        for (i, &binder) in alt.binders.iter().enumerate() {
+            let offset = CON_FIELDS_START + (8 * i as i32);
+            let field_val = builder.ins().load(types::I64, MemFlags::trusted(), scrut_ptr, offset);
+            builder.declare_value_needs_stack_map(field_val);
+            ctx.env.insert(binder, SsaVal::HeapPtr(field_val));
+            bound_vars.push(binder);
+        }
+
+        let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, alt.body)?;
+        let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, result);
+        builder.ins().jump(merge_block, &[result_ptr]);
+
+        // Clean up
+        for binder in bound_vars {
+            ctx.env.remove(&binder);
+        }
+    }
+
+    // Emit default block
+    builder.switch_to_block(default_block);
+    builder.seal_block(default_block);
+    if let Some(alt) = default_alt {
+        let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, alt.body)?;
+        let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, result);
+        builder.ins().jump(merge_block, &[result_ptr]);
+    } else {
+        builder.ins().trap(TrapCode::unwrap_user(2));
+    }
+
+    Ok(())
+}
+
+fn emit_lit_dispatch(
+    ctx: &mut EmitContext,
+    pipeline: &mut CodegenPipeline,
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    tree: &CoreExpr,
+    scrut_ptr: Value,
+    lit_alts: &[&Alt<usize>],
+    default_alt: Option<&Alt<usize>>,
+    merge_block: ir::Block,
+) -> Result<(), EmitError> {
+    // Load value from LIT object: offset 16
+    let scrut_value = builder.ins().load(types::I64, MemFlags::trusted(), scrut_ptr, LIT_VALUE_OFFSET);
+
+    for &alt in lit_alts {
+        let alt_block = builder.create_block();
+        let next_check_block = builder.create_block();
+
+        if let AltCon::LitAlt(lit) = &alt.con {
+            match lit {
+                Literal::LitInt(n) => {
+                    let lit_val = builder.ins().iconst(types::I64, *n);
+                    let eq = builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
+                    builder.ins().brif(eq, alt_block, &[], next_check_block, &[]);
+                }
+                Literal::LitWord(n) => {
+                    let lit_val = builder.ins().iconst(types::I64, *n as i64);
+                    let eq = builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
+                    builder.ins().brif(eq, alt_block, &[], next_check_block, &[]);
+                }
+                Literal::LitChar(c) => {
+                    let lit_val = builder.ins().iconst(types::I64, *c as i64);
+                    let eq = builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
+                    builder.ins().brif(eq, alt_block, &[], next_check_block, &[]);
+                }
+                Literal::LitFloat(bits) => {
+                    let scrut_f64 = builder.ins().bitcast(types::F64, MemFlags::trusted(), scrut_value);
+                    let lit_val = builder.ins().f64const(f64::from_bits(*bits));
+                    let eq = builder.ins().fcmp(ir::condcodes::FloatCC::Equal, scrut_f64, lit_val);
+                    builder.ins().brif(eq, alt_block, &[], next_check_block, &[]);
+                }
+                Literal::LitDouble(bits) => {
+                    let scrut_f64 = builder.ins().bitcast(types::F64, MemFlags::trusted(), scrut_value);
+                    let lit_val = builder.ins().f64const(f64::from_bits(*bits));
+                    let eq = builder.ins().fcmp(ir::condcodes::FloatCC::Equal, scrut_f64, lit_val);
+                    builder.ins().brif(eq, alt_block, &[], next_check_block, &[]);
+                }
+                Literal::LitString(_) => return Err(EmitError::NotYetImplemented("LitString in Case".into())),
+            }
+        }
+
+        // Emit alt body
+        builder.switch_to_block(alt_block);
+        builder.seal_block(alt_block);
+        let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, alt.body)?;
+        let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, result);
+        builder.ins().jump(merge_block, &[result_ptr]);
+
+        // Continue to next check
+        builder.switch_to_block(next_check_block);
+        builder.seal_block(next_check_block);
+    }
+
+    // Default or trap
+    if let Some(alt) = default_alt {
+        let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, alt.body)?;
+        let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, result);
+        builder.ins().jump(merge_block, &[result_ptr]);
+    } else {
+        builder.ins().trap(TrapCode::unwrap_user(2));
+    }
+
+    Ok(())
+}

--- a/codegen/src/emit/expr.rs
+++ b/codegen/src/emit/expr.rs
@@ -339,7 +339,9 @@ impl EmitContext {
                 }
                 Ok(body_val)
             }
-            CoreFrame::Case { .. } => Err(EmitError::NotYetImplemented("Case".into())),
+            CoreFrame::Case { scrutinee, binder, alts } => {
+                crate::emit::case::emit_case(self, pipeline, builder, vmctx, gc_sig, tree, *scrutinee, binder, alts)
+            }
             CoreFrame::Join { label, params, rhs, body } => {
                 crate::emit::join::emit_join(self, pipeline, builder, vmctx, gc_sig, tree, label, params, *rhs, *body)
             }

--- a/codegen/src/emit/mod.rs
+++ b/codegen/src/emit/mod.rs
@@ -1,5 +1,6 @@
 pub mod expr;
 pub mod primop;
+pub mod case;
 pub mod join;
 
 use cranelift_codegen::ir::Value;

--- a/codegen/tests/emit_case.rs
+++ b/codegen/tests/emit_case.rs
@@ -1,0 +1,215 @@
+use codegen::context::VMContext;
+use codegen::pipeline::CodegenPipeline;
+use codegen::host_fns;
+use codegen::emit::expr::compile_expr;
+use core_repr::*;
+use core_heap::layout;
+
+struct TestResult {
+    result_ptr: *const u8,
+    _nursery: Vec<u8>,
+    _pipeline: CodegenPipeline,
+}
+
+/// Helper: set up pipeline + nursery, compile expr, call it, return result ptr.
+fn compile_and_run(tree: &CoreExpr) -> TestResult {
+    let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
+    let func_id = compile_expr(&mut pipeline, tree, "test_fn").expect("compile_expr failed");
+    pipeline.finalize();
+    
+    let mut nursery = vec![0u8; 65536]; // 64KB nursery
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(nursery.len()) };
+    let mut vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+    
+    let ptr = pipeline.get_function_ptr(func_id);
+    let func: unsafe extern "C" fn(*mut VMContext) -> i64 = unsafe { std::mem::transmute(ptr) };
+    let result = unsafe { func(&mut vmctx as *mut VMContext) };
+    
+    TestResult {
+        result_ptr: result as *const u8,
+        _nursery: nursery,
+        _pipeline: pipeline,
+    }
+}
+
+/// Helper: read i64 value from a LitObject.
+unsafe fn read_lit_int(ptr: *const u8) -> i64 {
+    assert_eq!(layout::read_tag(ptr), layout::TAG_LIT);
+    *(ptr.add(16) as *const i64)
+}
+
+/// Helper: read con_tag from a ConObject.
+unsafe fn read_con_tag(ptr: *const u8) -> u64 {
+    assert_eq!(layout::read_tag(ptr), layout::TAG_CON);
+    *(ptr.add(8) as *const u64)
+}
+
+#[test]
+fn test_case_three_constructors() {
+    // case Con(1, []) of { DataAlt(0) -> 10; DataAlt(1) -> 20; DataAlt(2) -> 30 }
+    // With con_tag=1, should return 20
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Con { tag: DataConId(1), fields: vec![] },  // 0: scrutinee
+        CoreFrame::Lit(Literal::LitInt(10)),                    // 1: alt 0 body
+        CoreFrame::Lit(Literal::LitInt(20)),                    // 2: alt 1 body
+        CoreFrame::Lit(Literal::LitInt(30)),                    // 3: alt 2 body
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(DataConId(0)), binders: vec![], body: 1 },
+                Alt { con: AltCon::DataAlt(DataConId(1)), binders: vec![], body: 2 },
+                Alt { con: AltCon::DataAlt(DataConId(2)), binders: vec![], body: 3 },
+            ],
+        },                                                      // 4: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 20); }
+}
+
+#[test]
+fn test_case_default_catches_unmatched() {
+    // case Con(5, []) of { DataAlt(0) -> 10; Default -> 99 }
+    // Con tag 5 doesn't match alt 0, so default fires
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Con { tag: DataConId(5), fields: vec![] },
+        CoreFrame::Lit(Literal::LitInt(10)),
+        CoreFrame::Lit(Literal::LitInt(99)),
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(DataConId(0)), binders: vec![], body: 1 },
+                Alt { con: AltCon::Default, binders: vec![], body: 2 },
+            ],
+        },
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 99); }
+}
+
+#[test]
+fn test_case_field_binding() {
+    // case Con(0, [Lit(1), Lit(2)]) of { DataAlt(0) [a, b] -> a + b }
+    // Should return 3
+    let a = VarId(1);
+    let b = VarId(2);
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(1)),                     // 0
+        CoreFrame::Lit(Literal::LitInt(2)),                     // 1
+        CoreFrame::Con { tag: DataConId(0), fields: vec![0, 1] }, // 2: scrutinee
+        CoreFrame::Var(a),                                       // 3
+        CoreFrame::Var(b),                                       // 4
+        CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![3, 4] }, // 5: a + b
+        CoreFrame::Case {
+            scrutinee: 2,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(DataConId(0)), binders: vec![a, b], body: 5 },
+            ],
+        },                                                       // 6: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 3); }
+}
+
+#[test]
+fn test_case_nested() {
+    let x = VarId(1);
+    let outer_binder = VarId(98);
+    let inner_binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Con { tag: DataConId(1), fields: vec![] },   // 0: inner con
+        CoreFrame::Con { tag: DataConId(0), fields: vec![0] },  // 1: outer con (scrutinee)
+        CoreFrame::Lit(Literal::LitInt(42)),                     // 2: innermost body
+        CoreFrame::Var(x),                                       // 3: reference to x for inner scrutinee
+        CoreFrame::Case {                                        // 4: inner case
+            scrutinee: 3,
+            binder: inner_binder,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(DataConId(1)), binders: vec![], body: 2 },
+            ],
+        },
+        CoreFrame::Case {                                        // 5: outer case (root)
+            scrutinee: 1,
+            binder: outer_binder,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(DataConId(0)), binders: vec![x], body: 4 },
+            ],
+        },
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}
+
+#[test]
+fn test_case_lit_alt() {
+    // case Lit(42) of { LitAlt(0) -> 10; LitAlt(42) -> 99; Default -> 0 }
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(42)),                     // 0: scrutinee
+        CoreFrame::Lit(Literal::LitInt(10)),                     // 1: alt 0 body
+        CoreFrame::Lit(Literal::LitInt(99)),                     // 2: alt 42 body
+        CoreFrame::Lit(Literal::LitInt(0)),                      // 3: default body
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::LitAlt(Literal::LitInt(0)), binders: vec![], body: 1 },
+                Alt { con: AltCon::LitAlt(Literal::LitInt(42)), binders: vec![], body: 2 },
+                Alt { con: AltCon::Default, binders: vec![], body: 3 },
+            ],
+        },                                                        // 4: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 99); }
+}
+
+#[test]
+fn test_case_default_only() {
+    // case Lit(42) of { Default -> 100 }
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(42)),
+        CoreFrame::Lit(Literal::LitInt(100)),
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::Default, binders: vec![], body: 1 },
+            ],
+        },
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 100); }
+}
+
+#[test]
+fn test_case_binder_used() {
+    // case Con(0, [Lit(7)]) of x { DataAlt(0) [_] -> x }
+    // Case binder x = the whole scrutinee Con object
+    let x = VarId(1);
+    let dummy = VarId(2);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(7)),                      // 0
+        CoreFrame::Con { tag: DataConId(0), fields: vec![0] },  // 1: scrutinee
+        CoreFrame::Var(x),                                       // 2: body uses case binder
+        CoreFrame::Case {
+            scrutinee: 1,
+            binder: x,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(DataConId(0)), binders: vec![dummy], body: 2 },
+            ],
+        },                                                        // 3: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe {
+        // Result should be the Con object itself
+        assert_eq!(layout::read_tag(result.result_ptr), layout::TAG_CON);
+        assert_eq!(read_con_tag(result.result_ptr), 0);
+    }
+}


### PR DESCRIPTION
Implement Case dispatch for the CoreExpr to Cranelift IR emitter.

- **DataAlt Dispatch:** Uses  for O(1) constructor matching based on con_tag.
- **LitAlt Dispatch:** Uses a sequential comparison chain for literal values.
- **GC Safety:** Explicitly declares stack maps for all heap pointer SSA values, including block parameters and loaded fields.
- **Integration Tests:** Comprehensive tests in  covering constructor matching, field binding, literal matching, default branches, and nested case expressions.