### PR TITLE
feat(codegen): add IntQuot, IntRem, Chr, Ord primops and Box<T> bridge

### DIFF
--- a/codegen/src/emit/primop.rs
+++ b/codegen/src/emit/primop.rs
@@ -122,6 +122,28 @@ pub fn emit_primop(
             let tag = builder.ins().load(types::I64, MemFlags::trusted(), obj, CON_TAG_OFFSET);
             Ok(SsaVal::Raw(tag, LIT_TAG_INT))
         }
+        PrimOpKind::IntQuot => {
+            check_arity(op, 2, args.len())?;
+            let a = unbox_int(builder, args[0]);
+            let b = unbox_int(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().sdiv(a, b), LIT_TAG_INT))
+        }
+        PrimOpKind::IntRem => {
+            check_arity(op, 2, args.len())?;
+            let a = unbox_int(builder, args[0]);
+            let b = unbox_int(builder, args[1]);
+            Ok(SsaVal::Raw(builder.ins().srem(a, b), LIT_TAG_INT))
+        }
+        PrimOpKind::Chr => {
+            check_arity(op, 1, args.len())?;
+            let v = unbox_int(builder, args[0]);
+            Ok(SsaVal::Raw(v, LIT_TAG_CHAR))
+        }
+        PrimOpKind::Ord => {
+            check_arity(op, 1, args.len())?;
+            let v = unbox_int(builder, args[0]);
+            Ok(SsaVal::Raw(v, LIT_TAG_INT))
+        }
         PrimOpKind::TagToEnum | PrimOpKind::IndexArray | PrimOpKind::SeqOp => {
             Err(EmitError::NotYetImplemented(format!("{:?}", op)))
         }

--- a/codegen/src/heap_bridge.rs
+++ b/codegen/src/heap_bridge.rs
@@ -109,10 +109,18 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
                     *ptr.add(layout::LIT_TAG_OFFSET) = 4;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *bits as i64;
                 }
-                Literal::LitString(_) => {
-                    // LitString cannot be heap-allocated from host side (data section only)
-                    // For responses, strings are never sent back — only primitives and constructors
-                    return Err(BridgeError::UnexpectedLitTag(5));
+                Literal::LitString(bytes) => {
+                    // Allocate string data: [len: u64][bytes...]
+                    let data_size = 8 + bytes.len();
+                    let data_ptr = bump_alloc_from_vmctx(vmctx, data_size);
+                    *(data_ptr as *mut u64) = bytes.len() as u64;
+                    std::ptr::copy_nonoverlapping(
+                        bytes.as_ptr(),
+                        data_ptr.add(8),
+                        bytes.len(),
+                    );
+                    *ptr.add(layout::LIT_TAG_OFFSET) = 5;
+                    *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = data_ptr as i64;
                 }
             }
             Ok(ptr)

--- a/core-bridge/src/impls.rs
+++ b/core-bridge/src/impls.rs
@@ -55,6 +55,20 @@ impl<T> ToCore for std::marker::PhantomData<T> {
     }
 }
 
+// Box
+
+impl<T: FromCore> FromCore for Box<T> {
+    fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
+        T::from_value(value, table).map(Box::new)
+    }
+}
+
+impl<T: ToCore> ToCore for Box<T> {
+    fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        (**self).to_value(table)
+    }
+}
+
 // Unit
 
 impl ToCore for () {

--- a/core-eval/src/eval.rs
+++ b/core-eval/src/eval.rs
@@ -371,6 +371,38 @@ fn dispatch_primop(op: PrimOpKind, args: Vec<Value>) -> Result<Value, EvalError>
                 })
             }
         }
+        PrimOpKind::IntQuot => {
+            let (a, b) = bin_op_int(op, &args)?;
+            Ok(Value::Lit(Literal::LitInt(a.wrapping_div(b))))
+        }
+        PrimOpKind::IntRem => {
+            let (a, b) = bin_op_int(op, &args)?;
+            Ok(Value::Lit(Literal::LitInt(a.wrapping_rem(b))))
+        }
+        PrimOpKind::Chr => {
+            if args.len() != 1 {
+                return Err(EvalError::ArityMismatch {
+                    context: "arguments",
+                    expected: 1,
+                    got: args.len(),
+                });
+            }
+            let n = expect_int(&args[0])?;
+            Ok(Value::Lit(Literal::LitChar(
+                char::from_u32(n as u32).unwrap_or('\0'),
+            )))
+        }
+        PrimOpKind::Ord => {
+            if args.len() != 1 {
+                return Err(EvalError::ArityMismatch {
+                    context: "arguments",
+                    expected: 1,
+                    got: args.len(),
+                });
+            }
+            let c = expect_char(&args[0])?;
+            Ok(Value::Lit(Literal::LitInt(c as i64)))
+        }
         PrimOpKind::IndexArray | PrimOpKind::TagToEnum => Err(EvalError::UnsupportedPrimOp(op)),
     }
 }

