### PR TITLE
feat: add EvalResult with JSON rendering to tidepool-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,6 +2373,7 @@ version = "0.0.1"
 dependencies = [
  "blake3",
  "frunk",
+ "serde_json",
  "tempfile",
  "tidepool-codegen",
  "tidepool-effect",

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -11,6 +11,7 @@ tidepool-repr = { version = "0.0.1", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.0.1", path = "../tidepool-eval" }
 tidepool-effect = { version = "0.0.1", path = "../tidepool-effect" }
 tidepool-codegen = { version = "0.0.1", path = "../tidepool-codegen" }
+serde_json = "1"
 tempfile = "3"
 blake3 = "1"
 

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -83,7 +83,7 @@ pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
 /// Writes data to a temporary file then renames it to the target path
 /// to ensure that readers never see partially written or corrupted files.
 fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
-    let dir = path.parent().ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "no parent dir"))?;
+    let dir = path.parent().ok_or_else(|| std::io::Error::other("no parent dir"))?;
     let mut temp = tempfile::NamedTempFile::new_in(dir)?;
     use std::io::Write;
     temp.write_all(data)?;

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -16,6 +16,9 @@ use std::process::Command;
 use tempfile::TempDir;
 
 mod cache;
+mod render;
+
+pub use render::EvalResult;
 
 /// Result of successful Haskell compilation: a Core expression and its associated DataCon metadata.
 pub type CompileResult = (CoreExpr, DataConTable);
@@ -206,7 +209,7 @@ const DEFAULT_NURSERY_SIZE: usize = 1 << 20; // 1 MiB
 /// * `nursery_size` - Size of the allocation nursery in bytes.
 ///
 /// # Returns
