### PR TITLE
feat(mcp): capture Console output in eval responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,8 @@ dependencies = [
  "tidepool-mcp",
  "tidepool-repr",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/examples/mcp-server/src/main.rs
+++ b/examples/mcp-server/src/main.rs
@@ -5,7 +5,7 @@ use tidepool_bridge_derive::FromCore;
 use tidepool_effect::dispatch::{EffectContext, EffectHandler};
 use tidepool_effect::error::EffectError;
 use tidepool_eval::value::Value;
-use tidepool_mcp::{DescribeEffect, EffectDecl, TidepoolMcpServer};
+use tidepool_mcp::{CapturedOutput, DescribeEffect, EffectDecl, TidepoolMcpServer};
 
 // === Tag 0: Console ===
 
@@ -28,12 +28,12 @@ impl DescribeEffect for ConsoleHandler {
     }
 }
 
-impl EffectHandler<()> for ConsoleHandler {
+impl EffectHandler<CapturedOutput> for ConsoleHandler {
     type Request = ConsoleReq;
-    fn handle(&mut self, req: ConsoleReq, cx: &EffectContext<'_, ()>) -> Result<Value, EffectError> {
+    fn handle(&mut self, req: ConsoleReq, cx: &EffectContext<'_, CapturedOutput>) -> Result<Value, EffectError> {
         match req {
             ConsoleReq::Print(s) => {
-                eprintln!("[console] {}", s);
+                cx.user().push(s);
                 cx.respond(())
             }
         }
@@ -82,9 +82,9 @@ impl DescribeEffect for KvHandler {
     }
 }
 
-impl EffectHandler<()> for KvHandler {
+impl EffectHandler<CapturedOutput> for KvHandler {
     type Request = KvReq;
-    fn handle(&mut self, req: KvReq, cx: &EffectContext<'_, ()>) -> Result<Value, EffectError> {
+    fn handle(&mut self, req: KvReq, cx: &EffectContext<'_, CapturedOutput>) -> Result<Value, EffectError> {
         let mut store = self
             .store
             .lock()
@@ -176,9 +176,9 @@ impl DescribeEffect for FsHandler {
     }
 }
 
-impl EffectHandler<()> for FsHandler {
+impl EffectHandler<CapturedOutput> for FsHandler {
     type Request = FsReq;
-    fn handle(&mut self, req: FsReq, cx: &EffectContext<'_, ()>) -> Result<Value, EffectError> {
+    fn handle(&mut self, req: FsReq, cx: &EffectContext<'_, CapturedOutput>) -> Result<Value, EffectError> {
         match req {
             FsReq::Read(path) => {
                 let resolved = self.resolve(&path)?;

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -197,14 +197,43 @@ fn format_error_with_source(title: &str, error: &str, source: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Output capture
+// ---------------------------------------------------------------------------
+
+/// Captured output from effect handlers (e.g., Console Print).
+///
+/// Clone is cheap (Arc-backed). Thread-safe for use across spawn_blocking.
+#[derive(Clone, Default)]
+pub struct CapturedOutput {
+    lines: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl CapturedOutput {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push a line of output.
+    pub fn push(&self, line: String) {
+        self.lines.lock().unwrap().push(line);
+    }
+
+    /// Drain all captured lines, returning them and clearing the buffer.
+    pub fn drain(&self) -> Vec<String> {
+        let mut lines = self.lines.lock().unwrap();
+        std::mem::take(&mut *lines)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Server internals
 // ---------------------------------------------------------------------------
 
 /// Trait combining effect dispatch with cloning for the MCP server.
-pub trait McpEffectHandler: DispatchEffect<()> + DynClone + Send + Sync + 'static {}
+pub trait McpEffectHandler: DispatchEffect<CapturedOutput> + DynClone + Send + Sync + 'static {}
 clone_trait_object!(McpEffectHandler);
 
-impl<T> McpEffectHandler for T where T: DispatchEffect<()> + Clone + Send + Sync + 'static {}
+impl<T> McpEffectHandler for T where T: DispatchEffect<CapturedOutput> + Clone + Send + Sync + 'static {}
 
 /// Generic MCP server wrapper that compiles and runs Haskell via Tidepool.
 #[derive(Clone)]
@@ -225,12 +254,12 @@ pub struct TidepoolMcpServerImpl {
 
 struct HandlerWrapper<'a>(&'a mut dyn McpEffectHandler);
 
-impl<'a> DispatchEffect<()> for HandlerWrapper<'a> {
+impl<'a> DispatchEffect<CapturedOutput> for HandlerWrapper<'a> {
     fn dispatch(
         &mut self,
         tag: u64,
         request: &tidepool_eval::value::Value,
-        cx: &tidepool_effect::dispatch::EffectContext<'_, ()>,
+        cx: &tidepool_effect::dispatch::EffectContext<'_, CapturedOutput>,
     ) -> Result<tidepool_eval::value::Value, tidepool_effect::error::EffectError> {
         self.0.dispatch(tag, request, cx)
     }
@@ -251,6 +280,8 @@ impl TidepoolMcpServerImpl {
         let mut handlers = dyn_clone::clone_box(&*self.handler_factory);
         let include_refs: Vec<PathBuf> = self.include.clone();
         let source_for_blocking = Arc::clone(&source);
+        let captured = CapturedOutput::new();
+        let captured_for_blocking = captured.clone();
 
         let result = tokio::task::spawn_blocking(move || {
             let include_paths: Vec<&Path> = include_refs.iter().map(|p| p.as_path()).collect();
@@ -261,19 +292,29 @@ impl TidepoolMcpServerImpl {
                     "result",
                     &include_paths,
                     &mut wrapper,
-                    &(),
+                    &captured_for_blocking,
                 )
             }))
         })
         .await
         .map_err(|e| McpError::internal_error(format!("task join error: {}", e), None))?;
 
+        let output_lines = captured.drain();
+
         match result {
             Ok(Ok(eval_result)) => {
                 tracing::info!("eval succeeded");
-                Ok(CallToolResult::success(vec![Content::text(
-                    eval_result.to_string_pretty(),
-                )]))
+                let mut response = String::new();
+                if !output_lines.is_empty() {
+                    response.push_str("## Output\n");
+                    for line in &output_lines {
+                        response.push_str(line);
+                        response.push('\n');
+                    }
+                    response.push_str("\n## Result\n");
+                }
+                response.push_str(&eval_result.to_string_pretty());
+                Ok(CallToolResult::success(vec![Content::text(response)]))
             }
             Ok(Err(e)) => {
                 let error_msg = format_error_with_source("Error", &e.to_string(), &source);
@@ -370,7 +411,7 @@ impl ServerHandler for TidepoolMcpServerImpl {
 
 impl<H> TidepoolMcpServer<H>
 where
-    H: DispatchEffect<()> + Clone + Send + Sync + 'static + CollectEffectDecls,
+    H: DispatchEffect<CapturedOutput> + Clone + Send + Sync + 'static + CollectEffectDecls,
 {
     /// Create a new server with the given effect handler stack.
     ///


### PR DESCRIPTION
This PR adds output capture for Console effects in the Tidepool MCP server.

- Added 'CapturedOutput' to 'tidepool-mcp' to store output lines.
- Updated 'McpEffectHandler' to use 'CapturedOutput' as user context.
- Modified 'eval' tool to drain and prepend captured output to the response.
- Updated 'ConsoleHandler' in 'mcp-server-example' to use 'CapturedOutput' instead of 'eprintln!'.