--- a/core-repr/src/serial/mod.rs
+++ b/core-repr/src/serial/mod.rs
@@ -207,7 +207,7 @@ mod tests {
             WordSub, WordMul, WordEq, WordNe, WordLt, WordLe, WordGt, WordGe, DoubleAdd, DoubleSub,
             DoubleMul, DoubleDiv, DoubleEq, DoubleNe, DoubleLt, DoubleLe, DoubleGt, DoubleGe,
             CharEq, CharNe, CharLt, CharLe, CharGt, CharGe, IndexArray, SeqOp, TagToEnum,
-            DataToTag,
+            DataToTag, IntQuot, IntRem, Chr, Ord,
         ];
         for op in ops {
             roundtrip(RecursiveTree {

--- a/core-repr/src/serial/read.rs
+++ b/core-repr/src/serial/read.rs
@@ -612,6 +612,10 @@ fn decode_primop(s: &str) -> Result<PrimOpKind, ReadError> {
         "SeqOp" => Ok(SeqOp),
         "TagToEnum" => Ok(TagToEnum),
         "DataToTag" => Ok(DataToTag),
+        "IntQuot" => Ok(IntQuot),
+        "IntRem" => Ok(IntRem),
+        "Chr" => Ok(Chr),
+        "Ord" => Ok(PrimOpKind::Ord),
         _ => Err(ReadError::InvalidPrimOp(s.to_string())),
     }
 }

--- a/core-repr/src/serial/write.rs
+++ b/core-repr/src/serial/write.rs
@@ -184,6 +184,10 @@ fn encode_primop(op: &PrimOpKind) -> &'static str {
         SeqOp => "SeqOp",
         TagToEnum => "TagToEnum",
         DataToTag => "DataToTag",
+        IntQuot => "IntQuot",
+        IntRem => "IntRem",
+        Chr => "Chr",
+        Ord => "Ord",
     }
 }
 

--- a/core-repr/src/types.rs
+++ b/core-repr/src/types.rs
@@ -63,6 +63,10 @@ pub enum PrimOpKind {
     SeqOp,
     TagToEnum,
     DataToTag,
+    IntQuot,
+    IntRem,
+    Chr,
+    Ord,
 }
 
 /// Case alternative constructor.
@@ -157,6 +161,10 @@ impl std::fmt::Display for PrimOpKind {
             PrimOpKind::SeqOp => "seq",
             PrimOpKind::TagToEnum => "tagToEnum#",
             PrimOpKind::DataToTag => "dataToTag#",
+            PrimOpKind::IntQuot => "quotInt#",
+            PrimOpKind::IntRem => "remInt#",
+            PrimOpKind::Chr => "chr#",
+            PrimOpKind::Ord => "ord#",
         };
         f.write_str(name)
     }

--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -403,6 +403,10 @@ mapPrimOp = \case
   TagToEnumOp -> "TagToEnum"
   DataToTagSmallOp -> "DataToTag"
   DataToTagLargeOp -> "DataToTag"
+  IntQuotOp -> "IntQuot"
+  IntRemOp  -> "IntRem"
+  ChrOp     -> "Chr"
+  OrdOp     -> "Ord"
   other       -> error $ "Unsupported primop: " ++ showPprUnsafe other
 
 collectDataCons :: [TyCon] -> [(Word64, Text, Int, Int, [Text])]


### PR DESCRIPTION
## Summary
- Add 4 new primops across all layers (Translate.hs → core-repr → codegen emitter → core-eval interpreter):
  - `IntQuot` (`quotInt#`) → `sdiv`
  - `IntRem` (`remInt#`) → `srem`
  - `Chr` (`chr#`) → identity (Int# → Char#)
  - `Ord` (`ord#`) → identity (Char# → Int#)
- Fix `value_to_heap` LitString support in `codegen/src/heap_bridge.rs` — bump-allocates `[len:u64][bytes...]` in nursery
- Add `FromCore`/`ToCore` for `Box<T>` in `core-bridge/src/impls.rs`

## Test plan
- [x] `cargo test --workspace` passes (2 pre-existing gc_audit failures on main, unrelated)
- [x] Primop serial roundtrip test updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)