### PR TITLE
feat: implement Display for Value

### DIFF
--- a/tidepool-eval/src/value.rs
+++ b/tidepool-eval/src/value.rs
@@ -35,12 +35,17 @@ impl std::fmt::Display for Value {
             Value::Lit(lit) => match lit {
                 Literal::LitInt(n) => write!(f, "{}", n),
                 Literal::LitWord(n) => write!(f, "{}", n),
-                Literal::LitChar(c) => write!(f, "'{}'", c),
+                Literal::LitChar(c) => write!(f, "'{}'", c.escape_default()),
                 Literal::LitString(bs) => match std::str::from_utf8(bs) {
-                    Ok(s) => write!(f, "\"{}\"", s),
+                    Ok(s) => write!(f, "{:?}", s),
                     Err(_) => write!(f, "<bytes len={}>", bs.len()),
                 },
-                Literal::LitFloat(bits) => write!(f, "{}", f32::from_bits(*bits as u32)),
+                Literal::LitFloat(bits) => {
+                    match u32::try_from(*bits) {
+                        Ok(bits32) => write!(f, "{}", f32::from_bits(bits32)),
+                        Err(_) => write!(f, "<invalid f32 bits=0x{:016x}>", *bits),
+                    }
+                }
                 Literal::LitDouble(bits) => write!(f, "{}", f64::from_bits(*bits)),
             },
             Value::Con(id, fields) => {
@@ -74,11 +79,20 @@ mod tests {
 
         assert_eq!(Value::Lit(Literal::LitInt(42)).to_string(), "42");
         assert_eq!(Value::Lit(Literal::LitChar('x')).to_string(), "'x'");
+        assert_eq!(Value::Lit(Literal::LitChar('\n')).to_string(), r"'\n'");
         assert_eq!(
             Value::Lit(Literal::LitString(b"hello".to_vec())).to_string(),
             "\"hello\""
         );
+        assert_eq!(
+            Value::Lit(Literal::LitString(b"with \"quotes\"".to_vec())).to_string(),
+            "\"with \\\"quotes\\\"\""
+        );
         assert_eq!(Value::Lit(Literal::from(3.14f64)).to_string(), "3.14");
+        assert_eq!(
+            Value::Lit(Literal::LitFloat(0xFFFF_FFFF_FFFF_FFFF)).to_string(),
+            "<invalid f32 bits=0xffffffffffffffff>"
+        );
 
         assert_eq!(Value::Con(DataConId(1), vec![]).to_string(), "<Con#1>");
         assert_eq!(

--- a/tidepool-eval/src/value.rs
+++ b/tidepool-eval/src/value.rs
@@ -23,10 +23,95 @@ pub enum Value {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ThunkId(pub u32);
 
+impl std::fmt::Display for ThunkId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<thunk#{}>", self.0)
+    }
+}
+
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::Lit(lit) => match lit {
+                Literal::LitInt(n) => write!(f, "{}", n),
+                Literal::LitWord(n) => write!(f, "{}", n),
+                Literal::LitChar(c) => write!(f, "'{}'", c),
+                Literal::LitString(bs) => match std::str::from_utf8(bs) {
+                    Ok(s) => write!(f, "\"{}\"", s),
+                    Err(_) => write!(f, "<bytes len={}>", bs.len()),
+                },
+                Literal::LitFloat(bits) => write!(f, "{}", f32::from_bits(*bits as u32)),
+                Literal::LitDouble(bits) => write!(f, "{}", f64::from_bits(*bits)),
+            },
+            Value::Con(id, fields) => {
+                write!(f, "<Con#{}>", id.0)?;
+                for field in fields {
+                    write!(f, " {}", field)?;
+                }
+                Ok(())
+            }
+            Value::Closure(..) => write!(f, "<closure>"),
+            Value::ThunkRef(id) => write!(f, "{}", id),
+            Value::JoinCont(..) => write!(f, "<join>"),
+            Value::ConFun(id, arity, args) => {
+                write!(f, "<partial Con#{} {}/{}>", id.0, args.len(), arity)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tidepool_repr::{CoreFrame, RecursiveTree};
+
+    #[test]
+    fn test_value_display() {
+        let env = Env::new();
+        let expr = RecursiveTree {
+            nodes: vec![CoreFrame::Var(VarId(0))],
+        };
+
+        assert_eq!(Value::Lit(Literal::LitInt(42)).to_string(), "42");
+        assert_eq!(Value::Lit(Literal::LitChar('x')).to_string(), "'x'");
+        assert_eq!(
+            Value::Lit(Literal::LitString(b"hello".to_vec())).to_string(),
+            "\"hello\""
+        );
+        assert_eq!(Value::Lit(Literal::from(3.14f64)).to_string(), "3.14");
+
+        assert_eq!(Value::Con(DataConId(1), vec![]).to_string(), "<Con#1>");
+        assert_eq!(
+            Value::Con(DataConId(1), vec![Value::Lit(Literal::LitInt(42))]).to_string(),
+            "<Con#1> 42"
+        );
+        assert_eq!(
+            Value::Con(
+                DataConId(1),
+                vec![
+                    Value::Lit(Literal::LitInt(42)),
+                    Value::Lit(Literal::LitString(b"hi".to_vec()))
+                ]
+            )
+            .to_string(),
+            "<Con#1> 42 \"hi\""
+        );
+
+        assert_eq!(
+            Value::Closure(env.clone(), VarId(0), expr.clone()).to_string(),
+            "<closure>"
+        );
+        assert_eq!(Value::ThunkRef(ThunkId(123)).to_string(), "<thunk#123>");
+        assert_eq!(
+            Value::JoinCont(vec![VarId(1)], expr, env).to_string(),
+            "<join>"
+        );
+
+        assert_eq!(
+            Value::ConFun(DataConId(1), 2, vec![Value::Lit(Literal::LitInt(42))]).to_string(),
+            "<partial Con#1 1/2>"
+        );
+    }
 
     #[test]
     fn test_value_construction() {


### PR DESCRIPTION
This PR adds a human-readable `Display` implementation for the `Value` enum and `ThunkId` in `tidepool-eval`. This improves the output in the REPL and MCP server by replacing the verbose `Debug` output with cleaner, Haskell-like representations.\n\nChanges:\n- `Lit(LitInt(42))` -> `42`\n- `Con(id, fields)` -> `<Con#id> field1 field2`\n- `Closure` -> `<closure>`\n- `ThunkRef(id)` -> `<thunk#id>`\n- `JoinCont` -> `<join>`\n- `ConFun` -> `<partial Con#id n/arity>`\n\nVerified with existing and new tests.