### PR TITLE
test: continuation logic in CompiledEffectMachine

### DIFF
--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -284,12 +284,12 @@ mod tests {
     #[test]
     fn test_lit_double_roundtrip() {
         let (_nursery, mut vmctx) = setup_vmctx(1024);
-        let val = Value::Lit(Literal::LitDouble(f64::to_bits(3.14159)));
+        let val = Value::Lit(Literal::LitDouble(f64::to_bits(1.2345678)));
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
             if let Value::Lit(Literal::LitDouble(bits)) = back {
-                assert_eq!(f64::from_bits(bits), 3.14159);
+                assert_eq!(f64::from_bits(bits), 1.2345678);
             } else {
                 panic!("Expected LitDouble, got {:?}", back);
             }
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn test_lit_float_roundtrip() {
         let (_nursery, mut vmctx) = setup_vmctx(1024);
-        let bits = f32::to_bits(3.14f32) as u64;
+        let bits = f32::to_bits(1.23f32) as u64;
         let val = Value::Lit(Literal::LitFloat(bits));
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -267,7 +267,11 @@ pub fn take_runtime_error() -> Option<RuntimeError> {
 /// Usage: `CodegenPipeline::new(&host_fn_symbols())`
 /// Debug: called before every App call_indirect to validate the function pointer.
 /// Prints the heap tag and code_ptr. Aborts on non-closure.
-pub extern "C" fn debug_app_check(fun_ptr: *const u8) {
+///
+/// # Safety
+///
+/// `fun_ptr` must point to a valid HeapObject if not null.
+pub unsafe extern "C" fn debug_app_check(fun_ptr: *const u8) {
     use std::io::Write;
     // If a runtime error is already pending, don't abort on tag mismatches —
     // we're in error-propagation mode and the effect machine will handle it.

--- a/tidepool-codegen/tests/effect_machine.rs
+++ b/tidepool-codegen/tests/effect_machine.rs
@@ -3,7 +3,10 @@ use tidepool_codegen::pipeline::CodegenPipeline;
 use tidepool_codegen::host_fns;
 use tidepool_codegen::alloc::emit_alloc_fast_path;
 use tidepool_codegen::yield_type::{Yield, YieldError};
-use tidepool_codegen::effect_machine::CompiledEffectMachine;
+use tidepool_codegen::effect_machine::{CompiledEffectMachine, ConTags};
+use tidepool_codegen::emit::expr::compile_expr;
+use tidepool_repr::{CoreExpr, CoreFrame, VarId, DataConId};
+use tidepool_heap::layout;
 
 use cranelift_codegen::ir::{self, types, AbiParam, InstBuilder, UserFuncName, MemFlags};
 use cranelift_codegen::Context;
@@ -52,7 +55,7 @@ where
     pipeline.finalize().expect("failed to finalize");
 
     let ptr = pipeline.get_function_ptr(func_id);
-    let func = unsafe { std::mem::transmute(ptr) };
+    let func: unsafe extern "C" fn(*mut VMContext) -> *mut u8 = unsafe { std::mem::transmute::<*const u8, unsafe extern "C" fn(*mut VMContext) -> *mut u8>(ptr) };
     (pipeline, func)
 }
 
@@ -433,5 +436,1058 @@ fn test_unexpected_con_tag() {
     );
     let result = machine.step();
 
-    assert_eq!(result, Yield::Error(YieldError::UnexpectedConTag(999)));
-}
+            assert_eq!(result, Yield::Error(YieldError::UnexpectedConTag(999)));
+
+        }
+
+        
+
+        /// Dummy function for tests that only use machine.resume.
+        unsafe extern "C" fn dummy_machine_func(_vmctx: *mut VMContext) -> *mut u8 {
+                    std::ptr::null_mut()
+
+        }
+
+        
+
+        fn create_machine(vmctx: VMContext) -> CompiledEffectMachine {
+
+            CompiledEffectMachine::new(
+
+                dummy_machine_func,
+
+                vmctx,
+
+                ConTags {
+
+                    val: VAL_CON_TAG,
+
+                    e: E_CON_TAG,
+
+                    union: UNION_CON_TAG,
+
+                    leaf: LEAF_CON_TAG,
+
+                    node: NODE_CON_TAG,
+
+                },
+
+            )
+
+        }
+
+        
+
+        /// Helper to allocate Con objects in tests since machine.alloc_con is private.
+        unsafe fn alloc_con_heap(machine: &mut CompiledEffectMachine, con_tag: u64, fields: &[*mut u8]) -> *mut u8 {
+                
+
+    
+
+        let size = 24 + 8 * fields.len();
+
+    
+
+        let ptr = tidepool_codegen::heap_bridge::bump_alloc_from_vmctx(machine.vmctx_mut(), size);
+
+    
+
+        if ptr.is_null() {
+
+    
+
+            return std::ptr::null_mut();
+
+    
+
+        }
+
+    
+
+        layout::write_header(ptr, layout::TAG_CON, size as u16);
+
+    
+
+        *(ptr.add(layout::CON_TAG_OFFSET) as *mut u64) = con_tag;
+
+    
+
+        *(ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *mut u16) = fields.len() as u16;
+
+    
+
+        for (i, &fp) in fields.iter().enumerate() {
+
+    
+
+            *(ptr.add(layout::CON_FIELDS_OFFSET + 8 * i) as *mut *mut u8) = fp;
+
+    
+
+        }
+
+    
+
+        ptr
+
+    
+
+    }
+
+    
+
+    
+
+    
+
+    /// Test 9: resume(Leaf(f), x) -> f(x)
+
+    
+
+    #[test]
+
+    
+
+    fn test_resume_leaf_identity() {
+
+    
+
+        let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
+
+    
+
+        
+
+    
+
+        // Identity closure: \x -> Val(x)
+
+    
+
+        let x = VarId(1);
+
+    
+
+        let val_con_id = DataConId(VAL_CON_TAG);
+
+    
+
+        let tree = CoreExpr { nodes: vec![
+
+    
+
+            CoreFrame::Var(x), // 0
+
+    
+
+            CoreFrame::Con { tag: val_con_id, fields: vec![0] }, // 1: Val(x)
+
+    
+
+            CoreFrame::Lam { binder: x, body: 1 }, // 2: \x -> Val(x)
+
+    
+
+        ]};
+
+    
+
+        let func_id = compile_expr(&mut pipeline, &tree, "identity").unwrap();
+
+    
+
+        pipeline.finalize().unwrap();
+
+    
+
+        let func_ptr = pipeline.get_function_ptr(func_id);
+
+    
+
+        let func: unsafe extern "C" fn(*mut VMContext) -> *mut u8 = unsafe { std::mem::transmute(func_ptr) };
+
+    
+
+    
+
+    
+
+        let mut nursery = vec![0u8; 4096];
+
+    
+
+        let start = nursery.as_mut_ptr();
+
+    
+
+        let end = unsafe { start.add(4096) };
+
+    
+
+        let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    
+
+        
+
+    
+
+        let mut machine = create_machine(vmctx);
+
+    
+
+        
+
+    
+
+        // Get closure ptr by running identity func
+
+    
+
+        let closure_ptr = unsafe { func(machine.vmctx_mut()) };
+
+    
+
+        assert!(!closure_ptr.is_null());
+
+    
+
+    
+
+    
+
+        // Build Leaf(closure)
+
+    
+
+        let leaf_ptr = unsafe { alloc_con_heap(&mut machine, LEAF_CON_TAG, &[closure_ptr]) };
+
+    
+
+        
+
+    
+
+        // Build Lit(42) as argument
+
+    
+
+        // Actually let's use a real Lit if we can, but a Val(null) is fine for identity.
+
+    
+
+        // Wait, let's use a Lit to be sure.
+
+    
+
+        let lit_ptr = unsafe {
+
+    
+
+            let size = 24;
+
+    
+
+            let p = tidepool_codegen::heap_bridge::bump_alloc_from_vmctx(machine.vmctx_mut(), size);
+
+    
+
+            layout::write_header(p, layout::TAG_LIT, size as u16);
+
+    
+
+            *p.add(layout::LIT_TAG_OFFSET) = 0; // Int
+
+    
+
+            *(p.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 42;
+
+    
+
+            p
+
+    
+
+        };
+
+    
+
+    
+
+    
+
+        let result = unsafe { machine.resume(leaf_ptr, lit_ptr) };
+
+    
+
+        
+
+    
+
+        match result {
+
+    
+
+            Yield::Done(res_ptr) => {
+
+    
+
+                assert_eq!(res_ptr, lit_ptr);
+
+    
+
+                let val = unsafe { *(res_ptr.add(16) as *const i64) };
+
+    
+
+                assert_eq!(val, 42);
+
+    
+
+            }
+
+    
+
+            _ => panic!("Expected Yield::Done, got {:?}", result),
+
+    
+
+        }
+
+    
+
+    }
+
+    
+
+    
+
+    
+
+    /// Test 10: resume(Node(Leaf(f), Leaf(g)), x) -> g(f(x))
+
+    
+
+    #[test]
+
+    
+
+    fn test_resume_node_identity() {
+
+    
+
+        let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
+
+    
+
+        
+
+    
+
+        // Identity closure: \x -> Val(x)
+
+    
+
+        let x = VarId(1);
+
+    
+
+        let val_con_id = DataConId(VAL_CON_TAG);
+
+    
+
+        let tree = CoreExpr { nodes: vec![
+
+    
+
+            CoreFrame::Var(x), // 0
+
+    
+
+            CoreFrame::Con { tag: val_con_id, fields: vec![0] }, // 1: Val(x)
+
+    
+
+            CoreFrame::Lam { binder: x, body: 1 }, // 2: \x -> Val(x)
+
+    
+
+        ]};
+
+    
+
+        let func_id = compile_expr(&mut pipeline, &tree, "identity").unwrap();
+
+    
+
+        pipeline.finalize().unwrap();
+
+    
+
+        let func_ptr = pipeline.get_function_ptr(func_id);
+
+    
+
+        let func: unsafe extern "C" fn(*mut VMContext) -> *mut u8 = unsafe { std::mem::transmute(func_ptr) };
+
+    
+
+    
+
+    
+
+        let mut nursery = vec![0u8; 8192]; // Bigger nursery for more allocs
+
+    
+
+        let start = nursery.as_mut_ptr();
+
+    
+
+        let end = unsafe { start.add(8192) };
+
+    
+
+        let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    
+
+        
+
+    
+
+        let mut machine = create_machine(vmctx);
+
+    
+
+        
+
+    
+
+        let closure_ptr = unsafe { func(machine.vmctx_mut()) };
+
+    
+
+        
+
+    
+
+        // Leaf(f) and Leaf(g)
+
+    
+
+        let leaf_f = unsafe { alloc_con_heap(&mut machine, LEAF_CON_TAG, &[closure_ptr]) };
+
+    
+
+        let leaf_g = unsafe { alloc_con_heap(&mut machine, LEAF_CON_TAG, &[closure_ptr]) };
+
+    
+
+        
+
+    
+
+        // Node(Leaf(f), Leaf(g))
+
+    
+
+        let node_ptr = unsafe { alloc_con_heap(&mut machine, NODE_CON_TAG, &[leaf_f, leaf_g]) };
+
+    
+
+        
+
+    
+
+        let lit_ptr = unsafe {
+
+    
+
+            let size = 24;
+
+    
+
+            let p = tidepool_codegen::heap_bridge::bump_alloc_from_vmctx(machine.vmctx_mut(), size);
+
+    
+
+            layout::write_header(p, layout::TAG_LIT, size as u16);
+
+    
+
+            *p.add(layout::LIT_TAG_OFFSET) = 0; // Int
+
+    
+
+            *(p.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 100;
+
+    
+
+            p
+
+    
+
+        };
+
+    
+
+    
+
+    
+
+        let result = unsafe { machine.resume(node_ptr, lit_ptr) };
+
+    
+
+        
+
+    
+
+        match result {
+
+    
+
+            Yield::Done(res_ptr) => {
+
+    
+
+                assert_eq!(res_ptr, lit_ptr);
+
+    
+
+                let val = unsafe { *(res_ptr.add(16) as *const i64) };
+
+    
+
+                assert_eq!(val, 100);
+
+    
+
+            }
+
+    
+
+            _ => panic!("Expected Yield::Done, got {:?}", result),
+
+    
+
+        }
+
+    
+
+    }
+
+    
+
+    
+
+    
+
+    /// Test 11: resume(null, x) -> Error(NullPointer)
+
+    
+
+    #[test]
+
+    
+
+    fn test_resume_null_continuation() {
+
+    
+
+        let mut nursery = vec![0u8; 1024];
+
+    
+
+        let vmctx = VMContext::new(nursery.as_mut_ptr(), unsafe { nursery.as_mut_ptr().add(1024) }, host_fns::gc_trigger);
+
+    
+
+        let mut machine = create_machine(vmctx);
+
+    
+
+        
+
+    
+
+        let result = unsafe { machine.resume(std::ptr::null_mut(), std::ptr::null_mut()) };
+
+    
+
+        assert_eq!(result, Yield::Error(YieldError::NullPointer));
+
+    
+
+    }
+
+    
+
+    
+
+    
+
+    /// Test 12: resume(Lit(0), x) -> Error(NullPointer) (because apply_cont returns null on unknown tag)
+
+    
+
+    #[test]
+
+    
+
+    fn test_resume_unknown_tag() {
+
+    
+
+        let mut nursery = vec![0u8; 1024];
+
+    
+
+        let vmctx = VMContext::new(nursery.as_mut_ptr(), unsafe { nursery.as_mut_ptr().add(1024) }, host_fns::gc_trigger);
+
+    
+
+        let mut machine = create_machine(vmctx);
+
+    
+
+        
+
+    
+
+        let lit_ptr = unsafe {
+
+    
+
+            let size = 24;
+
+    
+
+            let p = tidepool_codegen::heap_bridge::bump_alloc_from_vmctx(machine.vmctx_mut(), size);
+
+    
+
+            layout::write_header(p, layout::TAG_LIT, size as u16);
+
+    
+
+            p
+
+    
+
+        };
+
+    
+
+        
+
+    
+
+        let result = unsafe { machine.resume(lit_ptr, std::ptr::null_mut()) };
+
+    
+
+        assert_eq!(result, Yield::Error(YieldError::NullPointer));
+
+    
+
+    }
+
+    
+
+    
+
+    
+
+    /// Test 13: Node(Leaf(f), Leaf(g)) where f(x) returns Request E
+
+    
+
+    #[test]
+
+    
+
+    fn test_resume_node_with_effect_result() {
+
+    
+
+        let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols());
+
+    
+
+        
+
+    
+
+        // f = \x -> E(Union(7, x), Leaf(identity))
+
+    
+
+        let x = VarId(1);
+
+    
+
+        let val_con_id = DataConId(VAL_CON_TAG);
+
+    
+
+        let e_con_id = DataConId(E_CON_TAG);
+
+    
+
+        let union_con_id = DataConId(UNION_CON_TAG);
+
+    
+
+        let leaf_con_id = DataConId(LEAF_CON_TAG);
+
+    
+
+        
+
+    
+
+        let tree_identity = CoreExpr { nodes: vec![
+
+    
+
+            CoreFrame::Var(x), // 0
+
+    
+
+            CoreFrame::Con { tag: val_con_id, fields: vec![0] }, // 1: Val(x)
+
+    
+
+            CoreFrame::Lam { binder: x, body: 1 }, // 2: \x -> Val(x)
+
+    
+
+        ]};
+
+    
+
+        
+
+    
+
+        // Identity to use as g
+
+    
+
+        let func_id_identity = compile_expr(&mut pipeline, &tree_identity, "identity").unwrap();
+
+    
+
+        
+
+    
+
+        pipeline.finalize().unwrap();
+
+    
+
+        let id_func_ptr = pipeline.get_function_ptr(func_id_identity);
+
+    
+
+        let id_func: unsafe extern "C" fn(*mut VMContext) -> *mut u8 = unsafe { std::mem::transmute(id_func_ptr) };
+
+    
+
+    
+
+    
+
+        let mut nursery = vec![0u8; 8192];
+
+    
+
+        let start = nursery.as_mut_ptr();
+
+    
+
+        let end = unsafe { start.add(8192) };
+
+    
+
+        let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    
+
+        
+
+    
+
+        let mut machine = create_machine(vmctx);
+
+    
+
+        
+
+    
+
+        let id_closure_ptr = unsafe { id_func(machine.vmctx_mut()) };
+
+    
+
+        let leaf_id = unsafe { alloc_con_heap(&mut machine, LEAF_CON_TAG, &[id_closure_ptr]) };
+
+    
+
+        
+
+    
+
+        // Closure g: identity
+
+    
+
+        let leaf_g = leaf_id;
+
+    
+
+        
+
+    
+
+        // k1 = identity, but we'll cheat and make resume call it.
+
+    
+
+        // If k1(x) returns E(union, k_prime), then Node(k1, k2) returns E(union, Node(k_prime, k2))
+
+    
+
+        
+
+    
+
+        // To test this, we need k1 to return E.
+
+    
+
+        // We can compile a function that returns E.
+
+    
+
+        
+
+    
+
+        let tree_returns_e = CoreExpr { nodes: vec![
+
+    
+
+            CoreFrame::Var(x), // 0
+
+    
+
+            CoreFrame::Lit(tidepool_repr::Literal::LitInt(0)), // 1
+
+    
+
+            CoreFrame::Con { tag: leaf_con_id, fields: vec![1] }, // 2: Leaf(0)
+
+    
+
+            CoreFrame::Lit(tidepool_repr::Literal::LitWord(7)), // 3
+
+    
+
+            CoreFrame::Con { tag: union_con_id, fields: vec![3, 0] }, // 4: Union(7, x)
+
+    
+
+            CoreFrame::Con { tag: e_con_id, fields: vec![4, 2] }, // 5: E(...)
+
+    
+
+            CoreFrame::Lam { binder: x, body: 5 }, // 6
+
+    
+
+        ]};
+
+    
+
+        
+
+    
+
+        let mut pipeline2 = CodegenPipeline::new(&host_fns::host_fn_symbols());
+
+    
+
+        let f_id = compile_expr(&mut pipeline2, &tree_returns_e, "returns_e").unwrap();
+
+    
+
+        pipeline2.finalize().unwrap();
+
+    
+
+        let f_func_ptr = pipeline2.get_function_ptr(f_id);
+
+    
+
+        let f_func: unsafe extern "C" fn(*mut VMContext) -> *mut u8 = unsafe { std::mem::transmute(f_func_ptr) };
+
+    
+
+        
+
+    
+
+        let f_closure = unsafe { f_func(machine.vmctx_mut()) };
+
+    
+
+        let leaf_f = unsafe { alloc_con_heap(&mut machine, LEAF_CON_TAG, &[f_closure]) };
+
+    
+
+        
+
+    
+
+        let node_ptr = unsafe { alloc_con_heap(&mut machine, NODE_CON_TAG, &[leaf_f, leaf_g]) };
+
+    
+
+        
+
+    
+
+        let lit_ptr = unsafe {
+
+    
+
+            let size = 24;
+
+    
+
+            let p = tidepool_codegen::heap_bridge::bump_alloc_from_vmctx(machine.vmctx_mut(), size);
+
+    
+
+            layout::write_header(p, layout::TAG_LIT, size as u16);
+
+    
+
+            *p.add(layout::LIT_TAG_OFFSET) = 0; // Int
+
+    
+
+            *(p.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 123;
+
+    
+
+            p
+
+    
+
+        };
+
+    
+
+    
+
+    
+
+        let result = unsafe { machine.resume(node_ptr, lit_ptr) };
+
+    
+
+        
+
+    
+
+        match result {
+
+    
+
+            Yield::Request { tag, request, continuation } => {
+
+    
+
+                assert_eq!(tag, 7);
+
+    
+
+                assert_eq!(request, lit_ptr);
+
+    
+
+                
+
+    
+
+                // continuation should be Node(k_prime, leaf_g)
+
+    
+
+                let tag = unsafe { *continuation };
+
+    
+
+                assert_eq!(tag, layout::TAG_CON);
+
+    
+
+                let con_tag = unsafe { *(continuation.add(layout::CON_TAG_OFFSET) as *const u64) };
+
+    
+
+                assert_eq!(con_tag, NODE_CON_TAG);
+
+    
+
+                
+
+    
+
+                let k_prime = unsafe { *(continuation.add(layout::CON_FIELDS_OFFSET) as *const *mut u8) };
+
+    
+
+                let k2 = unsafe { *(continuation.add(layout::CON_FIELDS_OFFSET + 8) as *const *mut u8) };
+
+    
+
+                
+
+    
+
+                assert_eq!(k2, leaf_g);
+
+    
+
+                assert!(!k_prime.is_null());
+
+    
+
+            }
+
+    
+
+            _ => panic!("Expected Yield::Request, got {:?}", result),
+
+    
+
+        }
+
+    
+
+    }
+
+    
+
+    
+
+    
+
+    
+
+    

--- a/tidepool-codegen/tests/emit_case.rs
+++ b/tidepool-codegen/tests/emit_case.rs
@@ -218,19 +218,19 @@ fn test_case_binder_used() {
 fn test_case_lit_double() {
     // case Lit(3.14) of { LitAlt(1.0) -> 10; LitAlt(3.14) -> 99; Default -> 0 }
     let binder = VarId(99);
-    let pi_bits = 3.14f64.to_bits();
+    let val_bits = 1.23f64.to_bits();
     let one_bits = 1.0f64.to_bits();
     let tree = RecursiveTree { nodes: vec![
-        CoreFrame::Lit(Literal::LitDouble(pi_bits)),                // 0: scrutinee
+        CoreFrame::Lit(Literal::LitDouble(val_bits)),                // 0: scrutinee
         CoreFrame::Lit(Literal::LitInt(10)),                         // 1: alt 1.0 body
-        CoreFrame::Lit(Literal::LitInt(99)),                         // 2: alt 3.14 body
+        CoreFrame::Lit(Literal::LitInt(99)),                         // 2: alt 1.23 body
         CoreFrame::Lit(Literal::LitInt(0)),                          // 3: default body
         CoreFrame::Case {
             scrutinee: 0,
             binder,
             alts: vec![
                 Alt { con: AltCon::LitAlt(Literal::LitDouble(one_bits)), binders: vec![], body: 1 },
-                Alt { con: AltCon::LitAlt(Literal::LitDouble(pi_bits)), binders: vec![], body: 2 },
+                Alt { con: AltCon::LitAlt(Literal::LitDouble(val_bits)), binders: vec![], body: 2 },
                 Alt { con: AltCon::Default, binders: vec![], body: 3 },
             ],
         },                                                            // 4: root


### PR DESCRIPTION
This PR adds 5 new test functions to `tidepool-codegen/tests/effect_machine.rs` to cover the continuation application logic in `CompiledEffectMachine` (`apply_cont_heap`).

Tests added:
1. `test_resume_leaf_identity`: Tests `Leaf` continuation with an identity closure.
2. `test_resume_node_identity`: Tests `Node` continuation composing two identity `Leaf`s.
3. `test_resume_null_continuation`: Verifies graceful handling of null continuation pointers.
4. `test_resume_unknown_tag`: Verifies error handling for unexpected heap tags in continuation position.
5. `test_resume_node_with_effect_result`: Tests `Node` composition where the first continuation returns an effect request (`Yield::Request`).

Additionally:
- Fixed pre-existing clippy warnings in `heap_bridge.rs`, `host_fns.rs`, and `emit_case.rs` that were blocking lint verification.
- Improved `debug_app_check` with safety documentation.
- Standardized `transmute` calls in `effect_machine.rs` tests with explicit annotations.

All 13 tests in `effect_machine.rs` pass. `cargo check` and `cargo clippy` pass for the crate (with remaining unrelated warnings in other test files).