### PR TITLE
test(runtime): add integration tests for compile and run pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,6 +2015,7 @@ dependencies = [
  "core-effect",
  "core-eval",
  "core-repr",
+ "frunk",
  "tempfile",
 ]
 

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -10,3 +10,6 @@ core-effect = { path = "../core-effect" }
 codegen = { path = "../codegen" }
 tempfile = "3"
 blake3 = "1"
+
+[dev-dependencies]
+frunk = "0.4"

--- a/tidepool-runtime/tests/integration.rs
+++ b/tidepool-runtime/tests/integration.rs
@@ -1,0 +1,64 @@
+use frunk::HNil;
+use tidepool_runtime::{compile_haskell, compile_and_run, Value};
+use core_repr::Literal;
+
+#[test]
+#[ignore]
+fn test_compile_haskell_identity() {
+    let src = "module Test where\nidentity :: a -> a\nidentity x = x";
+    let (expr, table) = compile_haskell(src, "identity", &[]).unwrap();
+    assert!(!expr.nodes.is_empty());
+    assert!(!table.is_empty() || table.is_empty()); // just check it loaded
+}
+
+#[test]
+#[ignore]
+fn test_compile_and_run_literal() {
+    let src = "module Test where\nfortyTwo :: Int\nfortyTwo = 42";
+    let val = compile_and_run(src, "fortyTwo", &[], &mut HNil, &()).unwrap();
+    match val {
+        Value::Lit(Literal::LitInt(n)) => assert_eq!(n, 42),
+        Value::Con(_, ref fields) => {
+            // GHC may box as I# constructor
+            match fields.first() {
+                Some(Value::Lit(Literal::LitInt(n))) => assert_eq!(*n, 42),
+                other => panic!("unexpected boxed int field: {:?}", other),
+            }
+        }
+        other => panic!("expected int literal or boxed int, got: {:?}", other),
+    }
+}
+
+#[test]
+#[ignore]
+fn test_compile_and_run_arithmetic() {
+    let src = "module Test where\nresult :: Int\nresult = 2 + 3";
+    let val = compile_and_run(src, "result", &[], &mut HNil, &()).unwrap();
+    // Result may be boxed I# 5 or literal 5
+    match val {
+        Value::Lit(Literal::LitInt(n)) => assert_eq!(n, 5),
+        Value::Con(_, ref fields) => match fields.first() {
+            Some(Value::Lit(Literal::LitInt(n))) => assert_eq!(*n, 5),
+            other => panic!("unexpected: {:?}", other),
+        },
+        other => panic!("expected 5, got: {:?}", other),
+    }
+}
+
+#[test]
+#[ignore]
+fn test_compile_error() {
+    let src = "module Test where\nbad = undefined_thing";
+    let result = compile_haskell(src, "bad", &[]);
+    assert!(result.is_err());
+}
+
+#[test]
+#[ignore]
+fn test_caching_produces_same_result() {
+    let src = "module Test where\nval :: Int\nval = 10";
+    let v1 = compile_and_run(src, "val", &[], &mut HNil, &()).unwrap();
+    let v2 = compile_and_run(src, "val", &[], &mut HNil, &()).unwrap();
+    // Both should produce the same value (second from cache)
+    assert_eq!(format!("{:?}", v1), format!("{:?}", v2));
+}

--- a/tidepool-runtime/tests/integration.rs
+++ b/tidepool-runtime/tests/integration.rs
@@ -3,16 +3,16 @@ use tidepool_runtime::{compile_haskell, compile_and_run, Value};
 use core_repr::Literal;
 
 #[test]
-#[ignore]
+#[ignore] // Manual test: requires tidepool-extract on PATH
 fn test_compile_haskell_identity() {
     let src = "module Test where\nidentity :: a -> a\nidentity x = x";
     let (expr, table) = compile_haskell(src, "identity", &[]).unwrap();
     assert!(!expr.nodes.is_empty());
-    assert!(!table.is_empty() || table.is_empty()); // just check it loaded
+    assert!(!table.is_empty()); // just check it loaded
 }
 
 #[test]
-#[ignore]
+#[ignore] // Manual test: requires tidepool-extract on PATH
 fn test_compile_and_run_literal() {
     let src = "module Test where\nfortyTwo :: Int\nfortyTwo = 42";
     let val = compile_and_run(src, "fortyTwo", &[], &mut HNil, &()).unwrap();
@@ -30,7 +30,7 @@ fn test_compile_and_run_literal() {
 }
 
 #[test]
-#[ignore]
+#[ignore] // Manual test: requires tidepool-extract on PATH
 fn test_compile_and_run_arithmetic() {
     let src = "module Test where\nresult :: Int\nresult = 2 + 3";
     let val = compile_and_run(src, "result", &[], &mut HNil, &()).unwrap();
@@ -46,7 +46,7 @@ fn test_compile_and_run_arithmetic() {
 }
 
 #[test]
-#[ignore]
+#[ignore] // Manual test: requires tidepool-extract on PATH
 fn test_compile_error() {
     let src = "module Test where\nbad = undefined_thing";
     let result = compile_haskell(src, "bad", &[]);
@@ -54,7 +54,7 @@ fn test_compile_error() {
 }
 
 #[test]
-#[ignore]
+#[ignore] // Manual test: requires tidepool-extract on PATH
 fn test_caching_produces_same_result() {
     let src = "module Test where\nval :: Int\nval = 10";
     let v1 = compile_and_run(src, "val", &[], &mut HNil, &()).unwrap();


### PR DESCRIPTION
Adds integration tests in `tidepool-runtime/tests/integration.rs` (all `#[ignore]`) covering:
- `compile_haskell` identity function
- `compile_and_run` with literals (boxed vs unboxed)
- `compile_and_run` with arithmetic
- `compile_haskell` error reporting
- Caching consistency check