-/// * `Ok(Value)` on successful execution.
+/// * `Ok(EvalResult)` on successful execution.
 /// * `Err(RuntimeError)` for compilation or JIT execution errors.
 pub fn compile_and_run_with_nursery_size<U, H: DispatchEffect<U>>(
     source: &str,
@@ -215,11 +218,11 @@ pub fn compile_and_run_with_nursery_size<U, H: DispatchEffect<U>>(
     handlers: &mut H,
     user: &U,
     nursery_size: usize,
-) -> Result<Value, RuntimeError> {
+) -> Result<EvalResult, RuntimeError> {
     let (expr, table) = compile_haskell(source, target, include)?;
     let mut machine = JitEffectMachine::compile(&expr, &table, nursery_size)?;
     let value = machine.run(&table, handlers, user)?;
-    Ok(value)
+    Ok(EvalResult::new(value, table))
 }
 
 /// Compile Haskell source and run it with the given effect handlers,
@@ -233,7 +236,7 @@ pub fn compile_and_run_with_nursery_size<U, H: DispatchEffect<U>>(
 /// * `user` - User context for effect handlers.
 ///
 /// # Returns
-/// * `Ok(Value)` on successful execution.
+/// * `Ok(EvalResult)` on successful execution.
 /// * `Err(RuntimeError)` for compilation or JIT execution errors.
 pub fn compile_and_run<U, H: DispatchEffect<U>>(
     source: &str,
@@ -241,7 +244,7 @@ pub fn compile_and_run<U, H: DispatchEffect<U>>(
     include: &[&Path],
     handlers: &mut H,
     user: &U,
-) -> Result<Value, RuntimeError> {
+) -> Result<EvalResult, RuntimeError> {
     compile_and_run_with_nursery_size(source, target, include, handlers, user, DEFAULT_NURSERY_SIZE)
 }
 

--- a/tidepool-runtime/src/render.rs
+++ b/tidepool-runtime/src/render.rs
@@ -145,7 +145,7 @@ fn literal_to_json(lit: &Literal) -> serde_json::Value {
         Literal::LitWord(n) => json!(n),
         Literal::LitChar(c) => json!(c.to_string()),
         Literal::LitString(bytes) => {
-            match String::from_utf8(bytes.clone()) {
+            match std::str::from_utf8(bytes) {
                 Ok(s) => json!(s),
                 Err(_) => json!(format!("<binary:{} bytes>", bytes.len())),
             }

--- a/tidepool-runtime/src/render.rs
+++ b/tidepool-runtime/src/render.rs
@@ -1,0 +1,231 @@
+use serde_json::json;
+use tidepool_eval::value::Value;
+use tidepool_repr::datacon_table::DataConTable;
+use tidepool_repr::types::{DataConId, Literal};
+
+const MAX_DEPTH: usize = 1000;
+const MAX_LIST_LEN: usize = 10000;
+
+/// Opaque result of evaluating a Haskell expression.
+/// Bundles the computed `Value` with the `DataConTable` needed to render constructor names.
+#[derive(Debug)]
+pub struct EvalResult {
+    value: Value,
+    table: DataConTable,
+}
+
+impl EvalResult {
+    pub(crate) fn new(value: Value, table: DataConTable) -> Self {
+        Self { value, table }
+    }
+
+    /// Render the result as structured JSON.
+    pub fn to_json(&self) -> serde_json::Value {
+        value_to_json(&self.value, &self.table, 0)
+    }
+
+    /// Pretty-print the JSON representation.
+    pub fn to_string_pretty(&self) -> String {
+        let j = self.to_json();
+        // For simple scalars, use compact form
+        match &j {
+            serde_json::Value::Number(_) | serde_json::Value::Bool(_) | serde_json::Value::Null => {
+                j.to_string()
+            }
+            serde_json::Value::String(s) => {
+                // Check if it's a single char or short string — use compact
+                if s.len() <= 80 {
+                    j.to_string()
+                } else {
+                    serde_json::to_string_pretty(&j).unwrap_or_else(|_| j.to_string())
+                }
+            }
+            _ => serde_json::to_string_pretty(&j).unwrap_or_else(|_| j.to_string()),
+        }
+    }
+
+    /// Consume and return the inner Value (escape hatch for callers that need raw access).
+    pub fn into_value(self) -> Value {
+        self.value
+    }
+
+    /// Borrow the inner Value.
+    pub fn value(&self) -> &Value {
+        &self.value
+    }
+
+    /// Borrow the DataConTable.
+    pub fn table(&self) -> &DataConTable {
+        &self.table
+    }
+}
+
+fn con_name(id: DataConId, table: &DataConTable) -> &str {
+    table.name_of(id).unwrap_or("<unknown>")
+}
+
+fn value_to_json(val: &Value, table: &DataConTable, depth: usize) -> serde_json::Value {
+    if depth > MAX_DEPTH {
+        return json!("<depth limit>");
+    }
+    let d = depth + 1;
+
+    match val {
+        // Literals
+        Value::Lit(lit) => literal_to_json(lit),
+
+        // Constructors — pattern match on known names
+        Value::Con(id, fields) => {
+            let name = con_name(*id, table);
+            match (name, fields.as_slice()) {
+                // Booleans
+                ("True", []) => json!(true),
+                ("False", []) => json!(false),
+
+                // Unit
+                ("()", []) => json!(null),
+
+                // Maybe
+                ("Nothing", []) => json!(null),
+                ("Just", [x]) => value_to_json(x, table, d),
+
+                // freer-simple Pure
+                ("Pure", [x]) => value_to_json(x, table, d),
+
+                // Boxing constructors: I#, W#, C#, D#, F#
+                ("I#", [x]) | ("W#", [x]) | ("D#", [x]) | ("F#", [x]) => {
+                    value_to_json(x, table, d)
+                }
+                ("C#", [x]) => value_to_json(x, table, d),
+
+                // List: try to collect as array or string
+                ("[]", []) => {
+                    // Empty list
+                    json!([])
+                }
+                (":", [head, tail]) => {
+                    collect_list(head, tail, table, d)
+                }
+
+                // Tuples: (,), (,,), (,,,), etc.
+                (n, fields) if n.starts_with('(') && n.ends_with(')') && n.chars().all(|c| c == '(' || c == ')' || c == ',') && fields.len() >= 2 => {
+                    let elems: Vec<serde_json::Value> = fields.iter().map(|f| value_to_json(f, table, d)).collect();
+                    json!(elems)
+                }
+
+                // Generic constructor
+                (_name, fields) => {
+                    if fields.is_empty() {
+                        json!(name)
+                    } else {
+                        let field_jsons: Vec<serde_json::Value> = fields.iter().map(|f| value_to_json(f, table, d)).collect();
+                        json!({
+                            "constructor": name,
+                            "fields": field_jsons
+                        })
+                    }
+                }
+            }
+        }
+
+        // Closures / thunks — opaque
+        Value::Closure(_, _, _) => json!("<closure>"),
+        Value::ThunkRef(_) => json!("<thunk>"),
+        Value::JoinCont(_, _, _) => json!("<join>"),
+        Value::ConFun(id, _, _) => {
+            let name = con_name(*id, table);
+            json!(format!("<partially-applied {}>", name))
+        }
+    }
+}
+
+fn literal_to_json(lit: &Literal) -> serde_json::Value {
+    match lit {
+        Literal::LitInt(n) => json!(n),
+        Literal::LitWord(n) => json!(n),
+        Literal::LitChar(c) => json!(c.to_string()),
+        Literal::LitString(bytes) => {
+            match String::from_utf8(bytes.clone()) {
+                Ok(s) => json!(s),
+                Err(_) => json!(format!("<binary:{} bytes>", bytes.len())),
+            }
+        }
+        Literal::LitFloat(bits) => {
+            let f = f32::from_bits(*bits as u32) as f64;
+            serde_json::Number::from_f64(f).map(serde_json::Value::Number).unwrap_or(json!(null))
+        }
+        Literal::LitDouble(bits) => {
+            let f = f64::from_bits(*bits);
+            serde_json::Number::from_f64(f).map(serde_json::Value::Number).unwrap_or(json!(null))
+        }
+    }
+}
+
+/// Collect a cons-chain into a JSON array, or a JSON string if all elements are chars.
+fn collect_list(head: &Value, tail: &Value, table: &DataConTable, depth: usize) -> serde_json::Value {
+    let mut elems = vec![head];
+    let mut current = tail;
+    let mut count = 1usize;
+
+    loop {
+        if count >= MAX_LIST_LEN {
+            // Truncate
+            let mut arr: Vec<serde_json::Value> = elems.iter().map(|e| value_to_json(e, table, depth)).collect();
+            arr.push(json!("..."));
+            return json!(arr);
+        }
+        match current {
+            Value::Con(id, fields) => {
+                let name = con_name(*id, table);
+                match (name, fields.as_slice()) {
+                    ("[]", []) => break,
+                    (":", [h, t]) => {
+                        elems.push(h);
+                        current = t;
+                        count += 1;
+                    }
+                    _ => {
+                        // Malformed list tail
+                        let mut arr: Vec<serde_json::Value> = elems.iter().map(|e| value_to_json(e, table, depth)).collect();
+                        arr.push(value_to_json(current, table, depth));
+                        return json!(arr);
+                    }
+                }
+            }
+            _ => {
+                // Non-constructor tail (thunk, etc)
+                let mut arr: Vec<serde_json::Value> = elems.iter().map(|e| value_to_json(e, table, depth)).collect();
+                arr.push(value_to_json(current, table, depth));
+                return json!(arr);
+            }
+        }
+    }
+
+    // Check if all elements are chars → render as string
+    let mut all_chars = true;
+    let mut char_buf = String::new();
+    for e in &elems {
+        match e {
+            Value::Lit(Literal::LitChar(c)) => char_buf.push(*c),
+            Value::Con(id, fields) if con_name(*id, table) == "C#" && fields.len() == 1 => {
+                if let Value::Lit(Literal::LitChar(c)) = &fields[0] {
+                    char_buf.push(*c);
+                } else {
+                    all_chars = false;
+                    break;
+                }
+            }
+            _ => {
+                all_chars = false;
+                break;
+            }
+        }
+    }
+
+    if all_chars && !char_buf.is_empty() {
+        json!(char_buf)
+    } else {
+        let arr: Vec<serde_json::Value> = elems.iter().map(|e| value_to_json(e, table, depth)).collect();
+        json!(arr)
+    }
+}

--- a/tidepool-runtime/tests/integration.rs
+++ b/tidepool-runtime/tests/integration.rs
@@ -1,5 +1,5 @@
 use frunk::HNil;
-use tidepool_runtime::{compile_haskell, compile_and_run, Value};
+use tidepool_runtime::{compile_haskell, compile_and_run, Value, EvalResult};
 use tidepool_repr::Literal;
 
 #[test]
@@ -15,7 +15,7 @@ fn test_compile_haskell_identity() {
 #[ignore] // Manual test: requires tidepool-extract on PATH
 fn test_compile_and_run_literal() {
     let src = "module Test where\nfortyTwo :: Int\nfortyTwo = 42";
-    let val = compile_and_run(src, "fortyTwo", &[], &mut HNil, &()).unwrap();
+    let val = compile_and_run(src, "fortyTwo", &[], &mut HNil, &()).unwrap().into_value();
     match val {
         Value::Lit(Literal::LitInt(n)) => assert_eq!(n, 42),
         Value::Con(_, ref fields) => {
@@ -33,7 +33,7 @@ fn test_compile_and_run_literal() {
 #[ignore] // Manual test: requires tidepool-extract on PATH
 fn test_compile_and_run_arithmetic() {
     let src = "module Test where\nresult :: Int\nresult = 2 + 3";
-    let val = compile_and_run(src, "result", &[], &mut HNil, &()).unwrap();
+    let val = compile_and_run(src, "result", &[], &mut HNil, &()).unwrap().into_value();
     // Result may be boxed I# 5 or literal 5
     match val {
         Value::Lit(Literal::LitInt(n)) => assert_eq!(n, 5),
@@ -57,8 +57,18 @@ fn test_compile_error() {
 #[ignore] // Manual test: requires tidepool-extract on PATH
 fn test_caching_produces_same_result() {
     let src = "module Test where\nval :: Int\nval = 10";
-    let v1 = compile_and_run(src, "val", &[], &mut HNil, &()).unwrap();
-    let v2 = compile_and_run(src, "val", &[], &mut HNil, &()).unwrap();
+    let r1 = compile_and_run(src, "val", &[], &mut HNil, &()).unwrap();
+    let r2 = compile_and_run(src, "val", &[], &mut HNil, &()).unwrap();
     // Both should produce the same value (second from cache)
-    assert_eq!(format!("{:?}", v1), format!("{:?}", v2));
+    assert_eq!(r1.to_string_pretty(), r2.to_string_pretty());
+}
+
+#[test]
+#[ignore]
+fn test_eval_result_to_json() {
+    let src = "module Test where\nfortyTwo :: Int\nfortyTwo = 42";
+    let result = compile_and_run(src, "fortyTwo", &[], &mut HNil, &()).unwrap();
+    let json = result.to_json();
+    // Should be 42 (either directly or after unwrapping I#)
+    assert_eq!(json, serde_json::json!(42));
 }

--- a/tidepool-runtime/tests/integration.rs
+++ b/tidepool-runtime/tests/integration.rs
@@ -66,9 +66,109 @@ fn test_caching_produces_same_result() {
 #[test]
 #[ignore]
 fn test_eval_result_to_json() {
-    let src = "module Test where\nfortyTwo :: Int\nfortyTwo = 42";
-    let result = compile_and_run(src, "fortyTwo", &[], &mut HNil, &()).unwrap();
-    let json = result.to_json();
-    // Should be 42 (either directly or after unwrapping I#)
-    assert_eq!(json, serde_json::json!(42));
+    // Exercise JSON rendering for a variety of value shapes to catch regressions.
+    let src = r#"module Test where
+fortyTwo :: Int
+fortyTwo = 42
+
+helloStr :: String
+helloStr = "héllø 🌍"
+
+emptyIntList :: [Int]
+emptyIntList = []
+
+intList :: [Int]
+intList = [1, 2, 3]
+
+charList :: [Char]
+charList = "abc"
+
+tupleVal :: (Int, Bool)
+tupleVal = (1, True)
+
+unitVal :: ()
+unitVal = ()
+
+maybeJust :: Maybe Int
+maybeJust = Just 5
+
+maybeNothing :: Maybe Int
+maybeNothing = Nothing
+
+boolVal :: Bool
+boolVal = False
+
+nanVal :: Double
+nanVal = 0/0
+
+infVal :: Double
+infVal = 1/0
+
+customData :: Either Int String
+customData = Right "ok"
+
+deepList :: [Int]
+deepList = [1..1000]
+"#;
+
+    // Simple integer case should still render as JSON number 42.
+    let int_result = compile_and_run(src, "fortyTwo", &[], &mut HNil, &()).unwrap();
+    let int_json = int_result.to_json();
+    assert_eq!(int_json, serde_json::json!(42));
+
+    // Strings (including UTF-8).
+    let string_result = compile_and_run(src, "helloStr", &[], &mut HNil, &()).unwrap();
+    let string_json = string_result.to_json();
+    assert_eq!(string_json, serde_json::json!("héllø 🌍"));
+
+    // Lists: empty list and a small numeric list.
+    let empty_list_json =
+        compile_and_run(src, "emptyIntList", &[], &mut HNil, &()).unwrap().to_json();
+    assert_eq!(empty_list_json, serde_json::json!([]));
+
+    let int_list_json =
+        compile_and_run(src, "intList", &[], &mut HNil, &()).unwrap().to_json();
+    assert_eq!(int_list_json, serde_json::json!([1, 2, 3]));
+
+    // Character list: depending on implementation this might render as a string or an array.
+    let char_list_json =
+        compile_and_run(src, "charList", &[], &mut HNil, &()).unwrap().to_json();
+    match char_list_json {
+        serde_json::Value::String(_) | serde_json::Value::Array(_) => { /* acceptable */ }
+        other => panic!("unexpected JSON for char list: {:?}", other),
+    }
+
+    // Tuples: commonly rendered as a JSON array of fixed length.
+    let tuple_json =
+        compile_and_run(src, "tupleVal", &[], &mut HNil, &()).unwrap().to_json();
+    match tuple_json {
+        serde_json::Value::Array(ref arr) if arr.len() == 2 => { /* expected arity */ }
+        other => panic!("unexpected JSON for tuple: {:?}", other),
+    }
+
+    // Booleans should render as JSON booleans.
+    let bool_json =
+        compile_and_run(src, "boolVal", &[], &mut HNil, &()).unwrap().to_json();
+    match bool_json {
+        serde_json::Value::Bool(_) => { /* ok */ }
+        other => panic!("unexpected JSON for Bool: {:?}", other),
+    }
+
+    // Unit, Maybe, custom data constructors, floats (NaN/Inf), and deep lists:
+    // we don't assert a specific shape here, but we do ensure that JSON
+    // rendering succeeds without panicking on these edge cases.
+    let _unit_json =
+        compile_and_run(src, "unitVal", &[], &mut HNil, &()).unwrap().to_json();
+    let _maybe_just_json =
+        compile_and_run(src, "maybeJust", &[], &mut HNil, &()).unwrap().to_json();
+    let _maybe_nothing_json =
+        compile_and_run(src, "maybeNothing", &[], &mut HNil, &()).unwrap().to_json();
+    let _nan_json =
+        compile_and_run(src, "nanVal", &[], &mut HNil, &()).unwrap().to_json();
+    let _inf_json =
+        compile_and_run(src, "infVal", &[], &mut HNil, &()).unwrap().to_json();
+    let _custom_json =
+        compile_and_run(src, "customData", &[], &mut HNil, &()).unwrap().to_json();
+    let _deep_json =
+        compile_and_run(src, "deepList", &[], &mut HNil, &()).unwrap().to_json();
 }


### PR DESCRIPTION
Adds an opaque EvalResult type that bundles Value + DataConTable, exposes to_json() for structured JSON rendering, and updates compile_and_run to return EvalResult.