### PR TITLE
Fix GC audit test failures for Case/Join safepoints

### DIFF
--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -67,6 +67,7 @@ pub fn emit_case(
     builder.switch_to_block(merge_block);
     let result = builder.block_params(merge_block)[0];
     builder.declare_value_needs_stack_map(result);
+    ctx.declare_env(builder);
 
     // 6. Clean up case binder
     ctx.env.remove(binder);
@@ -103,6 +104,7 @@ fn emit_data_dispatch(
             // Emit alt body
             builder.switch_to_block(alt_block);
             builder.seal_block(alt_block);
+            ctx.declare_env(builder);
 
             // Bind pattern variables
             let mut bound_vars = Vec::new();
@@ -131,6 +133,7 @@ fn emit_data_dispatch(
 
     // Default or trap
     if let Some(alt) = default_alt {
+        ctx.declare_env(builder);
         let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, alt.body)?;
         let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, result);
         builder.ins().jump(merge_block, &[result_ptr]);
@@ -199,6 +202,7 @@ fn emit_lit_dispatch(
         // Emit alt body
         builder.switch_to_block(alt_block);
         builder.seal_block(alt_block);
+        ctx.declare_env(builder);
         let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, alt.body)?;
         let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, result);
         builder.ins().jump(merge_block, &[result_ptr]);
@@ -210,6 +214,7 @@ fn emit_lit_dispatch(
 
     // Default or trap
     if let Some(alt) = default_alt {
+        ctx.declare_env(builder);
         let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, tree, alt.body)?;
         let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, result);
         builder.ins().jump(merge_block, &[result_ptr]);

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -94,6 +94,7 @@ impl EmitContext {
                             let kind_val = builder.ins().iconst(types::I64, kind as i64);
                             let inst = builder.ins().call(err_ref, &[kind_val]);
                             let result = builder.inst_results(inst)[0];
+                            builder.declare_value_needs_stack_map(result);
                             return Ok(SsaVal::HeapPtr(result));
                         }
 
@@ -113,6 +114,7 @@ impl EmitContext {
                         let var_id_val = builder.ins().iconst(types::I64, vid.0 as i64);
                         let inst = builder.ins().call(trap_ref, &[var_id_val]);
                         let result = builder.inst_results(inst)[0];
+                        builder.declare_value_needs_stack_map(result);
                         Ok(SsaVal::HeapPtr(result))
                     }
                 };
@@ -153,6 +155,7 @@ impl EmitContext {
                 break primop::emit_primop(builder, op, &arg_vals);
             }
             CoreFrame::App { fun, arg } => {
+                self.declare_env(builder);
                 let fun_val = self.emit_node(pipeline, builder, vmctx, gc_sig, tree, *fun)?;
                 let arg_val = self.emit_node(pipeline, builder, vmctx, gc_sig, tree, *arg)?;
                 let fun_ptr = fun_val.value();

--- a/tidepool-codegen/src/emit/join.rs
+++ b/tidepool-codegen/src/emit/join.rs
@@ -47,6 +47,7 @@ pub fn emit_join(
 
     // 6. Switch to join block, emit rhs
     builder.switch_to_block(join_block);
+    ctx.declare_env(builder);
     
     // Bind params to block params
     let block_params = builder.block_params(join_block).to_vec();
@@ -72,6 +73,7 @@ pub fn emit_join(
     builder.switch_to_block(merge_block);
     let result = builder.block_params(merge_block)[0];
     builder.declare_value_needs_stack_map(result);  // CRITICAL
+    ctx.declare_env(builder);
 
     // 9. Clean up
     ctx.join_blocks.remove(label);

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -90,6 +90,21 @@ impl EmitContext {
         }
     }
 
+    /// Re-declare all heap pointers currently in the environment as needing
+    /// stack map entries. Should be called after switching to a new block
+    /// (e.g., merge blocks, join points, case alternatives) to ensure
+    /// liveness is tracked correctly across block boundaries.
+    pub fn declare_env(&self, builder: &mut cranelift_frontend::FunctionBuilder) {
+        // Collect and sort keys for deterministic IR output (useful for debugging/tests)
+        let mut keys: Vec<_> = self.env.keys().collect();
+        keys.sort_by_key(|v| v.0);
+        for &k in keys {
+            if let SsaVal::HeapPtr(v) = self.env[&k] {
+                builder.declare_value_needs_stack_map(v);
+            }
+        }
+    }
+
     pub fn next_lambda_name(&mut self) -> String {
         let n = self.lambda_counter;
         self.lambda_counter += 1;


### PR DESCRIPTION
This PR fixes the `gc_audit` test failures by ensuring that stack map declarations for heap pointers are correctly propagated across block boundaries and into nested contexts.

### Changes:
- **`tidepool-codegen/src/emit/mod.rs`**: Added `declare_env` to re-declare environment heap pointers at block boundaries.
- **`tidepool-codegen/src/emit/case.rs`**: Integrated `declare_env` into case alternatives and merge blocks.
- **`tidepool-codegen/src/emit/join.rs`**: Integrated `declare_env` into join RHS and merge blocks.
- **`tidepool-codegen/src/emit/expr.rs`**: Integrated `declare_env` into `App` emission and added missing stack map declarations for runtime error results.