### PR TITLE
test: add 8 JIT case expression tests

### DIFF
--- a/tidepool-codegen/tests/emit_case.rs
+++ b/tidepool-codegen/tests/emit_case.rs
@@ -264,3 +264,198 @@ fn test_case_lit_float() {
     let result = compile_and_run(&tree);
     unsafe { assert_eq!(read_lit_int(result.result_ptr), 77); }
 }
+
+#[test]
+fn test_case_bool() {
+    // case True of { True -> 1; False -> 0 }
+    let true_id = DataConId(1);
+    let false_id = DataConId(0);
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Con { tag: true_id, fields: vec![] },         // 0: scrutinee
+        CoreFrame::Lit(Literal::LitInt(1)),                    // 1: True body
+        CoreFrame::Lit(Literal::LitInt(0)),                    // 2: False body
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(true_id), binders: vec![], body: 1 },
+                Alt { con: AltCon::DataAlt(false_id), binders: vec![], body: 2 },
+            ],
+        },                                                      // 3: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 1); }
+}
+
+#[test]
+fn test_case_computed_int_compare() {
+    // case (3 > 2) of { 1# -> 10; 0# -> 20 }
+    // 3 > 2 returns 1# (True)
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(3)),                     // 0
+        CoreFrame::Lit(Literal::LitInt(2)),                     // 1
+        CoreFrame::PrimOp { op: PrimOpKind::IntGt, args: vec![0, 1] }, // 2: 3 > 2
+        CoreFrame::Lit(Literal::LitInt(10)),                    // 3: 1# body
+        CoreFrame::Lit(Literal::LitInt(20)),                    // 4: 0# body
+        CoreFrame::Case {
+            scrutinee: 2,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::LitAlt(Literal::LitInt(1)), binders: vec![], body: 3 },
+                Alt { con: AltCon::LitAlt(Literal::LitInt(0)), binders: vec![], body: 4 },
+            ],
+        },                                                      // 5: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 10); }
+}
+
+#[test]
+fn test_case_many_lit_alts() {
+    // case 2# of { 1# -> 10; 2# -> 20; 3# -> 30; DEFAULT -> 0 }
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(2)),                     // 0: scrutinee
+        CoreFrame::Lit(Literal::LitInt(10)),                    // 1
+        CoreFrame::Lit(Literal::LitInt(20)),                    // 2
+        CoreFrame::Lit(Literal::LitInt(30)),                    // 3
+        CoreFrame::Lit(Literal::LitInt(0)),                     // 4: default
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::LitAlt(Literal::LitInt(1)), binders: vec![], body: 1 },
+                Alt { con: AltCon::LitAlt(Literal::LitInt(2)), binders: vec![], body: 2 },
+                Alt { con: AltCon::LitAlt(Literal::LitInt(3)), binders: vec![], body: 3 },
+                Alt { con: AltCon::Default, binders: vec![], body: 4 },
+            ],
+        },                                                      // 5: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 20); }
+}
+
+#[test]
+fn test_case_word_lit() {
+    // case 0## of { 0## -> 100; DEFAULT -> 200 }
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitWord(0)),                    // 0: scrutinee
+        CoreFrame::Lit(Literal::LitInt(100)),                   // 1
+        CoreFrame::Lit(Literal::LitInt(200)),                   // 2: default
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::LitAlt(Literal::LitWord(0)), binders: vec![], body: 1 },
+                Alt { con: AltCon::Default, binders: vec![], body: 2 },
+            ],
+        },                                                      // 3: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 100); }
+}
+
+#[test]
+fn test_case_char_lit() {
+    // case 'b'# of { 'a'# -> 1; 'b'# -> 2; DEFAULT -> 0 }
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitChar('b')),                  // 0: scrutinee
+        CoreFrame::Lit(Literal::LitInt(1)),                     // 1
+        CoreFrame::Lit(Literal::LitInt(2)),                     // 2
+        CoreFrame::Lit(Literal::LitInt(0)),                     // 3: default
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::LitAlt(Literal::LitChar('a')), binders: vec![], body: 1 },
+                Alt { con: AltCon::LitAlt(Literal::LitChar('b')), binders: vec![], body: 2 },
+                Alt { con: AltCon::Default, binders: vec![], body: 3 },
+            ],
+        },                                                      // 4: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 2); }
+}
+
+#[test]
+fn test_case_nested_field_binding() {
+    // case Con(0, [Con(1, [42]), 99]) of { DataAlt(0) [a, b] -> case a of { DataAlt(1) [n] -> n } }
+    let a = VarId(1);
+    let b = VarId(2);
+    let n = VarId(3);
+    let outer_binder = VarId(98);
+    let inner_binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(42)),                    // 0
+        CoreFrame::Con { tag: DataConId(1), fields: vec![0] },  // 1: inner con
+        CoreFrame::Lit(Literal::LitInt(99)),                    // 2
+        CoreFrame::Con { tag: DataConId(0), fields: vec![1, 2] }, // 3: outer con (scrutinee)
+        CoreFrame::Var(a),                                       // 4
+        CoreFrame::Var(n),                                       // 5: body of inner case
+        CoreFrame::Case {                                        // 6: inner case
+            scrutinee: 4,
+            binder: inner_binder,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(DataConId(1)), binders: vec![n], body: 5 },
+            ],
+        },
+        CoreFrame::Case {                                        // 7: outer case (root)
+            scrutinee: 3,
+            binder: outer_binder,
+            alts: vec![
+                Alt { con: AltCon::DataAlt(DataConId(0)), binders: vec![a, b], body: 6 },
+            ],
+        },
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}
+
+#[test]
+fn test_case_scrutinee_lambda_app() {
+    // case ((\x -> x) 42) of { DEFAULT x -> x }
+    let x = VarId(1);
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Var(x),                                       // 0: lambda body
+        CoreFrame::Lam { binder: x, body: 0 },                  // 1: \x -> x
+        CoreFrame::Lit(Literal::LitInt(42)),                    // 2: arg
+        CoreFrame::App { fun: 1, arg: 2 },                      // 3: (\x -> x) 42 (scrutinee)
+        CoreFrame::Var(binder),                                  // 4: body
+        CoreFrame::Case {
+            scrutinee: 3,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::Default, binders: vec![], body: 4 },
+            ],
+        },                                                      // 5: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}
+
+#[test]
+fn test_case_multiple_alts_same_result() {
+    // case 2# of { 1# -> 42; 2# -> 42; DEFAULT -> 0 }
+    let binder = VarId(99);
+    let tree = RecursiveTree { nodes: vec![
+        CoreFrame::Lit(Literal::LitInt(2)),                     // 0: scrutinee
+        CoreFrame::Lit(Literal::LitInt(42)),                    // 1: shared result
+        CoreFrame::Lit(Literal::LitInt(0)),                     // 2: default
+        CoreFrame::Case {
+            scrutinee: 0,
+            binder,
+            alts: vec![
+                Alt { con: AltCon::LitAlt(Literal::LitInt(1)), binders: vec![], body: 1 },
+                Alt { con: AltCon::LitAlt(Literal::LitInt(2)), binders: vec![], body: 1 },
+                Alt { con: AltCon::Default, binders: vec![], body: 2 },
+            ],
+        },                                                      // 3: root
+    ] };
+    let result = compile_and_run(&tree);
+    unsafe { assert_eq!(read_lit_int(result.result_ptr), 42); }
+}


### PR DESCRIPTION
This PR adds 8 new JIT case expression tests to `tidepool-codegen/tests/emit_case.rs`. These tests cover:
- Case on Bool (True/False)
- Case on computed values (Int comparison result)
- Case with multiple literal alts
- Case on Word literals
- Case on Char literals
- Nested case on constructor fields
- Case where scrutinee is a lambda application (needs forcing)
- Case with same result in multiple alts

All existing and new tests in `emit_case.rs` are passing.