### PR TITLE
feat(runtime): implement compile_and_run, caching, and RuntimeError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +182,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -315,6 +341,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-bridge"
@@ -1978,6 +2010,10 @@ dependencies = [
 name = "tidepool-runtime"
 version = "0.1.0"
 dependencies = [
+ "blake3",
+ "codegen",
+ "core-effect",
+ "core-eval",
  "core-repr",
  "tempfile",
 ]

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -5,4 +5,8 @@ edition = "2021"
 
 [dependencies]
 core-repr = { path = "../core-repr" }
+core-eval = { path = "../core-eval" }
+core-effect = { path = "../core-effect" }
+codegen = { path = "../codegen" }
 tempfile = "3"
+blake3 = "1"

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -1,0 +1,37 @@
+use std::path::{Path, PathBuf};
+
+fn cache_dir() -> Option<PathBuf> {
+    std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+        .map(|d| d.join("tidepool"))
+}
+
+pub(crate) fn cache_key(source: &str, target: &str, include: &[&Path]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(source.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(target.as_bytes());
+    hasher.update(b"\0");
+    let mut sorted: Vec<&Path> = include.to_vec();
+    sorted.sort();
+    for p in &sorted {
+        hasher.update(p.as_os_str().as_encoded_bytes());
+        hasher.update(b"\0");
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+pub(crate) fn cache_load(key: &str) -> Option<(Vec<u8>, Vec<u8>)> {
+    let dir = cache_dir()?;
+    let expr_bytes = std::fs::read(dir.join(format!("{}.cbor", key))).ok()?;
+    let meta_bytes = std::fs::read(dir.join(format!("{}.meta.cbor", key))).ok()?;
+    Some((expr_bytes, meta_bytes))
+}
+
+pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
+    let Some(dir) = cache_dir() else { return };
+    if std::fs::create_dir_all(&dir).is_err() { return; }
+    let _ = std::fs::write(dir.join(format!("{}.cbor", key)), expr_bytes);
+    let _ = std::fs::write(dir.join(format!("{}.meta.cbor", key)), meta_bytes);
+}

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::fs;
 
+/// Returns the platform-specific cache directory for Tidepool.
+/// Following XDG conventions: `$XDG_CACHE_HOME/tidepool` or `~/.cache/tidepool`.
 fn cache_dir() -> Option<PathBuf> {
     std::env::var_os("XDG_CACHE_HOME")
         .map(PathBuf::from)
@@ -8,6 +10,9 @@ fn cache_dir() -> Option<PathBuf> {
         .map(|d| d.join("tidepool"))
 }
 
+/// Computes a unique cache key for a compilation request.
+/// The key includes the source code, the target binder, and a fingerprint of
+/// all include directories to ensure cache invalidation when dependencies change.
 pub(crate) fn cache_key(source: &str, target: &str, include: &[&Path]) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(source.as_bytes());
@@ -27,6 +32,8 @@ pub(crate) fn cache_key(source: &str, target: &str, include: &[&Path]) -> String
     hasher.finalize().to_hex().to_string()
 }
 
+/// Recursively walks a directory to fingerprint its contents.
+/// Considers file paths, sizes, and modification times of `.hs` and `.hs-boot` files.
 fn fingerprint_dir(dir: &Path, hasher: &mut blake3::Hasher) {
     let Ok(entries) = fs::read_dir(dir) else { return };
     let mut paths: Vec<_> = entries.filter_map(|e| e.ok()).collect();
@@ -52,6 +59,8 @@ fn fingerprint_dir(dir: &Path, hasher: &mut blake3::Hasher) {
     }
 }
 
+/// Attempts to load the Core expression and metadata from the cache.
+/// Returns `Some((expr_bytes, meta_bytes))` on success.
 pub(crate) fn cache_load(key: &str) -> Option<(Vec<u8>, Vec<u8>)> {
     let dir = cache_dir()?;
     let expr_bytes = fs::read(dir.join(format!("{}.cbor", key))).ok()?;
@@ -59,6 +68,7 @@ pub(crate) fn cache_load(key: &str) -> Option<(Vec<u8>, Vec<u8>)> {
     Some((expr_bytes, meta_bytes))
 }
 
+/// Stores the compilation results in the cache atomically.
 pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
     let Some(dir) = cache_dir() else { return };
     if fs::create_dir_all(&dir).is_err() { return; }
@@ -70,6 +80,8 @@ pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
     let _ = atomic_write(&meta_path, meta_bytes);
 }
 
+/// Writes data to a temporary file then renames it to the target path
+/// to ensure that readers never see partially written or corrupted files.
 fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
     let dir = path.parent().ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "no parent dir"))?;
     let mut temp = tempfile::NamedTempFile::new_in(dir)?;

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::fs;
 
 fn cache_dir() -> Option<PathBuf> {
     std::env::var_os("XDG_CACHE_HOME")
@@ -13,25 +14,119 @@ pub(crate) fn cache_key(source: &str, target: &str, include: &[&Path]) -> String
     hasher.update(b"\0");
     hasher.update(target.as_bytes());
     hasher.update(b"\0");
-    let mut sorted: Vec<&Path> = include.to_vec();
-    sorted.sort();
-    for p in &sorted {
-        hasher.update(p.as_os_str().as_encoded_bytes());
+
+    // Fingerprint include directories to catch changes in dependency modules.
+    let mut sorted_includes: Vec<&Path> = include.to_vec();
+    sorted_includes.sort();
+    for root in sorted_includes {
+        hasher.update(root.as_os_str().as_encoded_bytes());
         hasher.update(b"\0");
+        fingerprint_dir(root, &mut hasher);
     }
+
     hasher.finalize().to_hex().to_string()
+}
+
+fn fingerprint_dir(dir: &Path, hasher: &mut blake3::Hasher) {
+    let Ok(entries) = fs::read_dir(dir) else { return };
+    let mut paths: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    paths.sort_by_key(|e| e.path());
+
+    for entry in paths {
+        let path = entry.path();
+        if path.is_dir() {
+            fingerprint_dir(&path, hasher);
+        } else if let Some(ext) = path.extension() {
+            if ext == "hs" || ext == "hs-boot" {
+                if let Ok(meta) = entry.metadata() {
+                    hasher.update(path.as_os_str().as_encoded_bytes());
+                    hasher.update(&meta.len().to_le_bytes());
+                    if let Ok(mtime) = meta.modified() {
+                        if let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH) {
+                            hasher.update(&dur.as_nanos().to_le_bytes());
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 pub(crate) fn cache_load(key: &str) -> Option<(Vec<u8>, Vec<u8>)> {
     let dir = cache_dir()?;
-    let expr_bytes = std::fs::read(dir.join(format!("{}.cbor", key))).ok()?;
-    let meta_bytes = std::fs::read(dir.join(format!("{}.meta.cbor", key))).ok()?;
+    let expr_bytes = fs::read(dir.join(format!("{}.cbor", key))).ok()?;
+    let meta_bytes = fs::read(dir.join(format!("{}.meta.cbor", key))).ok()?;
     Some((expr_bytes, meta_bytes))
 }
 
 pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
     let Some(dir) = cache_dir() else { return };
-    if std::fs::create_dir_all(&dir).is_err() { return; }
-    let _ = std::fs::write(dir.join(format!("{}.cbor", key)), expr_bytes);
-    let _ = std::fs::write(dir.join(format!("{}.meta.cbor", key)), meta_bytes);
+    if fs::create_dir_all(&dir).is_err() { return; }
+
+    let expr_path = dir.join(format!("{}.cbor", key));
+    let meta_path = dir.join(format!("{}.meta.cbor", key));
+
+    let _ = atomic_write(&expr_path, expr_bytes);
+    let _ = atomic_write(&meta_path, meta_bytes);
+}
+
+fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let dir = path.parent().ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "no parent dir"))?;
+    let mut temp = tempfile::NamedTempFile::new_in(dir)?;
+    use std::io::Write;
+    temp.write_all(data)?;
+    temp.persist(path).map(|_| ()).map_err(|e| e.error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_cache_key_determinism() {
+        let source = "main = print 42";
+        let target = "main";
+        let k1 = cache_key(source, target, &[]);
+        let k2 = cache_key(source, target, &[]);
+        assert_eq!(k1, k2);
+        
+        let k3 = cache_key("main = print 43", target, &[]);
+        assert_ne!(k1, k3);
+    }
+
+    #[test]
+    fn test_cache_roundtrip() {
+        let temp_dir = TempDir::new().unwrap();
+        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+
+        let key = "test-key";
+        let expr = b"expr-data";
+        let meta = b"meta-data";
+
+        cache_store(key, expr, meta);
+        let loaded = cache_load(key).expect("cache should load after store");
+        assert_eq!(loaded.0, expr);
+        assert_eq!(loaded.1, meta);
+    }
+
+    #[test]
+    fn test_cache_key_include_fingerprint() {
+        let include_dir = TempDir::new().unwrap();
+        let hs_file = include_dir.path().join("Lib.hs");
+        fs::write(&hs_file, "module Lib where").unwrap();
+
+        let source = "import Lib\nmain = print 42";
+        let target = "main";
+        let includes = [include_dir.path()];
+
+        let k1 = cache_key(source, target, &includes);
+        
+        // Wait a bit to ensure mtime changes if we overwrite (though some filesystems have low precision)
+        // or just write different content/size.
+        fs::write(&hs_file, "module Lib where\nfoo = 1").unwrap();
+        let k2 = cache_key(source, target, &includes);
+        
+        assert_ne!(k1, k2, "Cache key should change when dependency file changes");
+    }
 }

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -1,3 +1,7 @@
+use codegen::jit_machine::JitEffectMachine;
+pub use codegen::jit_machine::JitError;
+pub use core_effect::dispatch::DispatchEffect;
+pub use core_eval::value::Value;
 use core_repr::serial::{read_cbor, read_metadata, ReadError};
 use core_repr::{CoreExpr, DataConTable};
 use std::fmt;
@@ -5,6 +9,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
+
+mod cache;
 
 /// Result of successful Haskell compilation: a Core expression and its associated DataCon metadata.
 pub type CompileResult = (CoreExpr, DataConTable);
@@ -57,6 +63,43 @@ impl From<ReadError> for CompileError {
     }
 }
 
+/// Unified error type for compile + run pipeline.
+#[derive(Debug)]
+pub enum RuntimeError {
+    Compile(CompileError),
+    Jit(JitError),
+}
+
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RuntimeError::Compile(e) => write!(f, "{}", e),
+            RuntimeError::Jit(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RuntimeError::Compile(e) => Some(e),
+            RuntimeError::Jit(e) => Some(e),
+        }
+    }
+}
+
+impl From<CompileError> for RuntimeError {
+    fn from(e: CompileError) -> Self {
+        Self::Compile(e)
+    }
+}
+
+impl From<JitError> for RuntimeError {
+    fn from(e: JitError) -> Self {
+        Self::Jit(e)
+    }
+}
+
 /// Compiles Haskell source code to Tidepool Core at runtime.
 ///
 /// This function shells out to `tidepool-extract` (which must be available on the system `$PATH`)
@@ -76,6 +119,13 @@ pub fn compile_haskell(
     target: &str,
     include: &[&Path],
 ) -> Result<CompileResult, CompileError> {
+    let key = cache::cache_key(source, target, include);
+    if let Some((expr_bytes, meta_bytes)) = cache::cache_load(&key) {
+        let expr = read_cbor(&expr_bytes)?;
+        let table = read_metadata(&meta_bytes)?;
+        return Ok((expr, table));
+    }
+
     // 1. Setup temporary workspace
     let temp_dir = TempDir::new()?;
     let input_path = temp_dir.path().join("input.hs");
@@ -122,10 +172,28 @@ pub fn compile_haskell(
     let expr_bytes = std::fs::read(&expr_path)?;
     let meta_bytes = std::fs::read(&meta_path)?;
 
+    cache::cache_store(&key, &expr_bytes, &meta_bytes);
+
     let expr = read_cbor(&expr_bytes)?;
     let table = read_metadata(&meta_bytes)?;
 
     Ok((expr, table))
+}
+
+const DEFAULT_NURSERY_SIZE: usize = 1 << 20; // 1 MiB
+
+/// Compile Haskell source and run it with the given effect handlers.
+pub fn compile_and_run<U, H: DispatchEffect<U>>(
+    source: &str,
+    target: &str,
+    include: &[&Path],
+    handlers: &mut H,
+    user: &U,
+) -> Result<Value, RuntimeError> {
+    let (expr, table) = compile_haskell(source, target, include)?;
+    let mut machine = JitEffectMachine::compile(&expr, &table, DEFAULT_NURSERY_SIZE)?;
+    let value = machine.run(&table, handlers, user)?;
+    Ok(value)
 }
 
 #[cfg(test)]

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -121,9 +121,11 @@ pub fn compile_haskell(
 ) -> Result<CompileResult, CompileError> {
     let key = cache::cache_key(source, target, include);
     if let Some((expr_bytes, meta_bytes)) = cache::cache_load(&key) {
-        let expr = read_cbor(&expr_bytes)?;
-        let table = read_metadata(&meta_bytes)?;
-        return Ok((expr, table));
+        // Attempt to deserialize cached data. If this fails, treat it as a cache
+        // miss and fall through to recompilation instead of propagating the error.
+        if let (Ok(expr), Ok(table)) = (read_cbor(&expr_bytes), read_metadata(&meta_bytes)) {
+            return Ok((expr, table));
+        }
     }
 
     // 1. Setup temporary workspace
@@ -172,15 +174,32 @@ pub fn compile_haskell(
     let expr_bytes = std::fs::read(&expr_path)?;
     let meta_bytes = std::fs::read(&meta_path)?;
 
-    cache::cache_store(&key, &expr_bytes, &meta_bytes);
-
     let expr = read_cbor(&expr_bytes)?;
     let table = read_metadata(&meta_bytes)?;
+
+    // Only store in cache if deserialization succeeded
+    cache::cache_store(&key, &expr_bytes, &meta_bytes);
 
     Ok((expr, table))
 }
 
 const DEFAULT_NURSERY_SIZE: usize = 1 << 20; // 1 MiB
+
+/// Compile Haskell source and run it with the given effect handlers,
+/// using the specified nursery size.
+pub fn compile_and_run_with_nursery_size<U, H: DispatchEffect<U>>(
+    source: &str,
+    target: &str,
+    include: &[&Path],
+    handlers: &mut H,
+    user: &U,
+    nursery_size: usize,
+) -> Result<Value, RuntimeError> {
+    let (expr, table) = compile_haskell(source, target, include)?;
+    let mut machine = JitEffectMachine::compile(&expr, &table, nursery_size)?;
+    let value = machine.run(&table, handlers, user)?;
+    Ok(value)
+}
 
 /// Compile Haskell source and run it with the given effect handlers.
 pub fn compile_and_run<U, H: DispatchEffect<U>>(
@@ -190,10 +209,7 @@ pub fn compile_and_run<U, H: DispatchEffect<U>>(
     handlers: &mut H,
     user: &U,
 ) -> Result<Value, RuntimeError> {
-    let (expr, table) = compile_haskell(source, target, include)?;
-    let mut machine = JitEffectMachine::compile(&expr, &table, DEFAULT_NURSERY_SIZE)?;
-    let value = machine.run(&table, handlers, user)?;
-    Ok(value)
+    compile_and_run_with_nursery_size(source, target, include, handlers, user, DEFAULT_NURSERY_SIZE)
 }
 
 #[cfg(test)]

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -106,6 +106,10 @@ impl From<JitError> for RuntimeError {
 /// to perform GHC parsing, type-checking, and Core translation. It writes the source to a 
 /// temporary file, executes the extractor, and reads back the resulting CBOR and metadata.
 ///
+/// Compiled results are cached in the XDG cache directory (typically `~/.cache/tidepool`)
+/// to speed up repeated compilations. The cache key is derived from the source code,
+/// the target binder, and a fingerprint of any included dependency directories.
+///
 /// # Arguments
 /// * `source` - The Haskell source code to compile.
 /// * `target` - The name of the top-level binder to use as the entry point (e.g., "main").
@@ -187,6 +191,18 @@ const DEFAULT_NURSERY_SIZE: usize = 1 << 20; // 1 MiB
 
 /// Compile Haskell source and run it with the given effect handlers,
 /// using the specified nursery size.
+///
+/// # Arguments
+/// * `source` - The Haskell source code to compile.
+/// * `target` - The name of the entry point binder.
+/// * `include` - Search paths for Haskell modules.
+/// * `handlers` - Effect dispatchers for the JIT machine.
+/// * `user` - User context for effect handlers.
+/// * `nursery_size` - Size of the allocation nursery in bytes.
+///
+/// # Returns
+/// * `Ok(Value)` on successful execution.
+/// * `Err(RuntimeError)` for compilation or JIT execution errors.
 pub fn compile_and_run_with_nursery_size<U, H: DispatchEffect<U>>(
     source: &str,
     target: &str,
@@ -201,7 +217,19 @@ pub fn compile_and_run_with_nursery_size<U, H: DispatchEffect<U>>(
     Ok(value)
 }
 
-/// Compile Haskell source and run it with the given effect handlers.
+/// Compile Haskell source and run it with the given effect handlers,
+/// using the default nursery size (1 MiB).
+///
+/// # Arguments
+/// * `source` - The Haskell source code to compile.
+/// * `target` - The name of the entry point binder.
+/// * `include` - Search paths for Haskell modules.
+/// * `handlers` - Effect dispatchers for the JIT machine.
+/// * `user` - User context for effect handlers.
+///
+/// # Returns
+/// * `Ok(Value)` on successful execution.
+/// * `Err(RuntimeError)` for compilation or JIT execution errors.
 pub fn compile_and_run<U, H: DispatchEffect<U>>(
     source: &str,
     target: &str,


### PR DESCRIPTION
## Summary
- Implemented `compile_and_run` in `tidepool-runtime` for unified Haskell compilation and JIT execution.
- Added a caching mechanism in `src/cache.rs` using `blake3` hashes to store CBOR output and metadata, significantly speeding up repeated runs.
- Introduced `RuntimeError` to unify `CompileError` and `JitError`.
- Re-exported `Value`, `JitError`, and `DispatchEffect` from the crate root.
- Updated dependencies to include `core-eval`, `core-effect`, `codegen`, and `blake3`.

## Verification
- `cargo check -p tidepool-runtime` passes.
- Caching logic follows XDG conventions for directory locations.