### PR TITLE
feat(examples): add MCP server example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcp-server-example"
+version = "0.1.0"
+dependencies = [
+ "core-effect",
+ "core-eval",
+ "core-repr",
+ "frunk",
+ "tidepool-mcp",
+ "tidepool-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["core-repr", "core-eval", "core-testing", "core-heap", "core-optimize", "core-bridge", "core-bridge-derive", "tidepool-macro", "core-effect", "codegen", "examples/guess", "examples/guess-interpreted", "examples/tide", "tidepool-runtime", "tidepool-mcp"]
+members = ["core-repr", "core-eval", "core-testing", "core-heap", "core-optimize", "core-bridge", "core-bridge-derive", "tidepool-macro", "core-effect", "codegen", "examples/guess", "examples/guess-interpreted", "examples/tide", "tidepool-runtime", "tidepool-mcp", "examples/mcp-server"]
 resolver = "2"

--- a/examples/mcp-server/Cargo.toml
+++ b/examples/mcp-server/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mcp-server-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "mcp-server-example"
+path = "src/main.rs"
+
+[dependencies]
+tidepool-mcp = { path = "../../tidepool-mcp" }
+tidepool-runtime = { path = "../../tidepool-runtime" }
+core-effect = { path = "../../core-effect" }
+core-eval = { path = "../../core-eval" }
+core-repr = { path = "../../core-repr" }
+frunk = "0.4"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/examples/mcp-server/Cargo.toml
+++ b/examples/mcp-server/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/main.rs"
 
 [dependencies]
 tidepool-mcp = { path = "../../tidepool-mcp" }
-tidepool-runtime = { path = "../../tidepool-runtime" }
 core-effect = { path = "../../core-effect" }
 core-eval = { path = "../../core-eval" }
 core-repr = { path = "../../core-repr" }

--- a/examples/mcp-server/src/main.rs
+++ b/examples/mcp-server/src/main.rs
@@ -1,0 +1,47 @@
+//! Example MCP server demonstrating Tidepool with custom effect handlers.
+
+use core_effect::dispatch::{EffectContext, EffectHandler};
+use core_effect::error::EffectError;
+use core_eval::value::Value;
+use tidepool_mcp::TidepoolMcpServer;
+
+/// Console effect handler — handles print-like effects (tag 0).
+#[derive(Clone)]
+struct ConsoleHandler;
+
+impl EffectHandler<()> for ConsoleHandler {
+    type Request = Value;
+
+    fn handle(
+        &mut self,
+        req: Self::Request,
+        _cx: &EffectContext<'_, ()>,
+    ) -> Result<Value, EffectError> {
+        eprintln!("[console] {:?}", req);
+        Ok(Value::Lit(core_repr::Literal::LitInt(0)))
+    }
+}
+
+/// Environment effect handler — handles env-lookup effects (tag 1).
+#[derive(Clone)]
+struct EnvHandler;
+
+impl EffectHandler<()> for EnvHandler {
+    type Request = Value;
+
+    fn handle(
+        &mut self,
+        req: Self::Request,
+        _cx: &EffectContext<'_, ()>,
+    ) -> Result<Value, EffectError> {
+        eprintln!("[env] lookup {:?}", req);
+        Ok(Value::Lit(core_repr::Literal::LitString("example_value".into())))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let handlers = frunk::hlist![ConsoleHandler, EnvHandler];
+    let server = TidepoolMcpServer::new(handlers);
+    server.serve_stdio().await
+}

--- a/examples/mcp-server/src/main.rs
+++ b/examples/mcp-server/src/main.rs
@@ -15,10 +15,10 @@ impl EffectHandler<()> for ConsoleHandler {
     fn handle(
         &mut self,
         req: Self::Request,
-        _cx: &EffectContext<'_, ()>,
+        cx: &EffectContext<'_, ()>,
     ) -> Result<Value, EffectError> {
         eprintln!("[console] {:?}", req);
-        Ok(Value::Lit(core_repr::Literal::LitInt(0)))
+        cx.respond(())
     }
 }
 
@@ -32,10 +32,10 @@ impl EffectHandler<()> for EnvHandler {
     fn handle(
         &mut self,
         req: Self::Request,
-        _cx: &EffectContext<'_, ()>,
+        cx: &EffectContext<'_, ()>,
     ) -> Result<Value, EffectError> {
         eprintln!("[env] lookup {:?}", req);
-        Ok(Value::Lit(core_repr::Literal::LitString("example_value".into())))
+        cx.respond("example_value".to_string())
     }
 }
 


### PR DESCRIPTION
This PR adds a minimal MCP server example demonstrating Tidepool with custom effect handlers for console and environment lookups.