### PR TITLE
test: add CBOR roundtrip tests for CoreExpr and DataConTable

### DIFF
--- a/tidepool-repr/src/datacon_table.rs
+++ b/tidepool-repr/src/datacon_table.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 /// Lookup table for data constructor metadata.
 /// Populated during deserialization from the CBOR metadata section.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DataConTable {
     by_id: HashMap<DataConId, DataCon>,
     by_name: HashMap<String, DataConId>,

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -4,6 +4,7 @@ pub mod write;
 pub use read::read_cbor;
 pub use read::read_metadata;
 pub use write::write_cbor;
+pub use write::write_metadata;
 
 #[derive(Debug)]
 pub enum ReadError {
@@ -324,5 +325,31 @@ mod tests {
                 CoreFrame::App { fun: 1, arg: 2 }, // 3
             ],
         });
+    }
+
+    #[test]
+    fn test_roundtrip_metadata() {
+        use crate::datacon::{DataCon, SrcBang};
+        use crate::datacon_table::DataConTable;
+
+        let mut table = DataConTable::new();
+        table.insert(DataCon {
+            id: DataConId(1),
+            name: "Just".to_string(),
+            tag: 1,
+            rep_arity: 1,
+            field_bangs: vec![SrcBang::SrcBang],
+        });
+        table.insert(DataCon {
+            id: DataConId(2),
+            name: "Nothing".to_string(),
+            tag: 2,
+            rep_arity: 0,
+            field_bangs: vec![],
+        });
+
+        let bytes = write_metadata(&table).expect("write_metadata failed");
+        let recovered = read_metadata(&bytes).expect("read_metadata failed");
+        assert_eq!(table, recovered);
     }
 }

--- a/tidepool-repr/src/serial/write.rs
+++ b/tidepool-repr/src/serial/write.rs
@@ -30,6 +30,47 @@ pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, Wri
     Ok(bytes)
 }
 
+/// Writes a DataConTable to CBOR-encoded metadata bytes.
+pub fn write_metadata(table: &crate::datacon_table::DataConTable) -> Result<Vec<u8>, WriteError> {
+    use crate::datacon::SrcBang;
+
+    let mut entries = Vec::with_capacity(table.len());
+    for dc in table.iter() {
+        let dcid = dc.id.0;
+        let name = &dc.name;
+        let tag = dc.tag as u64;
+        let arity = dc.rep_arity as u64;
+        let bangs = Value::Array(
+            dc.field_bangs
+                .iter()
+                .map(|b| {
+                    Value::Text(
+                        match b {
+                            SrcBang::SrcBang => "SrcBang",
+                            SrcBang::SrcUnpack => "SrcUnpack",
+                            SrcBang::NoSrcBang => "NoSrcBang",
+                        }
+                        .to_string(),
+                    )
+                })
+                .collect(),
+        );
+
+        entries.push(Value::Array(vec![
+            Value::Integer(dcid.into()),
+            Value::Text(name.clone()),
+            Value::Integer(tag.into()),
+            Value::Integer(arity.into()),
+            bangs,
+        ]));
+    }
+
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&Value::Array(entries), &mut bytes)
+        .map_err(|e| WriteError::Cbor(e.to_string()))?;
+    Ok(bytes)
+}
+
 fn encode_frame(frame: &CoreFrame<usize>) -> Value {
     match frame {
         CoreFrame::Var(id) => Value::Array(vec![


### PR DESCRIPTION
This PR adds unit tests for CBOR serialization and deserialization in `tidepool-repr`.

Changes:
- Implemented `write_metadata` in `tidepool-repr/src/serial/write.rs` to support `DataConTable` serialization.
- Added `PartialEq` and `Eq` to `DataConTable` to facilitate comparison in tests.
- Added `test_roundtrip_metadata` to `tidepool-repr/src/serial/mod.rs`.
- Verified all 20 serial tests pass, covering `CoreExpr` frames and `DataConTable`.

The base branch for this PR is `main`.