### PR TITLE
feat(error): replace stringly-typed errors with structured variants

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "exomonad": {
-      "httpUrl": "http://localhost:7432/agents/dev/yield/mcp"
+      "httpUrl": "http://localhost:7432/agents/dev/structured-errors/mcp"
     }
   },
   "hooks": {

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "exomonad": {
-      "httpUrl": "http://localhost:7432/agents/dev/structured-errors/mcp"
+      "httpUrl": "http://localhost:7432/agents/dev/yield/mcp"
     }
   },
   "hooks": {

--- a/codegen/src/effect_machine.rs
+++ b/codegen/src/effect_machine.rs
@@ -1,6 +1,21 @@
 use crate::context::VMContext;
 use crate::yield_type::{Yield, YieldError};
 
+/// Constructor tags for the freer-simple Eff type.
+///
+/// These identify which DataCon a heap-allocated constructor represents,
+/// allowing the effect machine to distinguish Val (pure result) from
+/// E (effect request) and destructure Union wrappers.
+#[derive(Debug, Clone, Copy)]
+pub struct ConTags {
+    /// Con_tag for the Val constructor (pure result).
+    pub val: u64,
+    /// Con_tag for the E constructor (effect request).
+    pub e: u64,
+    /// Con_tag for the Union constructor (effect type wrapper).
+    pub union: u64,
+}
+
 /// Compiled effect machine — drives JIT-compiled freer-simple effect stacks.
 ///
 /// The step/resume protocol:
@@ -18,7 +33,7 @@ pub struct CompiledEffectMachine {
     vmctx: VMContext,
     /// Con_tag value for Val constructor.
     val_con_tag: u64,
-    /// Con_tag value for E constructor.  
+    /// Con_tag value for E constructor.
     e_con_tag: u64,
     /// Con_tag value for Union constructor.
     #[allow(dead_code)]
@@ -33,16 +48,14 @@ impl CompiledEffectMachine {
     pub fn new(
         func_ptr: unsafe extern "C" fn(*mut VMContext) -> *mut u8,
         vmctx: VMContext,
-        val_con_tag: u64,
-        e_con_tag: u64,
-        union_con_tag: u64,
+        tags: ConTags,
     ) -> Self {
         Self {
             func_ptr,
             vmctx,
-            val_con_tag,
-            e_con_tag,
-            union_con_tag,
+            val_con_tag: tags.val,
+            e_con_tag: tags.e,
+            union_con_tag: tags.union,
         }
     }
 

--- a/codegen/src/yield_type.rs
+++ b/codegen/src/yield_type.rs
@@ -14,6 +14,26 @@ pub enum Yield {
     Error(YieldError),
 }
 
+impl std::fmt::Display for Yield {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Yield::Done(ptr) => write!(f, "Done({:p})", ptr),
+            Yield::Request {
+                tag,
+                request,
+                continuation,
+            } => {
+                write!(
+                    f,
+                    "Request(tag={}, req={:p}, cont={:p})",
+                    tag, request, continuation
+                )
+            }
+            Yield::Error(e) => write!(f, "Error({})", e),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum YieldError {
     /// Result HeapObject had unexpected tag byte.
@@ -24,8 +44,27 @@ pub enum YieldError {
     BadValFields(u16),
     /// E constructor had wrong number of fields.
     BadEFields(u16),
-    /// Union constructor had wrong number of fields.  
+    /// Union constructor had wrong number of fields.
     BadUnionFields(u16),
     /// Null pointer encountered.
     NullPointer,
 }
+
+impl std::fmt::Display for YieldError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            YieldError::UnexpectedTag(tag) => write!(f, "unexpected heap tag: {}", tag),
+            YieldError::UnexpectedConTag(tag) => write!(f, "unexpected constructor tag: {}", tag),
+            YieldError::BadValFields(n) => {
+                write!(f, "Val constructor has {} fields, expected >= 1", n)
+            }
+            YieldError::BadEFields(n) => write!(f, "E constructor has {} fields, expected 2", n),
+            YieldError::BadUnionFields(n) => {
+                write!(f, "Union constructor has {} fields, expected 2", n)
+            }
+            YieldError::NullPointer => write!(f, "null pointer in effect result"),
+        }
+    }
+}
+
+impl std::error::Error for YieldError {}

--- a/codegen/tests/effect_machine.rs
+++ b/codegen/tests/effect_machine.rs
@@ -189,7 +189,15 @@ fn test_yield_done_val() {
     let end = unsafe { start.add(4096) };
     let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
 
-    let mut machine = CompiledEffectMachine::new(func, vmctx, VAL_CON_TAG, E_CON_TAG, UNION_CON_TAG);
+    let mut machine = CompiledEffectMachine::new(
+        func,
+        vmctx,
+        codegen::effect_machine::ConTags {
+            val: VAL_CON_TAG,
+            e: E_CON_TAG,
+            union: UNION_CON_TAG,
+        },
+    );
     let result = machine.step();
 
     match result {
@@ -224,7 +232,15 @@ fn test_yield_request_e() {
     let end = unsafe { start.add(4096) };
     let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
 
-    let mut machine = CompiledEffectMachine::new(func, vmctx, VAL_CON_TAG, E_CON_TAG, UNION_CON_TAG);
+    let mut machine = CompiledEffectMachine::new(
+        func,
+        vmctx,
+        codegen::effect_machine::ConTags {
+            val: VAL_CON_TAG,
+            e: E_CON_TAG,
+            union: UNION_CON_TAG,
+        },
+    );
     let result = machine.step();
 
     match result {
@@ -264,7 +280,15 @@ fn test_unexpected_tag() {
     let end = unsafe { start.add(4096) };
     let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
 
-    let mut machine = CompiledEffectMachine::new(func, vmctx, VAL_CON_TAG, E_CON_TAG, UNION_CON_TAG);
+    let mut machine = CompiledEffectMachine::new(
+        func,
+        vmctx,
+        codegen::effect_machine::ConTags {
+            val: VAL_CON_TAG,
+            e: E_CON_TAG,
+            union: UNION_CON_TAG,
+        },
+    );
     let result = machine.step();
 
     assert_eq!(result, Yield::Error(YieldError::UnexpectedTag(TAG_LIT)));
@@ -284,7 +308,15 @@ fn test_unexpected_con_tag() {
     let end = unsafe { start.add(4096) };
     let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
 
-    let mut machine = CompiledEffectMachine::new(func, vmctx, VAL_CON_TAG, E_CON_TAG, UNION_CON_TAG);
+    let mut machine = CompiledEffectMachine::new(
+        func,
+        vmctx,
+        codegen::effect_machine::ConTags {
+            val: VAL_CON_TAG,
+            e: E_CON_TAG,
+            union: UNION_CON_TAG,
+        },
+    );
     let result = machine.step();
 
     assert_eq!(result, Yield::Error(YieldError::UnexpectedConTag(999)));

--- a/core-effect/src/error.rs
+++ b/core-effect/src/error.rs
@@ -5,9 +5,24 @@ use core_eval::error::EvalError;
 pub enum EffectError {
     Eval(EvalError),
     Bridge(BridgeError),
-    UnhandledEffect { tag: u64 },
-    BadContinuation(String),
-    BadUnion(String),
+    UnhandledEffect {
+        tag: u64,
+    },
+    /// A required constructor was not found in the DataConTable.
+    MissingConstructor {
+        name: &'static str,
+    },
+    /// A constructor had the wrong number of fields.
+    FieldCountMismatch {
+        constructor: &'static str,
+        expected: usize,
+        got: usize,
+    },
+    /// Encountered an unexpected value shape during dispatch.
+    UnexpectedValue {
+        context: &'static str,
+        got: String,
+    },
 }
 
 impl From<EvalError> for EffectError {
@@ -28,8 +43,19 @@ impl std::fmt::Display for EffectError {
             EffectError::Eval(e) => write!(f, "Eval error: {}", e),
             EffectError::Bridge(e) => write!(f, "Bridge error: {}", e),
             EffectError::UnhandledEffect { tag } => write!(f, "Unhandled effect at tag {}", tag),
-            EffectError::BadContinuation(s) => write!(f, "Bad continuation: {}", s),
-            EffectError::BadUnion(s) => write!(f, "Bad union: {}", s),
+            EffectError::MissingConstructor { name } => {
+                write!(f, "{} constructor not found in DataConTable", name)
+            }
+            EffectError::FieldCountMismatch {
+                constructor,
+                expected,
+                got,
+            } => {
+                write!(f, "{} expects {} fields, got {}", constructor, expected, got)
+            }
+            EffectError::UnexpectedValue { context, got } => {
+                write!(f, "expected {}, got {}", context, got)
+            }
         }
     }
 }

--- a/core-effect/src/machine.rs
+++ b/core-effect/src/machine.rs
@@ -18,23 +18,19 @@ impl<'a> EffectMachine<'a> {
     pub fn new(table: &'a DataConTable, heap: &'a mut dyn Heap) -> Result<Self, EffectError> {
         let val_id = table
             .get_by_name("Val")
-            .ok_or_else(|| {
-                EffectError::BadUnion("Val constructor not found in DataConTable".into())
-            })?;
+            .ok_or_else(|| EffectError::MissingConstructor { name: "Val" })?;
         let e_id = table
             .get_by_name("E")
-            .ok_or_else(|| {
-                EffectError::BadUnion("E constructor not found in DataConTable".into())
-            })?;
+            .ok_or_else(|| EffectError::MissingConstructor { name: "E" })?;
         let leaf_id = table
             .get_by_name("Leaf")
-            .ok_or_else(|| EffectError::BadContinuation("Leaf constructor not found".into()))?;
+            .ok_or_else(|| EffectError::MissingConstructor { name: "Leaf" })?;
         let node_id = table
             .get_by_name("Node")
-            .ok_or_else(|| EffectError::BadContinuation("Node constructor not found".into()))?;
+            .ok_or_else(|| EffectError::MissingConstructor { name: "Node" })?;
         let union_id = table
             .get_by_name("Union")
-            .ok_or_else(|| EffectError::BadUnion("Union constructor not found".into()))?;
+            .ok_or_else(|| EffectError::MissingConstructor { name: "Union" })?;
         Ok(Self {
             table,
             heap,
@@ -69,10 +65,11 @@ impl<'a> EffectMachine<'a> {
                 Value::Con(id, ref fields) if id == self.e_id => {
                     // E (Union tag# req) k
                     if fields.len() != 2 {
-                        return Err(EffectError::BadUnion(format!(
-                            "E expects 2 fields, got {}",
-                            fields.len()
-                        )));
+                        return Err(EffectError::FieldCountMismatch {
+                            constructor: "E",
+                            expected: 2,
+                            got: fields.len(),
+                        });
                     }
                     let union_val = core_eval::eval::deep_force(fields[0].clone(), self.heap)?;
                     let k = core_eval::eval::force(fields[1].clone(), self.heap)?;
@@ -81,19 +78,20 @@ impl<'a> EffectMachine<'a> {
                     let (tag, request) = match union_val {
                         Value::Con(uid, ref ufields) if uid == self.union_id => {
                             if ufields.len() != 2 {
-                                return Err(EffectError::BadUnion(format!(
-                                    "Union expects 2 fields, got {}",
-                                    ufields.len()
-                                )));
+                                return Err(EffectError::FieldCountMismatch {
+                                    constructor: "Union",
+                                    expected: 2,
+                                    got: ufields.len(),
+                                });
                             }
                             let tag = match &ufields[0] {
                                 Value::Lit(core_repr::Literal::LitWord(w)) => *w,
                                 Value::Lit(core_repr::Literal::LitInt(i)) => *i as u64,
                                 other => {
-                                    return Err(EffectError::BadUnion(format!(
-                                        "Union tag must be Word#/Int#, got {:?}",
-                                        other
-                                    )))
+                                    return Err(EffectError::UnexpectedValue {
+                                        context: "Union tag (Word#/Int#)",
+                                        got: format!("{:?}", other),
+                                    })
                                 }
                             };
                             // deep_force the request so FromCore never sees ThunkRef
@@ -101,10 +99,10 @@ impl<'a> EffectMachine<'a> {
                             (tag, req)
                         }
                         other => {
-                            return Err(EffectError::BadUnion(format!(
-                                "Expected Union constructor, got {:?}",
-                                other
-                            )))
+                            return Err(EffectError::UnexpectedValue {
+                                context: "Union constructor",
+                                got: format!("{:?}", other),
+                            })
                         }
                     };
 
@@ -115,10 +113,10 @@ impl<'a> EffectMachine<'a> {
                     current = self.apply_cont(k, response)?;
                 }
                 other => {
-                    return Err(EffectError::BadUnion(format!(
-                        "Expected Val or E constructor, got {:?}",
-                        other
-                    )));
+                    return Err(EffectError::UnexpectedValue {
+                        context: "Val or E constructor",
+                        got: format!("{:?}", other),
+                    });
                 }
             }
         }
@@ -131,10 +129,11 @@ impl<'a> EffectMachine<'a> {
             Value::Con(id, ref fields) if id == self.leaf_id => {
                 // Leaf(f) — apply f to arg
                 if fields.len() != 1 {
-                    return Err(EffectError::BadContinuation(format!(
-                        "Leaf expects 1 field, got {}",
-                        fields.len()
-                    )));
+                    return Err(EffectError::FieldCountMismatch {
+                        constructor: "Leaf",
+                        expected: 1,
+                        got: fields.len(),
+                    });
                 }
                 let f = core_eval::eval::force(fields[0].clone(), self.heap)?;
                 Ok(self.apply_closure(f, arg)?)
@@ -142,10 +141,11 @@ impl<'a> EffectMachine<'a> {
             Value::Con(id, ref fields) if id == self.node_id => {
                 // Node(k1, k2) — apply k1, then compose with k2
                 if fields.len() != 2 {
-                    return Err(EffectError::BadContinuation(format!(
-                        "Node expects 2 fields, got {}",
-                        fields.len()
-                    )));
+                    return Err(EffectError::FieldCountMismatch {
+                        constructor: "Node",
+                        expected: 2,
+                        got: fields.len(),
+                    });
                 }
                 let k1 = fields[0].clone();
                 let k2 = fields[1].clone();
@@ -164,29 +164,31 @@ impl<'a> EffectMachine<'a> {
                     Value::Con(eid, ref efields) if eid == self.e_id => {
                         // k1 yielded E(union, k') — compose: E(union, Node(k', k2))
                         if efields.len() != 2 {
-                            return Err(EffectError::BadContinuation(
-                                "E in continuation expects 2 fields".into(),
-                            ));
+                            return Err(EffectError::FieldCountMismatch {
+                                constructor: "E (continuation)",
+                                expected: 2,
+                                got: efields.len(),
+                            });
                         }
                         let union_val = efields[0].clone();
                         let k_prime = efields[1].clone();
                         let new_k = Value::Con(self.node_id, vec![k_prime, k2]);
                         Ok(Value::Con(self.e_id, vec![union_val, new_k]))
                     }
-                    other => Err(EffectError::BadContinuation(format!(
-                        "Expected Val or E after applying k1, got {:?}",
-                        other
-                    ))),
+                    other => Err(EffectError::UnexpectedValue {
+                        context: "Val or E after applying k1",
+                        got: format!("{:?}", other),
+                    }),
                 }
             }
             Value::Closure(..) => {
                 // Raw closure (degenerate continuation)
                 Ok(self.apply_closure(k, arg)?)
             }
-            other => Err(EffectError::BadContinuation(format!(
-                "Expected Leaf or Node, got {:?}",
-                other
-            ))),
+            other => Err(EffectError::UnexpectedValue {
+                context: "Leaf or Node continuation",
+                got: format!("{:?}", other),
+            }),
         }
     }
 
@@ -205,10 +207,10 @@ impl<'a> EffectMachine<'a> {
                     Ok(Value::ConFun(tag, arity, args))
                 }
             }
-            other => Err(EffectError::BadContinuation(format!(
-                "Expected closure, got {:?}",
-                other
-            ))),
+            other => Err(EffectError::UnexpectedValue {
+                context: "closure",
+                got: format!("{:?}", other),
+            }),
         }
     }
 }

--- a/core-eval/src/error.rs
+++ b/core-eval/src/error.rs
@@ -1,13 +1,45 @@
 use crate::value::ThunkId;
 use core_repr::{JoinId, PrimOpKind, VarId};
 
+/// Describes the kind of a Value for error reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValueKind {
+    Literal(&'static str), // "Int#", "Word#", "Double#", "Char#", "String"
+    Constructor,
+    Closure,
+    Thunk,
+    /// Fallback for complex values — stores Debug output
+    Other(String),
+}
+
+impl std::fmt::Display for ValueKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValueKind::Literal(name) => write!(f, "{}", name),
+            ValueKind::Constructor => write!(f, "constructor"),
+            ValueKind::Closure => write!(f, "closure"),
+            ValueKind::Thunk => write!(f, "thunk"),
+            ValueKind::Other(s) => write!(f, "{}", s),
+        }
+    }
+}
+
 /// Evaluation error.
 #[derive(Debug, Clone)]
 pub enum EvalError {
     /// Variable not found in environment
     UnboundVar(VarId),
+    /// Arity mismatch (wrong number of arguments or fields)
+    ArityMismatch {
+        context: &'static str, // "arguments", "fields", "case binders"
+        expected: usize,
+        got: usize,
+    },
     /// Type mismatch during evaluation
-    TypeMismatch { expected: String, got: String },
+    TypeMismatch {
+        expected: &'static str,
+        got: ValueKind,
+    },
     /// No matching alternative in case expression
     NoMatchingAlt,
     /// Infinite loop detected (thunk forced itself)
@@ -26,6 +58,17 @@ impl std::fmt::Display for EvalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EvalError::UnboundVar(v) => write!(f, "unbound variable: v_{}", v.0),
+            EvalError::ArityMismatch {
+                context,
+                expected,
+                got,
+            } => {
+                write!(
+                    f,
+                    "arity mismatch: expected {} {}, got {}",
+                    expected, context, got
+                )
+            }
             EvalError::TypeMismatch { expected, got } => {
                 write!(f, "type mismatch: expected {}, got {}", expected, got)
             }
@@ -49,9 +92,14 @@ mod tests {
     fn test_error_display() {
         let errs = vec![
             EvalError::UnboundVar(VarId(42)),
+            EvalError::ArityMismatch {
+                context: "arguments",
+                expected: 2,
+                got: 1,
+            },
             EvalError::TypeMismatch {
-                expected: "Int".to_string(),
-                got: "Char".to_string(),
+                expected: "Int#",
+                got: ValueKind::Literal("Char#"),
             },
             EvalError::NoMatchingAlt,
             EvalError::InfiniteLoop(ThunkId(0)),

--- a/core-eval/src/eval.rs
+++ b/core-eval/src/eval.rs
@@ -26,8 +26,8 @@ pub fn env_from_datacon_table(table: &DataConTable) -> Env {
 pub fn eval(expr: &CoreExpr, env: &Env, heap: &mut dyn Heap) -> Result<Value, EvalError> {
     if expr.nodes.is_empty() {
         return Err(EvalError::TypeMismatch {
-            expected: "non-empty expression".into(),
-            got: "empty expression".into(),
+            expected: "non-empty expression",
+            got: crate::error::ValueKind::Other("empty tree".into()),
         });
     }
     let res = eval_at(expr, expr.nodes.len() - 1, env, heap)?;
@@ -187,9 +187,10 @@ fn eval_at(
                         if let Value::Con(con_tag, fields) = &scrut_val {
                             if con_tag == tag {
                                 if fields.len() != alt.binders.len() {
-                                    return Err(EvalError::TypeMismatch {
-                                        expected: format!("{} fields", alt.binders.len()),
-                                        got: format!("{} fields", fields.len()),
+                                    return Err(EvalError::ArityMismatch {
+                                        context: "case binders",
+                                        expected: alt.binders.len(),
+                                        got: fields.len(),
                                     });
                                 }
                                 let mut alt_env = case_env;
@@ -241,9 +242,10 @@ fn eval_at(
             match env.get(&join_var) {
                 Some(Value::JoinCont(params, rhs_expr, join_env)) => {
                     if params.len() != args.len() {
-                        return Err(EvalError::TypeMismatch {
-                            expected: format!("{} arguments", params.len()),
-                            got: format!("{} arguments", args.len()),
+                        return Err(EvalError::ArityMismatch {
+                            context: "arguments",
+                            expected: params.len(),
+                            got: args.len(),
                         });
                     }
                     let params = params.clone();
@@ -277,9 +279,10 @@ fn dispatch_primop(op: PrimOpKind, args: Vec<Value>) -> Result<Value, EvalError>
         }
         PrimOpKind::IntNegate => {
             if args.len() != 1 {
-                return Err(EvalError::TypeMismatch {
-                    expected: "1 argument".into(),
-                    got: format!("{} arguments", args.len()),
+                return Err(EvalError::ArityMismatch {
+                    context: "arguments",
+                    expected: 1,
+                    got: args.len(),
                 });
             }
             let a = expect_int(&args[0])?;
@@ -343,26 +346,28 @@ fn dispatch_primop(op: PrimOpKind, args: Vec<Value>) -> Result<Value, EvalError>
 
         PrimOpKind::SeqOp => {
             if args.len() != 2 {
-                return Err(EvalError::TypeMismatch {
-                    expected: "2 arguments".into(),
-                    got: format!("{} arguments", args.len()),
+                return Err(EvalError::ArityMismatch {
+                    context: "arguments",
+                    expected: 2,
+                    got: args.len(),
                 });
             }
             Ok(args[1].clone())
         }
         PrimOpKind::DataToTag => {
             if args.len() != 1 {
-                return Err(EvalError::TypeMismatch {
-                    expected: "1 argument".into(),
-                    got: format!("{} arguments", args.len()),
+                return Err(EvalError::ArityMismatch {
+                    context: "arguments",
+                    expected: 1,
+                    got: args.len(),
                 });
             }
             if let Value::Con(DataConId(tag), _) = &args[0] {
                 Ok(Value::Lit(Literal::LitInt(*tag as i64)))
             } else {
                 Err(EvalError::TypeMismatch {
-                    expected: "Data constructor".into(),
-                    got: format!("{:?}", args[0]),
+                    expected: "Data constructor",
+                    got: crate::error::ValueKind::Other(format!("{:?}", args[0])),
                 })
             }
         }
@@ -375,8 +380,8 @@ fn expect_int(v: &Value) -> Result<i64, EvalError> {
         Ok(*n)
     } else {
         Err(EvalError::TypeMismatch {
-            expected: "Int#".into(),
-            got: format!("{:?}", v),
+            expected: "Int#",
+            got: crate::error::ValueKind::Other(format!("{:?}", v)),
         })
     }
 }
@@ -386,8 +391,8 @@ fn expect_word(v: &Value) -> Result<u64, EvalError> {
         Ok(*n)
     } else {
         Err(EvalError::TypeMismatch {
-            expected: "Word#".into(),
-            got: format!("{:?}", v),
+            expected: "Word#",
+            got: crate::error::ValueKind::Other(format!("{:?}", v)),
         })
     }
 }
@@ -397,8 +402,8 @@ fn expect_double(v: &Value) -> Result<f64, EvalError> {
         Ok(f64::from_bits(*bits))
     } else {
         Err(EvalError::TypeMismatch {
-            expected: "Double#".into(),
-            got: format!("{:?}", v),
+            expected: "Double#",
+            got: crate::error::ValueKind::Other(format!("{:?}", v)),
         })
     }
 }
@@ -408,17 +413,18 @@ fn expect_char(v: &Value) -> Result<char, EvalError> {
         Ok(*c)
     } else {
         Err(EvalError::TypeMismatch {
-            expected: "Char#".into(),
-            got: format!("{:?}", v),
+            expected: "Char#",
+            got: crate::error::ValueKind::Other(format!("{:?}", v)),
         })
     }
 }
 
 fn bin_op_int(_op: PrimOpKind, args: &[Value]) -> Result<(i64, i64), EvalError> {
     if args.len() != 2 {
-        return Err(EvalError::TypeMismatch {
-            expected: "2 arguments".into(),
-            got: format!("{} arguments", args.len()),
+        return Err(EvalError::ArityMismatch {
+            context: "arguments",
+            expected: 2,
+            got: args.len(),
         });
     }
     Ok((expect_int(&args[0])?, expect_int(&args[1])?))
@@ -426,9 +432,10 @@ fn bin_op_int(_op: PrimOpKind, args: &[Value]) -> Result<(i64, i64), EvalError> 
 
 fn bin_op_word(_op: PrimOpKind, args: &[Value]) -> Result<(u64, u64), EvalError> {
     if args.len() != 2 {
-        return Err(EvalError::TypeMismatch {
-            expected: "2 arguments".into(),
-            got: format!("{} arguments", args.len()),
+        return Err(EvalError::ArityMismatch {
+            context: "arguments",
+            expected: 2,
+            got: args.len(),
         });
     }
     Ok((expect_word(&args[0])?, expect_word(&args[1])?))
@@ -436,9 +443,10 @@ fn bin_op_word(_op: PrimOpKind, args: &[Value]) -> Result<(u64, u64), EvalError>
 
 fn bin_op_double(_op: PrimOpKind, args: &[Value]) -> Result<(f64, f64), EvalError> {
     if args.len() != 2 {
-        return Err(EvalError::TypeMismatch {
-            expected: "2 arguments".into(),
-            got: format!("{} arguments", args.len()),
+        return Err(EvalError::ArityMismatch {
+            context: "arguments",
+            expected: 2,
+            got: args.len(),
         });
     }
     Ok((expect_double(&args[0])?, expect_double(&args[1])?))
@@ -477,9 +485,10 @@ fn cmp_char(
     f: impl Fn(char, char) -> bool,
 ) -> Result<Value, EvalError> {
     if args.len() != 2 {
-        return Err(EvalError::TypeMismatch {
-            expected: "2 arguments".into(),
-            got: format!("{} arguments", args.len()),
+        return Err(EvalError::ArityMismatch {
+            context: "arguments",
+            expected: 2,
+            got: args.len(),
         });
     }
     let a = expect_char(&args[0])?;
@@ -1026,6 +1035,6 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap);
-        assert!(matches!(res, Err(EvalError::TypeMismatch { .. })));
+        assert!(matches!(res, Err(EvalError::ArityMismatch { .. })));
     }
 }


### PR DESCRIPTION
Replaces stringly-typed error variants with structured types across core-eval, core-effect, and codegen crates.

## Changes

- **core-eval**: 
  - Added `ValueKind` enum for detailed type mismatch reporting.
  - Split `EvalError::TypeMismatch` into `ArityMismatch` and structured `TypeMismatch`.
  - Updated all eval callsites to use structured errors.
- **core-effect**:
  - Replaced `BadContinuation` and `BadUnion` with `MissingConstructor`, `FieldCountMismatch`, and `UnexpectedValue`.
  - Updated `EffectMachine` to provide more precise error reporting.
- **codegen**:
  - Implemented `Display` and `Error` traits for `YieldError` and `Yield`.
  - Introduced `ConTags` struct for `CompiledEffectMachine` to avoid positional u64 arguments.
  - Updated all JIT tests to use structured tags.

Verified with `cargo test` and `cargo check --workspace`.