### PR TITLE
feat: investigate T.length returning -5 and document GHC Core analysis

### DIFF
--- a/haskell/test/text_length_core.hs
+++ b/haskell/test/text_length_core.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE NoImplicitPrelude, OverloadedStrings #-}
+module Test where
+import Tidepool.Prelude
+import qualified Data.Text as T
+
+textLength :: Text -> Int
+textLength = T.length
+
+textTake :: Int -> Text -> Text
+textTake = T.take
+
+textDrop :: Int -> Text -> Text
+textDrop = T.drop

--- a/tidepool-runtime/tests/text_core_analysis.md
+++ b/tidepool-runtime/tests/text_core_analysis.md
@@ -1,0 +1,70 @@
+# Analysis of GHC Core for `T.length`
+
+## Observations from GHC Core (`text-2.1.2`)
+
+The `textLength` function compiles to the following optimized Core:
+
+```haskell
+textLength :: Text -> Int
+  = \ (x_a9ba [Dmd=1!P(L,L,1L)] :: Text) ->
+      case x_a9ba of { Text bx_a9eA bx1_a9eB bx2_a9eC [Dmd=1L] ->
+      join {
+        $j2_a9ey [Dmd=1C(1,!P(L))] :: Int# -> Int
+        [LclId[JoinId(1)(Nothing)],
+         Arity=1,
+         Str=<L>,
+         Unf=Unf{Src=<vanilla>, TopLvl=False,
+                 Value=True, ConLike=True, WorkFree=True, Expandable=True,
+                 Guidance=IF_ARGS [0] 11 10}]
+        $j2_a9ey (x1_a9ez [OS=OneShot] :: Int#)
+          = I# (negateInt# x1_a9ez) } in
+      case bx2_a9eC of wild1_a9eE {
+        __DEFAULT ->
+          case {__ffi_static_ccall_unsafe text-2.1.2-9a59:_hs_text_measure_off :: ByteArray#
+                                                                   -> Word64#
+                                                                   -> Word64#
+                                                                   -> Word64#
+                                                                   -> State# RealWorld
+                                                                   -> (# State# RealWorld,
+                                                                         Int64# #)}_a9eF
+                 bx_a9eA
+                 (int64ToWord64# (intToInt64# bx1_a9eB))
+                 (int64ToWord64# (intToInt64# wild1_a9eE))
+                 9223372036854775807#Word64
+                 realWorld#
+          of
+          { (# _ [Occ=Dead, Dmd=A], ds11_a9eI #) ->
+          jump $j2_a9ey (int64ToInt# ds11_a9eI)
+          };
+        0# -> jump $j2_a9ey 0#
+      }
+      }
+```
+
+### Key Findings:
+1.  **FFI Signature**: `_hs_text_measure_off` takes 4 arguments (plus `State#`): `arr`, `off`, `len`, `n`.
+2.  **`T.length` Logic**: It calls `_hs_text_measure_off` with `n = 9223372036854775807` (which is `maxBound :: Int64`) and THEN negates the result.
+3.  **Expected Return**: For `T.length` to return a positive result (like 5 for "hello"), the FFI call MUST return a negative value (like -5).
+
+## The Bug in Tidepool
+
+### 1. Codegen Bug (`primop.rs`)
+The `PrimOpKind::FfiTextMeasureOff` handler only passes the first 3 arguments to the runtime function, discarding the 4th argument (`n`).
+
+### 2. Runtime Bug (`host_fns.rs`)
+The `runtime_text_measure_off` implementation is incorrect:
+-   It only takes 3 arguments.
+-   It treats the 3rd argument (`len`, which is the number of BYTES in the slice) as the number of characters to count.
+-   It returns the number of BYTES.
+-   It does not support returning a negated character count when requested.
+
+### Path to Failure:
+1.  Haskell calls `T.length "hello"`.
+2.  Core calls `_hs_text_measure_off(arr, 0, 5, 9223372036854775807)`.
+3.  Rust `emit_primop` calls `runtime_text_measure_off(addr, 0, 5)`, discarding `9223372036854775807`.
+4.  Rust `runtime_text_measure_off` sees `len=5`, so it counts 5 characters, finds 5 bytes, and returns `5`.
+5.  Haskell Core negates the result: `negateInt# 5 = -5`.
+6.  Result is `-5`.
+
+## Hypothesis
+If we fix `runtime_text_measure_off` to take 4 arguments and return a negated character count when `n` is `maxBound` (or negative), the negation in Haskell Core will yield the correct positive length.

