### PR TITLE
feat(mcp): wire dogfood effect handlers into mcp-server example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,12 @@ name = "mcp-server-example"
 version = "0.0.1"
 dependencies = [
  "frunk",
+ "tidepool-bridge",
+ "tidepool-bridge-derive",
  "tidepool-effect",
  "tidepool-eval",
  "tidepool-mcp",
+ "tidepool-repr",
  "tokio",
 ]
 

--- a/examples/mcp-server/Cargo.toml
+++ b/examples/mcp-server/Cargo.toml
@@ -12,5 +12,8 @@ path = "src/main.rs"
 tidepool-mcp = { path = "../../tidepool-mcp" }
 tidepool-effect = { path = "../../tidepool-effect" }
 tidepool-eval = { path = "../../tidepool-eval" }
+tidepool-bridge = { path = "../../tidepool-bridge" }
+tidepool-bridge-derive = { path = "../../tidepool-bridge-derive" }
+tidepool-repr = { path = "../../tidepool-repr" }
 frunk = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/examples/mcp-server/src/main.rs
+++ b/examples/mcp-server/src/main.rs
@@ -58,7 +58,10 @@ impl KvHandler {
 impl EffectHandler<()> for KvHandler {
     type Request = KvReq;
     fn handle(&mut self, req: KvReq, cx: &EffectContext<'_, ()>) -> Result<Value, EffectError> {
-        let mut store = self.store.lock().unwrap();
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|e| EffectError::Handler(format!("Mutex poisoned: {}", e)))?;
         match req {
             KvReq::Get(key) => {
                 let val = store.get(&key).cloned();
@@ -130,7 +133,7 @@ impl FsHandler {
                 path
             )));
         }
-        Ok(resolved)
+        Ok(check_path)
     }
 }
 

--- a/examples/mcp-server/src/main.rs
+++ b/examples/mcp-server/src/main.rs
@@ -1,47 +1,163 @@
-//! Example MCP server demonstrating Tidepool with custom effect handlers.
-
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tidepool_bridge_derive::FromCore;
 use tidepool_effect::dispatch::{EffectContext, EffectHandler};
 use tidepool_effect::error::EffectError;
 use tidepool_eval::value::Value;
 use tidepool_mcp::TidepoolMcpServer;
 
