### PR TITLE
test: add unit tests for render.rs and impls.rs

### DIFF
--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -916,4 +916,68 @@ mod tests {
         let res = bool::from_value(&value, &table);
         assert!(matches!(res, Err(BridgeError::TypeMismatch { .. })));
     }
+
+    #[test]
+    fn test_string_unboxed_fields() {
+        let table = test_table();
+        let s = "hello".to_string();
+        let value = s.to_value(&table).expect("ToValue failed");
+        
+        if let Value::Con(id, fields) = value {
+            assert_eq!(table.name_of(id), Some("Text"));
+            assert_eq!(fields.len(), 3);
+            // First field: ByteArray# (unboxed)
+            assert!(matches!(fields[0], Value::ByteArray(_)));
+            // Second field: Int# 0 (unboxed literal)
+            assert!(matches!(fields[1], Value::Lit(Literal::LitInt(0))));
+            // Third field: Int# len (unboxed literal)
+            assert!(matches!(fields[2], Value::Lit(Literal::LitInt(5))));
+        } else {
+            panic!("Expected Con, got {:?}", value);
+        }
+    }
+
+    #[test]
+    fn test_unit_roundtrip() {
+        let table = test_table();
+        roundtrip((), &table);
+    }
+
+    #[test]
+    fn test_f64_boxed_roundtrip() {
+        let table = test_table();
+        roundtrip(3.14159f64, &table);
+    }
+
+    #[test]
+    fn test_u64_boxed_roundtrip() {
+        let table = test_table();
+        roundtrip(42u64, &table);
+    }
+
+    #[test]
+    fn test_char_boxed_roundtrip() {
+        let table = test_table();
+        roundtrip('a', &table);
+    }
+
+    #[test]
+    fn test_vec_string_roundtrip() {
+        let table = test_table();
+        roundtrip(vec!["a".to_string(), "b".to_string()], &table);
+    }
+
+    #[test]
+    fn test_option_nested_roundtrip() {
+        let table = test_table();
+        roundtrip(Some(vec![1i64, 2]), &table);
+        roundtrip(None::<Vec<i64>>, &table);
+    }
+
+    #[test]
+    fn test_result_nested_roundtrip() {
+        let table = test_table();
+        roundtrip(Ok::<Vec<i64>, String>(vec![1, 2]), &table);
+        roundtrip(Err::<Vec<i64>, String>("error".to_string()), &table);
+    }
 }

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -923,8 +923,8 @@ mod tests {
         let s = "hello".to_string();
         let value = s.to_value(&table).expect("ToValue failed");
         
-        if let Value::Con(id, fields) = value {
-            assert_eq!(table.name_of(id), Some("Text"));
+        if let Value::Con(id, fields) = &value {
+            assert_eq!(table.name_of(*id), Some("Text"));
             assert_eq!(fields.len(), 3);
             // First field: ByteArray# (unboxed)
             assert!(matches!(fields[0], Value::ByteArray(_)));

--- a/tidepool-runtime/src/render.rs
+++ b/tidepool-runtime/src/render.rs
@@ -281,3 +281,164 @@ fn collect_list(head: &Value, tail: &Value, table: &DataConTable, depth: usize) 
         json!(arr)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidepool_repr::datacon::DataCon;
+    use tidepool_repr::types::DataConId;
+    use std::sync::{Arc, Mutex};
+
+    fn test_table() -> DataConTable {
+        let mut t = DataConTable::new();
+        let cons = [
+            (0, "Nothing", 0),
+            (1, "Just", 1),
+            (2, "True", 0),
+            (3, "False", 0),
+            (4, "()", 0),
+            (5, "I#", 1),
+            (6, "C#", 1),
+            (7, ":", 2),
+            (8, "[]", 0),
+            (9, "Text", 3),
+            (10, "(,)", 2),
+            (11, "(,,)", 3),
+            (12, "ByteArray", 1),
+        ];
+        for (id, name, arity) in cons {
+            t.insert(DataCon {
+                id: DataConId(id),
+                name: name.into(),
+                tag: id as u32,
+                rep_arity: arity,
+                field_bangs: vec![],
+            });
+        }
+        t
+    }
+
+    #[test]
+    fn test_render_lit_int() {
+        let table = test_table();
+        let val = Value::Lit(Literal::LitInt(42));
+        assert_eq!(value_to_json(&val, &table, 0), json!(42));
+    }
+
+    #[test]
+    fn test_render_lit_string() {
+        let table = test_table();
+        let val = Value::Lit(Literal::LitString(b"hello".to_vec()));
+        assert_eq!(value_to_json(&val, &table, 0), json!("hello"));
+    }
+
+    #[test]
+    fn test_render_bool() {
+        let table = test_table();
+        let true_val = Value::Con(table.get_by_name("True").unwrap(), vec![]);
+        let false_val = Value::Con(table.get_by_name("False").unwrap(), vec![]);
+        assert_eq!(value_to_json(&true_val, &table, 0), json!(true));
+        assert_eq!(value_to_json(&false_val, &table, 0), json!(false));
+    }
+
+    #[test]
+    fn test_render_option() {
+        let table = test_table();
+        let nothing = Value::Con(table.get_by_name("Nothing").unwrap(), vec![]);
+        let just = Value::Con(table.get_by_name("Just").unwrap(), vec![Value::Lit(Literal::LitInt(42))]);
+        assert_eq!(value_to_json(&nothing, &table, 0), json!(null));
+        assert_eq!(value_to_json(&just, &table, 0), json!(42));
+    }
+
+    #[test]
+    fn test_render_unit() {
+        let table = test_table();
+        let unit = Value::Con(table.get_by_name("()").unwrap(), vec![]);
+        assert_eq!(value_to_json(&unit, &table, 0), json!(null));
+    }
+
+    #[test]
+    fn test_render_list_int() {
+        let table = test_table();
+        let nil_id = table.get_by_name("[]").unwrap();
+        let cons_id = table.get_by_name(":").unwrap();
+        
+        // [1, 2]
+        let list = Value::Con(cons_id, vec![
+            Value::Lit(Literal::LitInt(1)),
+            Value::Con(cons_id, vec![
+                Value::Lit(Literal::LitInt(2)),
+                Value::Con(nil_id, vec![])
+            ])
+        ]);
+        assert_eq!(value_to_json(&list, &table, 0), json!([1, 2]));
+    }
+
+    #[test]
+    fn test_render_text() {
+        let table = test_table();
+        let text_id = table.get_by_name("Text").unwrap();
+        let ba = Value::ByteArray(Arc::new(Mutex::new(b"hello".to_vec())));
+        let val = Value::Con(text_id, vec![
+            ba,
+            Value::Lit(Literal::LitInt(0)),
+            Value::Lit(Literal::LitInt(5))
+        ]);
+        assert_eq!(value_to_json(&val, &table, 0), json!("hello"));
+    }
+
+    #[test]
+    fn test_render_list_string() {
+        let table = test_table();
+        let nil_id = table.get_by_name("[]").unwrap();
+        let cons_id = table.get_by_name(":").unwrap();
+        
+        // ["a", "b"]
+        let list = Value::Con(cons_id, vec![
+            Value::Lit(Literal::LitString(b"a".to_vec())),
+            Value::Con(cons_id, vec![
+                Value::Lit(Literal::LitString(b"b".to_vec())),
+                Value::Con(nil_id, vec![])
+            ])
+        ]);
+        assert_eq!(value_to_json(&list, &table, 0), json!(["a", "b"]));
+    }
+
+    #[test]
+    fn test_render_tuple() {
+        let table = test_table();
+        let pair_id = table.get_by_name("(,)").unwrap();
+        let triple_id = table.get_by_name("(,,)").unwrap();
+        
+        let pair = Value::Con(pair_id, vec![
+            Value::Lit(Literal::LitInt(1)),
+            Value::Lit(Literal::LitInt(2))
+        ]);
+        let triple = Value::Con(triple_id, vec![
+            Value::Lit(Literal::LitInt(1)),
+            Value::Lit(Literal::LitInt(2)),
+            Value::Lit(Literal::LitInt(3))
+        ]);
+        
+        assert_eq!(value_to_json(&pair, &table, 0), json!([1, 2]));
+        assert_eq!(value_to_json(&triple, &table, 0), json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn test_render_char_list_as_string() {
+        let table = test_table();
+        let nil_id = table.get_by_name("[]").unwrap();
+        let cons_id = table.get_by_name(":").unwrap();
+        let c_hash_id = table.get_by_name("C#").unwrap();
+        
+        // ['h', 'i']
+        let list = Value::Con(cons_id, vec![
+            Value::Con(c_hash_id, vec![Value::Lit(Literal::LitChar('h'))]),
+            Value::Con(cons_id, vec![
+                Value::Con(c_hash_id, vec![Value::Lit(Literal::LitChar('i'))]),
+                Value::Con(nil_id, vec![])
+            ])
+        ]);
+        assert_eq!(value_to_json(&list, &table, 0), json!("hi"));
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests to `tidepool-runtime/src/render.rs` to verify JSON rendering of Haskell values. It also expands the unit tests in `tidepool-bridge/src/impls.rs` to cover more types and specifically verifies that `String::to_value` produces unboxed fields (JIT requirement).

Tests added in `render.rs`:
- `LitInt` -> JSON number
- `LitString` -> JSON string
- `Bool` (True/False) -> JSON true/false
- `Option None` (Nothing) -> JSON null
- `Option Some` (Just) -> unwrapped inner value
- List of ints -> JSON array
- `Text` constructor -> JSON string
- List of strings -> JSON array
- Tuples -> JSON array
- Char list -> JSON string

Tests expanded in `impls.rs`:
- `String::to_value` unboxed fields check (fixed potential move per review)
- `()` roundtrip
- `f64` roundtrip
- `u64` roundtrip
- `char` roundtrip
- `Vec<String>` roundtrip
- `Option` nested roundtrip
- `Result` nested roundtrip

All tests pass and `cargo check` is clean.