--- a/tidepool-runtime/tests/text_core_validate.rs
+++ b/tidepool-runtime/tests/text_core_validate.rs
@@ -1,0 +1,107 @@
+/// Test to validate the hypothesis that `runtime_text_measure_off` needs to return
+/// a negated character count when requested by Haskell Core's `T.length`.
+#[cfg(test)]
+mod tests {
+    /// Simplified implementation of the hypothesized fix for `runtime_text_measure_off`.
+    fn validate_text_measure_off(addr: *const u8, off: i64, len: i64, n: i64) -> i64 {
+        let ptr = unsafe { addr.add(off as usize) };
+        let end = unsafe { ptr.add(len as usize) };
+        let mut p = ptr;
+
+        if n < 0 || n == i64::MAX {
+            // Count characters in the first `len` bytes.
+            // Return number of characters, negated.
+            let mut count = 0i64;
+            while p < end {
+                let b = unsafe { *p };
+                let char_len = if b < 0x80 {
+                    1
+                } else if b < 0xE0 {
+                    2
+                } else if b < 0xF0 {
+                    3
+                } else {
+                    4
+                };
+                p = unsafe { p.add(char_len) };
+                count += 1;
+            }
+            -count
+        } else {
+            // Measure how many bytes are in the first `n` characters,
+            // but don't go past `len` bytes.
+            let mut chars_to_count = n;
+            while chars_to_count > 0 && p < end {
+                let b = unsafe { *p };
+                let char_len = if b < 0x80 {
+                    1
+                } else if b < 0xE0 {
+                    2
+                } else if b < 0xF0 {
+                    3
+                } else {
+                    4
+                };
+                p = unsafe { p.add(char_len) };
+                chars_to_count -= 1;
+            }
+            unsafe { p.offset_from(ptr) as i64 }
+        }
+    }
+
+    #[test]
+    fn test_length_negation_logic() {
+        let s = "hello".as_bytes();
+        let addr = s.as_ptr();
+        
+        // Haskell calls with n = i64::MAX for T.length
+        let n = i64::MAX;
+        let result = validate_text_measure_off(addr, 0, 5, n);
+        
+        // It should return -5 (negated character count)
+        assert_eq!(result, -5, "Should return -5 for 5 ASCII characters when n=MAX");
+        
+        // The final Haskell result (as seen in Core) will be negateInt# (-5) = 5.
+        assert_eq!(-result, 5, "Haskell's negation should yield 5");
+    }
+
+    #[test]
+    fn test_take_byte_logic() {
+        let s = "hello".as_bytes();
+        let addr = s.as_ptr();
+        
+        // T.take 3 "hello" should call with n=3
+        let n = 3;
+        let result = validate_text_measure_off(addr, 0, 5, n);
+        
+        // It should return 3 (the number of bytes for 3 characters)
+        assert_eq!(result, 3, "Should return 3 bytes for 3 characters");
+    }
+
+    #[test]
+    fn test_multi_byte_length() {
+        // "λ" is 2 bytes: CF BB
+        // "😀" is 4 bytes: F0 9F 98 80
+        let s = "λ😀x".as_bytes(); // Total 2+4+1 = 7 bytes, 3 characters
+        let addr = s.as_ptr();
+        
+        let n = i64::MAX;
+        let result = validate_text_measure_off(addr, 0, 7, n);
+        
+        assert_eq!(result, -3, "Should return -3 for 3 characters (negated)");
+        assert_eq!(-result, 3, "Haskell's negation should yield 3");
+    }
+
+    #[test]
+    fn test_multi_byte_take() {
+        let s = "λ😀x".as_bytes(); // Total 2+4+1 = 7 bytes, 3 characters
+        let addr = s.as_ptr();
+        
+        // T.take 2 "λ😀x" should call with n=2
+        let n = 2;
+        let result = validate_text_measure_off(addr, 0, 7, n);
+        
+        // It should return 6 (2 bytes for λ + 4 bytes for 😀)
+        assert_eq!(result, 6, "Should return 6 bytes for 2 multi-byte characters");
+    }
+}


### PR DESCRIPTION
I have investigated why `T.length "hello"` returns -5 instead of 5 when round-tripped through the Rust bridge.

### Findings:
-   GHC Core for `Data.Text.length` (version 2.1.2) calls `_hs_text_measure_off` with 4 arguments: `arr`, `off`, `len`, and `n = 9223372036854775807` (maxBound).
-   Crucially, the Core then **negates** the result of this FFI call: `I# (negateInt# x1_a9ez)`.
-   The expected behavior for `_hs_text_measure_off` when `n` is negative (or very large/maxBound) is to return the number of characters in the slice, **negated**.
-   Our current implementation in `host_fns.rs` returns a positive number of bytes (5 for "hello"), which when negated by Haskell Core becomes -5.

### Changes:
-   Created `haskell/test/text_length_core.hs` for minimal Core reproduction.
-   Created `tidepool-runtime/tests/text_core_analysis.md` documenting the GHC Core analysis and the identified bug.
-   Created `tidepool-runtime/tests/text_core_validate.rs` with a Rust test validating the hypothesized fix (returning negated character count).

The fix will require updating `tidepool-codegen/src/emit/primop.rs` to pass the 4th argument and `tidepool-codegen/src/host_fns.rs` to implement the correct logic for `_hs_text_measure_off`.