-/// Console effect handler — handles print-like effects (tag 0).
+// === Tag 0: Console ===
+#[derive(FromCore)]
+enum ConsoleReq {
+    #[core(name = "Print")]
+    Print(String),
+}
+
 #[derive(Clone)]
 struct ConsoleHandler;
 
 impl EffectHandler<()> for ConsoleHandler {
-    type Request = Value;
-
-    fn handle(
-        &mut self,
-        req: Self::Request,
-        cx: &EffectContext<'_, ()>,
-    ) -> Result<Value, EffectError> {
-        eprintln!("[console] {:?}", req);
-        cx.respond(())
+    type Request = ConsoleReq;
+    fn handle(&mut self, req: ConsoleReq, cx: &EffectContext<'_, ()>) -> Result<Value, EffectError> {
+        match req {
+            ConsoleReq::Print(s) => {
+                eprintln!("[console] {}", s);
+                cx.respond(())
+            }
+        }
     }
 }
 
-/// Environment effect handler — handles env-lookup effects (tag 1).
+// === Tag 1: KV Store ===
+#[derive(FromCore)]
+enum KvReq {
+    #[core(name = "KvGet")]
+    Get(String),
+    #[core(name = "KvSet")]
+    Set(String, Value),
+    #[core(name = "KvDelete")]
+    Delete(String),
+    #[core(name = "KvKeys")]
+    Keys,
+}
+
 #[derive(Clone)]
-struct EnvHandler;
+struct KvHandler {
+    store: Arc<Mutex<HashMap<String, Value>>>,
+}
 
-impl EffectHandler<()> for EnvHandler {
-    type Request = Value;
+impl KvHandler {
+    fn new() -> Self {
+        Self {
+            store: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
 
-    fn handle(
-        &mut self,
-        req: Self::Request,
-        cx: &EffectContext<'_, ()>,
-    ) -> Result<Value, EffectError> {
-        eprintln!("[env] lookup {:?}", req);
-        cx.respond("example_value".to_string())
+impl EffectHandler<()> for KvHandler {
+    type Request = KvReq;
+    fn handle(&mut self, req: KvReq, cx: &EffectContext<'_, ()>) -> Result<Value, EffectError> {
+        let mut store = self.store.lock().unwrap();
+        match req {
+            KvReq::Get(key) => {
+                let val = store.get(&key).cloned();
+                cx.respond(val)
+            }
+            KvReq::Set(key, val) => {
+                store.insert(key, val);
+                cx.respond(())
+            }
+            KvReq::Delete(key) => {
+                store.remove(&key);
+                cx.respond(())
+            }
+            KvReq::Keys => {
+                let keys: Vec<String> = store.keys().cloned().collect();
+                cx.respond(keys)
+            }
+        }
+    }
+}
+
+// === Tag 2: File I/O (sandboxed to working directory) ===
+#[derive(FromCore)]
+enum FsReq {
+    #[core(name = "FsRead")]
+    Read(String),
+    #[core(name = "FsWrite")]
+    Write(String, String),
+}
+
+#[derive(Clone)]
+struct FsHandler {
+    root: PathBuf,
+}
+
+impl FsHandler {
+    fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    fn resolve(&self, path: &str) -> Result<PathBuf, EffectError> {
+        let resolved = self.root.join(path);
+        // Sandbox: ensure resolved path is under root
+        let canonical_root = self
+            .root
+            .canonicalize()
+            .map_err(|e| EffectError::Handler(e.to_string()))?;
+        // For new files that don't exist yet, check parent
+        let check_path = if resolved.exists() {
+            resolved
+                .canonicalize()
+                .map_err(|e| EffectError::Handler(e.to_string()))?
+        } else {
+            let parent = resolved
+                .parent()
+                .ok_or_else(|| EffectError::Handler("no parent dir".into()))?;
+            let canonical_parent = parent
+                .canonicalize()
+                .map_err(|e| EffectError::Handler(e.to_string()))?;
+            canonical_parent.join(
+                resolved
+                    .file_name()
+                    .ok_or_else(|| EffectError::Handler("invalid filename".into()))?,
+            )
+        };
+        if !check_path.starts_with(&canonical_root) {
+            return Err(EffectError::Handler(format!(
+                "path escape: {} is outside sandbox",
+                path
+            )));
+        }
+        Ok(resolved)
+    }
+}
+
+impl EffectHandler<()> for FsHandler {
+    type Request = FsReq;
+    fn handle(&mut self, req: FsReq, cx: &EffectContext<'_, ()>) -> Result<Value, EffectError> {
+        match req {
+            FsReq::Read(path) => {
+                let resolved = self.resolve(&path)?;
+                let contents = std::fs::read_to_string(&resolved)
+                    .map_err(|e| EffectError::Handler(e.to_string()))?;
+                cx.respond(contents)
+            }
+            FsReq::Write(path, contents) => {
+                let resolved = self.resolve(&path)?;
+                std::fs::write(&resolved, &contents)
+                    .map_err(|e| EffectError::Handler(e.to_string()))?;
+                cx.respond(())
+            }
+        }
     }
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let handlers = frunk::hlist![ConsoleHandler, EnvHandler];
+    let cwd = std::env::current_dir()?;
+    let handlers = frunk::hlist![ConsoleHandler, KvHandler::new(), FsHandler::new(cwd)];
     let server = TidepoolMcpServer::new(handlers);
     server.serve_stdio().await
 }

--- a/tidepool-codegen/tests/effect_machine.rs
+++ b/tidepool-codegen/tests/effect_machine.rs
@@ -305,7 +305,7 @@ fn test_unexpected_tag() {
 /// Test 5: runtime_error(0) → YieldError::DivisionByZero.
 #[test]
 fn test_runtime_error_div_zero() {
-    let (_pipeline, func) = build_test_fn("test_div_zero", |builder, vmctx, gc_sig| {
+    let (_pipeline, func) = build_test_fn("test_div_zero", |builder, _vmctx, _gc_sig| {
         // Call runtime_error(0) which sets thread-local and returns null
         let mut err_sig = ir::Signature::new(builder.func.signature.call_conv);
         err_sig.params.push(AbiParam::new(types::I64));
@@ -343,7 +343,7 @@ fn test_runtime_error_div_zero() {
 /// Test 6: runtime_error(1) → YieldError::Overflow.
 #[test]
 fn test_runtime_error_overflow() {
-    let (_pipeline, func) = build_test_fn("test_overflow", |builder, vmctx, gc_sig| {
+    let (_pipeline, func) = build_test_fn("test_overflow", |builder, _vmctx, _gc_sig| {
         let mut err_sig = ir::Signature::new(builder.func.signature.call_conv);
         err_sig.params.push(AbiParam::new(types::I64));
         err_sig.returns.push(AbiParam::new(types::I64));
@@ -380,7 +380,7 @@ fn test_runtime_error_overflow() {
 /// Test 7: null without runtime_error → YieldError::NullPointer (not a false positive).
 #[test]
 fn test_null_without_runtime_error() {
-    let (_pipeline, func) = build_test_fn("test_null", |builder, vmctx, gc_sig| {
+    let (_pipeline, func) = build_test_fn("test_null", |builder, _vmctx, _gc_sig| {
         let null = builder.ins().iconst(types::I64, 0);
         builder.ins().return_(&[null]);
     });

--- a/tidepool-runtime/tests/integration.rs
+++ b/tidepool-runtime/tests/integration.rs
@@ -1,5 +1,5 @@
 use frunk::HNil;
-use tidepool_runtime::{compile_haskell, compile_and_run, Value, EvalResult};
+use tidepool_runtime::{compile_haskell, compile_and_run, Value};
 use tidepool_repr::Literal;
 
 #[test]


### PR DESCRIPTION
Implement real effect handlers for Console, KV store, and sandboxed File I/O in the mcp-server example. This provides a functional reference for integrating concrete handlers with the TidepoolMcpServer.

- Console: Print to stderr
- KV Store: Arc<Mutex<HashMap>> for persistence
- File I/O: Path-sandboxed read/write