### PR TITLE
refactor(codegen): convert pipeline panics to Results

### DIFF
--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -290,6 +290,9 @@ impl CompiledEffectMachine {
     unsafe fn alloc_con(&mut self, con_tag: u64, fields: &[*mut u8]) -> *mut u8 {
         let size = 24 + 8 * fields.len();
         let ptr = heap_bridge::bump_alloc_from_vmctx(&mut self.vmctx, size);
+        if ptr.is_null() {
+            return std::ptr::null_mut();
+        }
         layout::write_header(ptr, layout::TAG_CON, size as u16);
         *(ptr.add(layout::CON_TAG_OFFSET) as *mut u64) = con_tag;
         *(ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *mut u16) = fields.len() as u16;

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -17,8 +17,7 @@ pub fn compile_expr(
     name: &str,
 ) -> Result<FuncId, EmitError> {
     let sig = pipeline.make_func_signature();
-    let func_id = pipeline.module.declare_function(name, Linkage::Export, &sig)
-        .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+    let func_id = pipeline.declare_function(name)?;
 
     let mut ctx = Context::new();
     ctx.func.signature = sig;
@@ -46,7 +45,7 @@ pub fn compile_expr(
     builder.ins().return_(&[ret]);
     builder.finalize();
 
-    pipeline.define_function(func_id, &mut ctx);
+    pipeline.define_function(func_id, &mut ctx)?;
 
     Ok(func_id)
 }
@@ -238,7 +237,7 @@ impl EmitContext {
                 inner_builder.finalize();
 
                 self.lambda_counter = inner_emit.lambda_counter;
-                pipeline.define_function(lambda_func_id, &mut inner_ctx);
+                pipeline.define_function(lambda_func_id, &mut inner_ctx)?;
 
                 let func_ref = pipeline.module.declare_func_in_func(lambda_func_id, builder.func);
                 let code_ptr = builder.ins().func_addr(types::I64, func_ref);
@@ -441,7 +440,7 @@ impl EmitContext {
                     inner_builder.ins().return_(&[ret_val]);
                     inner_builder.finalize();
                     self.lambda_counter = inner_emit.lambda_counter;
-                    pipeline.define_function(lambda_func_id, &mut inner_ctx);
+                    pipeline.define_function(lambda_func_id, &mut inner_ctx)?;
 
                     let func_ref = pipeline.module.declare_func_in_func(lambda_func_id, builder.func);
                     let code_ptr = builder.ins().func_addr(types::I64, func_ref);

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -62,6 +62,7 @@ pub enum EmitError {
     UnboundVariable(VarId),
     NotYetImplemented(String),
     CraneliftError(String),
+    Pipeline(crate::pipeline::PipelineError),
     InvalidArity(PrimOpKind, usize, usize),
 }
 
@@ -71,6 +72,7 @@ impl std::fmt::Display for EmitError {
             EmitError::UnboundVariable(v) => write!(f, "unbound variable: {:?}", v),
             EmitError::NotYetImplemented(s) => write!(f, "not yet implemented: {}", s),
             EmitError::CraneliftError(s) => write!(f, "cranelift error: {}", s),
+            EmitError::Pipeline(e) => write!(f, "pipeline error: {}", e),
             EmitError::InvalidArity(op, expected, got) => {
                 write!(f, "invalid arity for {:?}: expected {}, got {}", op, expected, got)
             }
@@ -79,6 +81,12 @@ impl std::fmt::Display for EmitError {
 }
 
 impl std::error::Error for EmitError {}
+
+impl From<crate::pipeline::PipelineError> for EmitError {
+    fn from(e: crate::pipeline::PipelineError) -> Self {
+        EmitError::Pipeline(e)
+    }
+}
 
 impl EmitContext {
     pub fn new(prefix: String) -> Self {

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -91,26 +91,30 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
             if ptr.is_null() {
                 return Err(BridgeError::NurseryExhausted);
             }
-            layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
 
             match lit {
                 Literal::LitInt(n) => {
+                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
                     *ptr.add(layout::LIT_TAG_OFFSET) = 0;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *n;
                 }
                 Literal::LitWord(n) => {
+                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
                     *ptr.add(layout::LIT_TAG_OFFSET) = 1;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *n as i64;
                 }
                 Literal::LitChar(c) => {
+                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
                     *ptr.add(layout::LIT_TAG_OFFSET) = 2;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *c as i64;
                 }
                 Literal::LitFloat(bits) => {
+                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
                     *ptr.add(layout::LIT_TAG_OFFSET) = 3;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *bits as i64;
                 }
                 Literal::LitDouble(bits) => {
+                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
                     *ptr.add(layout::LIT_TAG_OFFSET) = 4;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *bits as i64;
                 }
@@ -119,6 +123,8 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
                     let data_size = 8 + bytes.len();
                     let data_ptr = bump_alloc_from_vmctx(vmctx, data_size);
                     if data_ptr.is_null() {
+                        // Roll back the Lit object allocation to avoid dead space in nursery
+                        vmctx.alloc_ptr = ptr;
                         return Err(BridgeError::NurseryExhausted);
                     }
                     *(data_ptr as *mut u64) = bytes.len() as u64;
@@ -127,6 +133,9 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
                         data_ptr.add(8),
                         bytes.len(),
                     );
+                    
+                    // Only write the header once we're sure all allocations succeeded
+                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
                     *ptr.add(layout::LIT_TAG_OFFSET) = 5;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = data_ptr as i64;
                 }

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -9,6 +9,7 @@ pub enum BridgeError {
     UnexpectedHeapTag(u8),
     UnexpectedLitTag(u8),
     NullPointer,
+    NurseryExhausted,
 }
 
 impl fmt::Display for BridgeError {
@@ -17,6 +18,7 @@ impl fmt::Display for BridgeError {
             BridgeError::UnexpectedHeapTag(t) => write!(f, "unexpected heap tag: {}", t),
             BridgeError::UnexpectedLitTag(t) => write!(f, "unexpected lit tag: {}", t),
             BridgeError::NullPointer => write!(f, "null pointer"),
+            BridgeError::NurseryExhausted => write!(f, "nursery exhausted"),
         }
     }
 }
@@ -86,6 +88,9 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
     match val {
         Value::Lit(lit) => {
             let ptr = bump_alloc_from_vmctx(vmctx, layout::LIT_SIZE);
+            if ptr.is_null() {
+                return Err(BridgeError::NurseryExhausted);
+            }
             layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
 
             match lit {
@@ -113,6 +118,9 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
                     // Allocate string data: [len: u64][bytes...]
                     let data_size = 8 + bytes.len();
                     let data_ptr = bump_alloc_from_vmctx(vmctx, data_size);
+                    if data_ptr.is_null() {
+                        return Err(BridgeError::NurseryExhausted);
+                    }
                     *(data_ptr as *mut u64) = bytes.len() as u64;
                     std::ptr::copy_nonoverlapping(
                         bytes.as_ptr(),
@@ -134,6 +142,9 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
 
             let size = 24 + 8 * fields.len();
             let ptr = bump_alloc_from_vmctx(vmctx, size);
+            if ptr.is_null() {
+                return Err(BridgeError::NurseryExhausted);
+            }
             layout::write_header(ptr, layout::TAG_CON, size as u16);
 
             *(ptr.add(layout::CON_TAG_OFFSET) as *mut u64) = id.0;
@@ -148,7 +159,7 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
     }
 }
 
-/// Bump-allocate from VMContext. Panics if nursery is exhausted.
+/// Bump-allocate from VMContext. Returns null if nursery is exhausted.
 ///
 /// # Safety
 ///
@@ -159,11 +170,7 @@ pub unsafe fn bump_alloc_from_vmctx(vmctx: &mut VMContext, size: usize) -> *mut 
     let ptr = vmctx.alloc_ptr;
     let new_ptr = ptr.add(aligned_size);
     if new_ptr as *const u8 > vmctx.alloc_limit {
-        panic!(
-            "nursery exhausted: tried to allocate {} bytes, {} remaining",
-            aligned_size,
-            vmctx.alloc_limit as usize - ptr as usize
-        );
+        return std::ptr::null_mut();
     }
     vmctx.alloc_ptr = new_ptr;
     ptr

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -14,6 +14,7 @@ use crate::yield_type::Yield;
 #[derive(Debug)]
 pub enum JitError {
     Compilation(crate::emit::EmitError),
+    Pipeline(crate::pipeline::PipelineError),
     MissingConTags,
     Effect(EffectError),
     Yield(crate::yield_type::YieldError),
@@ -24,6 +25,7 @@ impl std::fmt::Display for JitError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             JitError::Compilation(e) => write!(f, "JIT compilation error: {}", e),
+            JitError::Pipeline(e) => write!(f, "pipeline error: {}", e),
             JitError::MissingConTags => write!(f, "missing freer-simple constructors in DataConTable"),
             JitError::Effect(e) => write!(f, "effect dispatch error: {}", e),
             JitError::Yield(e) => write!(f, "yield error: {}", e),
@@ -37,6 +39,12 @@ impl std::error::Error for JitError {}
 impl From<EffectError> for JitError {
     fn from(e: EffectError) -> Self {
         JitError::Effect(e)
+    }
+}
+
+impl From<crate::pipeline::PipelineError> for JitError {
+    fn from(e: crate::pipeline::PipelineError) -> Self {
+        JitError::Pipeline(e)
     }
 }
 
@@ -60,7 +68,7 @@ impl JitEffectMachine {
         let mut pipeline = CodegenPipeline::new(&crate::host_fns::host_fn_symbols());
         let func_id = crate::emit::expr::compile_expr(&mut pipeline, &expr, "main")
             .map_err(JitError::Compilation)?;
-        pipeline.finalize();
+        pipeline.finalize()?;
 
         let tags = ConTags::from_table(table).ok_or(JitError::MissingConTags)?;
         let nursery = Nursery::new(nursery_size);

--- a/tidepool-codegen/src/pipeline.rs
+++ b/tidepool-codegen/src/pipeline.rs
@@ -10,6 +10,32 @@ use std::sync::Arc;
 use crate::debug::LambdaRegistry;
 use crate::stack_map::{StackMapRegistry, RawStackMap};
 
+/// Errors from the Cranelift compilation pipeline.
+#[derive(Debug)]
+pub enum PipelineError {
+    /// Function declaration failed.
+    Declaration(String),
+    /// First-pass compilation failed (stack map extraction).
+    Compilation(String),
+    /// Module define_function failed.
+    Definition(String),
+    /// Module finalize_definitions failed.
+    Finalization(String),
+}
+
+impl std::fmt::Display for PipelineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PipelineError::Declaration(e) => write!(f, "function declaration failed: {}", e),
+            PipelineError::Compilation(e) => write!(f, "compilation failed: {}", e),
+            PipelineError::Definition(e) => write!(f, "define_function failed: {}", e),
+            PipelineError::Finalization(e) => write!(f, "finalize_definitions failed: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for PipelineError {}
+
 /// Cranelift JIT compilation pipeline.
 ///
 /// Implements the double-compile strategy:
@@ -80,11 +106,11 @@ impl CodegenPipeline {
     }
 
     /// Declare a function in the JIT module.
-    pub fn declare_function(&mut self, name: &str) -> FuncId {
+    pub fn declare_function(&mut self, name: &str) -> Result<FuncId, PipelineError> {
         let sig = self.make_func_signature();
         self.module
             .declare_function(name, Linkage::Export, &sig)
-            .unwrap_or_else(|e| panic!("failed to declare function `{}`: {}", name, e))
+            .map_err(|e| PipelineError::Declaration(format!("failed to declare `{}`: {}", name, e)))
     }
 
     /// Compile a function using the double-compile strategy.
@@ -94,13 +120,11 @@ impl CodegenPipeline {
     /// 3. Calls `module.define_function()` which recompiles for execution
     ///
     /// After calling this for all functions, call `finalize()` to make them callable.
-    pub fn define_function(&mut self, func_id: FuncId, ctx: &mut Context) {
+    pub fn define_function(&mut self, func_id: FuncId, ctx: &mut Context) -> Result<(), PipelineError> {
         // First compile: extract stack maps
         let mut ctrl_plane = ControlPlane::default();
         let compiled = ctx.compile(self.isa.as_ref(), &mut ctrl_plane)
-            .unwrap_or_else(|e| {
-                panic!("first compilation failed for function ID {:?}: {:?}", func_id, e);
-            });
+            .map_err(|e| PipelineError::Compilation(format!("{:?}", e)))?;
 
         let func_size = compiled.buffer.data().len() as u32;
 
@@ -118,19 +142,18 @@ impl CodegenPipeline {
         // Second compile: define in module for execution
         self.module
             .define_function(func_id, ctx)
-            .unwrap_or_else(|e| {
-                panic!("define_function failed for FuncId {:?}: {:?}", func_id, e);
-            });
+            .map_err(|e| PipelineError::Definition(format!("{:?}", e)))?;
 
         // Store raw maps and register after finalize.
         self.pending_stack_maps.push((func_id, func_size, raw_maps));
+        Ok(())
     }
 
     /// Finalize all defined functions, making them callable.
     /// Also registers stack maps now that we have function base pointers.
-    pub fn finalize(&mut self) {
+    pub fn finalize(&mut self) -> Result<(), PipelineError> {
         self.module.finalize_definitions()
-            .expect("finalize_definitions failed");
+            .map_err(|e| PipelineError::Finalization(format!("{}", e)))?;
 
         // Now register stack maps with actual base pointers
         let pending = std::mem::take(&mut self.pending_stack_maps);
@@ -138,6 +161,7 @@ impl CodegenPipeline {
             let base_ptr = self.module.get_finalized_function(func_id) as usize;
             self.stack_maps.register(base_ptr, func_size, &raw_maps);
         }
+        Ok(())
     }
 
     /// Get the callable function pointer after finalization.

--- a/tidepool-codegen/tests/effect_machine.rs
+++ b/tidepool-codegen/tests/effect_machine.rs
@@ -24,7 +24,7 @@ where
     F: FnOnce(&mut FunctionBuilder, ir::Value, ir::SigRef),
 {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
-    let func_id = pipeline.declare_function(name);
+    let func_id = pipeline.declare_function(name).expect("failed to declare");
 
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
@@ -48,8 +48,8 @@ where
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     let ptr = pipeline.get_function_ptr(func_id);
     let func = unsafe { std::mem::transmute(ptr) };

--- a/tidepool-codegen/tests/emit_case.rs
+++ b/tidepool-codegen/tests/emit_case.rs
@@ -15,7 +15,7 @@ struct TestResult {
 fn compile_and_run(tree: &CoreExpr) -> TestResult {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
     let func_id = compile_expr(&mut pipeline, tree, "test_fn").expect("compile_expr failed");
-    pipeline.finalize();
+    pipeline.finalize().expect("failed to finalize");
     
     let mut nursery = vec![0u8; 65536]; // 64KB nursery
     let start = nursery.as_mut_ptr();

--- a/tidepool-codegen/tests/emit_expr.rs
+++ b/tidepool-codegen/tests/emit_expr.rs
@@ -15,7 +15,7 @@ struct TestResult {
 fn compile_and_run(tree: &CoreExpr) -> TestResult {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
     let func_id = compile_expr(&mut pipeline, tree, "test_fn").expect("compile_expr failed");
-    pipeline.finalize();
+    pipeline.finalize().expect("failed to finalize");
     
     let mut nursery = vec![0u8; 65536]; // 64KB nursery
     let start = nursery.as_mut_ptr();

--- a/tidepool-codegen/tests/emit_join.rs
+++ b/tidepool-codegen/tests/emit_join.rs
@@ -15,7 +15,7 @@ struct TestResult {
 fn compile_and_run(tree: &CoreExpr) -> TestResult {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
     let func_id = compile_expr(&mut pipeline, tree, "test_fn").expect("compile_expr failed");
-    pipeline.finalize();
+    pipeline.finalize().expect("failed to finalize");
     
     let mut nursery = vec![0u8; 65536]; // 64KB nursery
     let start = nursery.as_mut_ptr();

--- a/tidepool-codegen/tests/emit_letrec_con.rs
+++ b/tidepool-codegen/tests/emit_letrec_con.rs
@@ -21,7 +21,7 @@ struct TestResult {
 fn compile_and_run(tree: &CoreExpr) -> TestResult {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
     let func_id = compile_expr(&mut pipeline, tree, "test_fn").expect("compile_expr failed");
-    pipeline.finalize();
+    pipeline.finalize().expect("failed to finalize");
 
     let mut nursery = vec![0u8; 65536];
     let start = nursery.as_mut_ptr();
@@ -419,5 +419,5 @@ fn compile_repl_cbor_inner() {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
     let result = compile_expr(&mut pipeline, &expr, "repl");
     assert!(result.is_ok(), "compile_expr failed: {:?}", result.err());
-    pipeline.finalize();
+    pipeline.finalize().expect("failed to finalize");
 }

--- a/tidepool-codegen/tests/gc_audit.rs
+++ b/tidepool-codegen/tests/gc_audit.rs
@@ -43,7 +43,7 @@ fn test_stack_map_app_safepoints() {
     let tree = CoreExpr { nodes };
     
     let _ = compile_expr(&mut pipeline, &tree, "test_app").unwrap();
-    pipeline.finalize();
+    pipeline.finalize().expect("failed to finalize");
     
     // The App(0, 1) is a safepoint.
     assert!(!pipeline.stack_maps.is_empty(), "Stack maps should be generated for App");
@@ -77,7 +77,7 @@ fn test_stack_map_case_safepoints() {
     
     let tree = CoreExpr { nodes };
     let _ = compile_expr(&mut pipeline, &tree, "test_case_safepoint").unwrap();
-    pipeline.finalize();
+    pipeline.finalize().expect("failed to finalize");
     
     // App(0, 1) inside Case alt is a safepoint.
     assert!(!pipeline.stack_maps.is_empty(), "Stack maps should be generated for App in Case alt");
@@ -112,7 +112,7 @@ fn test_stack_map_join_safepoints() {
     let tree = CoreExpr { nodes };
     
     let _ = compile_expr(&mut pipeline, &tree, "test_join_safepoint").unwrap();
-    pipeline.finalize();
+    pipeline.finalize().expect("failed to finalize");
     
     // App(0, 1) in RHS is a safepoint.
     assert!(!pipeline.stack_maps.is_empty(), "Stack maps should be generated for App in Join RHS");

--- a/tidepool-codegen/tests/gc_frame_walker.rs
+++ b/tidepool-codegen/tests/gc_frame_walker.rs
@@ -20,7 +20,7 @@ fn test_frame_walker_finds_roots() {
     };
     let gc_id = pipeline.module.declare_function("gc_trigger", cranelift_module::Linkage::Import, &gc_sig_ext).unwrap();
 
-    let func_id = pipeline.declare_function("test_find_roots");
+    let func_id = pipeline.declare_function("test_find_roots").expect("failed to declare");
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
     let mut fb_ctx = FunctionBuilderContext::new();
@@ -52,8 +52,8 @@ fn test_frame_walker_finds_roots() {
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     host_fns::reset_test_counters();
     host_fns::set_stack_map_registry(&pipeline.stack_maps);
@@ -91,7 +91,7 @@ fn test_frame_walker_rewrite_roots() {
     };
     let gc_id = pipeline.module.declare_function("gc_trigger", cranelift_module::Linkage::Import, &gc_sig_ext).unwrap();
 
-    let func_id = pipeline.declare_function("test_rewrite_roots");
+    let func_id = pipeline.declare_function("test_rewrite_roots").expect("failed to declare");
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
     let mut fb_ctx = FunctionBuilderContext::new();
@@ -118,8 +118,8 @@ fn test_frame_walker_rewrite_roots() {
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     host_fns::reset_test_counters();
     host_fns::set_stack_map_registry(&pipeline.stack_maps);
@@ -152,7 +152,7 @@ fn test_frame_walker_rewrite_roots() {
 #[test]
 fn test_frame_walker_terminates_at_jit_boundary() {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
-    let func_id = pipeline.declare_function("test_boundary");
+    let func_id = pipeline.declare_function("test_boundary").expect("failed to declare");
 
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
@@ -179,8 +179,8 @@ fn test_frame_walker_terminates_at_jit_boundary() {
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     host_fns::reset_test_counters();
     host_fns::set_stack_map_registry(&pipeline.stack_maps);

--- a/tidepool-codegen/tests/scaffold.rs
+++ b/tidepool-codegen/tests/scaffold.rs
@@ -12,7 +12,7 @@ use cranelift_module::Module;
 #[test]
 fn test_jit_boot_empty_fn() {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
-    let func_id = pipeline.declare_function("test_empty");
+    let func_id = pipeline.declare_function("test_empty").expect("failed to declare");
 
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
@@ -30,8 +30,8 @@ fn test_jit_boot_empty_fn() {
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     let ptr = pipeline.get_function_ptr(func_id);
     let func: unsafe extern "C" fn(*mut VMContext) -> i64 = unsafe { std::mem::transmute(ptr) };
@@ -69,7 +69,7 @@ fn test_stack_map_registry_populates() {
     };
     let callee_id = pipeline.module.declare_function("callee", cranelift_module::Linkage::Import, &callee_sig).unwrap();
 
-    let func_id = pipeline.declare_function("test_stack_maps");
+    let func_id = pipeline.declare_function("test_stack_maps").expect("failed to declare");
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
     let mut fb_ctx = FunctionBuilderContext::new();
@@ -98,8 +98,8 @@ fn test_stack_map_registry_populates() {
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     // Stack maps should have been populated
     assert!(!pipeline.stack_maps.is_empty(), "Stack map registry should have entries");
@@ -121,7 +121,7 @@ fn test_gc_trigger_called_from_jit() {
     };
     let gc_id = pipeline.module.declare_function("gc_trigger", cranelift_module::Linkage::Import, &gc_sig).unwrap();
 
-    let func_id = pipeline.declare_function("test_rbp");
+    let func_id = pipeline.declare_function("test_rbp").expect("failed to declare");
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
     let mut fb_ctx = FunctionBuilderContext::new();
@@ -143,8 +143,8 @@ fn test_gc_trigger_called_from_jit() {
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     host_fns::reset_test_counters();
 
@@ -167,7 +167,7 @@ fn test_gc_trigger_called_from_jit() {
 #[test]
 fn test_alloc_fast_path() {
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
-    let func_id = pipeline.declare_function("test_alloc");
+    let func_id = pipeline.declare_function("test_alloc").expect("failed to declare");
 
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
@@ -193,8 +193,8 @@ fn test_alloc_fast_path() {
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     // Set up VMContext with nursery
     let mut nursery = vec![0u8; 4096];
@@ -227,7 +227,7 @@ fn test_stack_map_end_to_end() {
     };
     let gc_id = pipeline.module.declare_function("gc_trigger", cranelift_module::Linkage::Import, &gc_sig_ext).unwrap();
 
-    let func_id = pipeline.declare_function("test_e2e");
+    let func_id = pipeline.declare_function("test_e2e").expect("failed to declare");
     let mut ctx = Context::new();
     ctx.func = ir::Function::with_name_signature(UserFuncName::default(), pipeline.make_func_signature());
     let mut fb_ctx = FunctionBuilderContext::new();
@@ -256,8 +256,8 @@ fn test_stack_map_end_to_end() {
         builder.finalize();
     }
 
-    pipeline.define_function(func_id, &mut ctx);
-    pipeline.finalize();
+    pipeline.define_function(func_id, &mut ctx).expect("failed to define");
+    pipeline.finalize().expect("failed to finalize");
 
     // Verify stack maps have entries with 2 offsets at the safepoint
     assert!(!pipeline.stack_maps.is_empty());


### PR DESCRIPTION
This PR converts various panics in the `tidepool-codegen` pipeline and heap bridge to `Result` types.

Key changes:
- Introduced `PipelineError` for `CodegenPipeline` methods.
- Propagated `PipelineError` through `JitError` and `EmitError`.
- Updated `bump_alloc_from_vmctx` to return null on nursery exhaustion instead of panicking.
- Updated `value_to_heap` and the effect machine's `alloc_con` to handle allocation failure.
- Updated all integration tests in `tidepool-codegen` to handle the new `Result` return types.