### PR TITLE
feat: fix LetRec topological sort and closure capture

### DIFF
--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -989,6 +989,19 @@ impl EmitContext {
                             CLOSURE_CODE_PTR_OFFSET,
                         );
 
+                        // Zero-initialize capture slots so GC doesn't trace garbage
+                        // if triggered before Phase 3a'.
+                        let null_val = builder.ins().iconst(types::I64, 0);
+                        for i in 0..sorted_fvs.len() {
+                            let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                            builder.ins().store(
+                                MemFlags::trusted(),
+                                null_val,
+                                closure_ptr,
+                                offset,
+                            );
+                        }
+
                         // Fill captures that are already in env. Defer those that
                         // reference deferred simple bindings (not yet evaluated).
                         let mut has_deferred = false;
@@ -1050,11 +1063,42 @@ impl EmitContext {
 
                     // Phase 3c: Evaluate deferred simple bindings (now that Con fields
                     // they may access at runtime are populated).
-                    // Topologically sort: if binding A references binding B (both in
-                    // deferred_simple), B must be evaluated first.
+                    // Topologically sort: if binding A references binding B transitively,
+                    // B must be evaluated first.
                     let deferred_simple = {
                         let deferred_set: std::collections::HashSet<VarId> =
                             deferred_simple.iter().map(|(b, _)| *b).collect();
+                        
+                        // Compute full dependency map for all bindings in this LetRec
+                        let mut deps: std::collections::HashMap<VarId, std::collections::HashSet<VarId>> = std::collections::HashMap::new();
+                        for (binder, rhs_idx) in bindings {
+                            let fvs = tidepool_repr::free_vars::free_vars(&tree.extract_subtree(*rhs_idx));
+                            deps.insert(*binder, fvs);
+                        }
+                        
+                        // Transitive closure of dependencies
+                        let mut changed = true;
+                        while changed {
+                            changed = false;
+                            let keys: Vec<VarId> = deps.keys().copied().collect();
+                            for k in keys {
+                                let current_deps = deps[&k].clone();
+                                let mut new_deps = current_deps.clone();
+                                for dep in current_deps {
+                                    if let Some(transit_deps) = deps.get(&dep) {
+                                        for td in transit_deps {
+                                            if new_deps.insert(*td) {
+                                                changed = true;
+                                            }
+                                        }
+                                    }
+                                }
+                                if changed {
+                                    deps.insert(k, new_deps);
+                                }
+                            }
+                        }
+
                         let mut sorted = Vec::with_capacity(deferred_simple.len());
                         let mut remaining: Vec<(VarId, usize)> = deferred_simple;
                         let mut progress = true;
@@ -1062,18 +1106,11 @@ impl EmitContext {
                             progress = false;
                             let mut next_remaining = Vec::new();
                             for (binder, rhs_idx) in remaining {
-                                let rhs_fvs = tidepool_repr::free_vars::free_vars(
-                                    &tree.extract_subtree(rhs_idx),
-                                );
-                                let blocked = rhs_fvs.iter().any(
-                                    |fv| {
-                                        deferred_set.contains(fv)
-                                            && !sorted
-                                                .iter()
-                                                .any(|(b, _): &(VarId, usize)| *b == *fv)
-                                            && *fv != binder
-                                    }, // self-reference is OK (will be in env from rec)
-                                );
+                                let blocked = deps[&binder].iter().any(|fv| {
+                                    deferred_set.contains(fv)
+                                        && !sorted.iter().any(|(b, _): &(VarId, usize)| *b == *fv)
+                                        && *fv != binder
+                                });
                                 if blocked {
                                     next_remaining.push((binder, rhs_idx));
                                 } else {
@@ -1087,6 +1124,7 @@ impl EmitContext {
                         sorted.extend(remaining);
                         sorted
                     };
+
                     for (binder, rhs_idx) in &deferred_simple {
                         if Self::rhs_has_error_sentinel(tree, *rhs_idx) {
                             let poison_addr = crate::host_fns::error_poison_ptr() as i64;
@@ -1099,25 +1137,35 @@ impl EmitContext {
                             self.trace_scope(&format!("insert LetRec(simple) {:?}", binder));
                             self.env.insert(*binder, rhs_val);
                         }
+                        
+                        // Incrementally fill pending captures as dependencies become available!
+                        // This guarantees that closures have their capture slots filled before
+                        // subsequent simple bindings in this LetRec are evaluated, which might
+                        // invoke those closures.
+                        for pc in &mut pending_captures {
+                            for (i, var_id) in pc.fvs.iter().enumerate() {
+                                if *var_id == *binder {
+                                    if let Some(ssaval) = self.env.get(var_id) {
+                                        let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, *ssaval);
+                                        let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                                        builder.ins().store(
+                                            MemFlags::trusted(),
+                                            cap_val,
+                                            pc.closure_ptr,
+                                            offset,
+                                        );
+                                    }
+                                }
+                            }
+                        }
                     }
 
-                    // Phase 3a': Fill closure capture slots. Deferred from Phase 3a
-                    // because some captures reference deferred simple bindings
-                    // (evaluated in Phase 3c). All captured VarIds are now in env.
+                    // Phase 3a': Verify all captures are filled. (They should be, via incremental updates)
                     for pc in &pending_captures {
                         for (i, var_id) in pc.fvs.iter().enumerate() {
-                            let ssaval = self.env.get(var_id).unwrap_or_else(|| {
-                            panic!("LetRec capture fill: VarId({:#x}) not in env after Phase 3c. env keys: {:?}",
-                                   var_id.0, self.env.keys().map(|k| format!("{:#x}", k.0)).collect::<Vec<_>>())
-                        });
-                            let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, *ssaval);
-                            let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
-                            builder.ins().store(
-                                MemFlags::trusted(),
-                                cap_val,
-                                pc.closure_ptr,
-                                offset,
-                            );
+                            if !self.env.contains_key(var_id) {
+                                panic!("LetRec capture fill: VarId({:#x}) not in env after Phase 3c.", var_id.0);
+                            }
                         }
                     }
 

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -839,6 +839,19 @@ impl EmitContext {
                                     CON_NUM_FIELDS_OFFSET,
                                 );
 
+                                // Zero-initialize Con fields so GC doesn't trace garbage
+                                // if triggered before Phase 3b/3d.
+                                let null_val = builder.ins().iconst(types::I64, 0);
+                                for i in 0..num_fields {
+                                    let offset = CON_FIELDS_START + 8 * i as i32;
+                                    builder.ins().store(
+                                        MemFlags::trusted(),
+                                        null_val,
+                                        ptr,
+                                        offset,
+                                    );
+                                }
+
                                 builder.declare_value_needs_stack_map(ptr);
                                 pre_allocs.push(PreAlloc::Con {
                                     binder: *binder,
@@ -882,11 +895,7 @@ impl EmitContext {
                     // We compile the inner function (which reads captures by slot
                     // position) and store code pointers, then fill capture slots
                     // in Phase 3a' after simple bindings are evaluated.
-                    struct PendingCaptures {
-                        closure_ptr: cranelift_codegen::ir::Value,
-                        fvs: Vec<VarId>,
-                    }
-                    let mut pending_captures: Vec<PendingCaptures> = Vec::new();
+                    let mut pending_capture_updates: std::collections::HashMap<VarId, Vec<(cranelift_codegen::ir::Value, i32)>> = std::collections::HashMap::new();
 
                     for pa in &pre_allocs {
                         let (closure_ptr, sorted_fvs, rhs_idx) = match pa {
@@ -1004,11 +1013,10 @@ impl EmitContext {
 
                         // Fill captures that are already in env. Defer those that
                         // reference deferred simple bindings (not yet evaluated).
-                        let mut has_deferred = false;
                         for (i, var_id) in sorted_fvs.iter().enumerate() {
+                            let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
                             if let Some(ssaval) = self.env.get(var_id) {
                                 let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, *ssaval);
-                                let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
                                 builder.ins().store(
                                     MemFlags::trusted(),
                                     cap_val,
@@ -1016,14 +1024,11 @@ impl EmitContext {
                                     offset,
                                 );
                             } else {
-                                has_deferred = true;
+                                pending_capture_updates
+                                    .entry(*var_id)
+                                    .or_default()
+                                    .push((closure_ptr, offset));
                             }
-                        }
-                        if has_deferred {
-                            pending_captures.push(PendingCaptures {
-                                closure_ptr,
-                                fvs: sorted_fvs.clone(),
-                            });
                         }
                     }
 
@@ -1063,40 +1068,39 @@ impl EmitContext {
 
                     // Phase 3c: Evaluate deferred simple bindings (now that Con fields
                     // they may access at runtime are populated).
-                    // Topologically sort: if binding A references binding B transitively,
-                    // B must be evaluated first.
+                    // Topologically sort: if binding A references binding B in deferred_simple,
+                    // B must be evaluated first. This includes dependencies mediated by closures.
                     let deferred_simple = {
                         let deferred_set: std::collections::HashSet<VarId> =
                             deferred_simple.iter().map(|(b, _)| *b).collect();
                         
-                        // Compute full dependency map for all bindings in this LetRec
-                        let mut deps: std::collections::HashMap<VarId, std::collections::HashSet<VarId>> = std::collections::HashMap::new();
+                        let mut direct_deps: std::collections::HashMap<VarId, Vec<VarId>> = std::collections::HashMap::new();
                         for (binder, rhs_idx) in bindings {
                             let fvs = tidepool_repr::free_vars::free_vars(&tree.extract_subtree(*rhs_idx));
-                            deps.insert(*binder, fvs);
+                            direct_deps.insert(*binder, fvs.into_iter().collect());
                         }
-                        
-                        // Transitive closure of dependencies
-                        let mut changed = true;
-                        while changed {
-                            changed = false;
-                            let keys: Vec<VarId> = deps.keys().copied().collect();
-                            for k in keys {
-                                let current_deps = deps[&k].clone();
-                                let mut new_deps = current_deps.clone();
-                                for dep in current_deps {
-                                    if let Some(transit_deps) = deps.get(&dep) {
-                                        for td in transit_deps {
-                                            if new_deps.insert(*td) {
-                                                changed = true;
-                                            }
-                                        }
+
+                        // Compute reachability on-demand using DFS
+                        let mut reachable_deferred: std::collections::HashMap<VarId, std::collections::HashSet<VarId>> = std::collections::HashMap::new();
+                        for &(start_node, _) in &deferred_simple {
+                            let mut visited = std::collections::HashSet::new();
+                            let mut stack = vec![start_node];
+                            let mut reached = std::collections::HashSet::new();
+                            
+                            while let Some(node) = stack.pop() {
+                                if !visited.insert(node) {
+                                    continue;
+                                }
+                                if node != start_node && deferred_set.contains(&node) {
+                                    reached.insert(node);
+                                }
+                                if let Some(neighbors) = direct_deps.get(&node) {
+                                    for &next in neighbors {
+                                        stack.push(next);
                                     }
                                 }
-                                if changed {
-                                    deps.insert(k, new_deps);
-                                }
                             }
+                            reachable_deferred.insert(start_node, reached);
                         }
 
                         let mut sorted = Vec::with_capacity(deferred_simple.len());
@@ -1106,10 +1110,8 @@ impl EmitContext {
                             progress = false;
                             let mut next_remaining = Vec::new();
                             for (binder, rhs_idx) in remaining {
-                                let blocked = deps[&binder].iter().any(|fv| {
-                                    deferred_set.contains(fv)
-                                        && !sorted.iter().any(|(b, _): &(VarId, usize)| *b == *fv)
-                                        && *fv != binder
+                                let blocked = reachable_deferred[&binder].iter().any(|fv| {
+                                    !sorted.iter().any(|(b, _): &(VarId, usize)| *b == *fv)
                                 });
                                 if blocked {
                                     next_remaining.push((binder, rhs_idx));
@@ -1142,30 +1144,36 @@ impl EmitContext {
                         // This guarantees that closures have their capture slots filled before
                         // subsequent simple bindings in this LetRec are evaluated, which might
                         // invoke those closures.
-                        for pc in &mut pending_captures {
-                            for (i, var_id) in pc.fvs.iter().enumerate() {
-                                if *var_id == *binder {
-                                    if let Some(ssaval) = self.env.get(var_id) {
-                                        let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, *ssaval);
-                                        let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
-                                        builder.ins().store(
-                                            MemFlags::trusted(),
-                                            cap_val,
-                                            pc.closure_ptr,
-                                            offset,
-                                        );
-                                    }
+                        if let Some(updates) = pending_capture_updates.remove(binder) {
+                            if let Some(ssaval) = self.env.get(binder) {
+                                let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, *ssaval);
+                                for (closure_ptr, offset) in updates {
+                                    builder.ins().store(
+                                        MemFlags::trusted(),
+                                        cap_val,
+                                        closure_ptr,
+                                        offset,
+                                    );
                                 }
                             }
                         }
                     }
 
-                    // Phase 3a': Verify all captures are filled. (They should be, via incremental updates)
-                    for pc in &pending_captures {
-                        for (i, var_id) in pc.fvs.iter().enumerate() {
-                            if !self.env.contains_key(var_id) {
-                                panic!("LetRec capture fill: VarId({:#x}) not in env after Phase 3c.", var_id.0);
-                            }
+                    // Phase 3a': Fill any remaining closure capture slots.
+                    // These are captures of Lam/Con bindings (or trivial simple bindings)
+                    // that were not in env during Phase 1 but are now in env.
+                    for (var_id, updates) in pending_capture_updates {
+                        let ssaval = self.env.get(&var_id).unwrap_or_else(|| {
+                            panic!("LetRec capture fill: VarId({:#x}) not in env after Phase 3c.", var_id.0);
+                        });
+                        let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, *ssaval);
+                        for (closure_ptr, offset) in updates {
+                            builder.ins().store(
+                                MemFlags::trusted(),
+                                cap_val,
+                                closure_ptr,
+                                offset,
+                            );
                         }
                     }
 

--- a/tidepool-codegen/src/emit/primop.rs
+++ b/tidepool-codegen/src/emit/primop.rs
@@ -963,12 +963,9 @@ pub fn emit_primop(
             // clz8# :: Word# -> Word#
             check_arity(op, 1, args.len())?;
             let v = unbox_int(builder, args[0]);
-            // clz of a byte: mask to 8 bits, count leading zeros of the 64-bit value, subtract 56
-            let mask = builder.ins().iconst(types::I64, 0xFF);
-            let masked = builder.ins().band(v, mask);
-            let clz64 = builder.ins().clz(masked);
-            let adj = builder.ins().iconst(types::I64, 56);
-            let result = builder.ins().isub(clz64, adj);
+            let narrow = builder.ins().ireduce(types::I8, v);
+            let clz8 = builder.ins().clz(narrow);
+            let result = builder.ins().uextend(types::I64, clz8);
             Ok(SsaVal::Raw(result, LIT_TAG_WORD))
         }
         PrimOpKind::Raise => {

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -170,9 +170,6 @@ pub extern "C" fn unresolved_var_trap(var_id: u64) -> *mut u8 {
         "[FATAL] Forced unresolved external variable: VarId({:#x}) [tag='{}', key={}]",
         var_id, tag_char, key
     );
-    eprintln!("  Backtrace:");
-    let bt = std::backtrace::Backtrace::force_capture();
-    eprintln!("{}", bt);
     use std::io::Write;
     let _ = std::io::stderr().flush();
     std::process::abort();
@@ -290,6 +287,8 @@ pub unsafe extern "C" fn debug_app_check(fun_ptr: *const u8) {
     }
     let tag = unsafe { *fun_ptr };
     if tag != tidepool_heap::layout::TAG_CLOSURE {
+        use std::io::Write;
+        let mut stderr = std::io::stderr().lock();
         if has_error {
             return; // Error already flagged, tag mismatch is expected (poison object)
         }
@@ -300,16 +299,17 @@ pub unsafe extern "C" fn debug_app_check(fun_ptr: *const u8) {
             3 => "Lit",
             _ => "UNKNOWN",
         };
-        eprintln!(
+        let _ = writeln!(
+            stderr,
             "[JIT] App: fun_ptr={:p} has tag {} ({}) — expected Closure!",
             fun_ptr, tag, tag_name
         );
         if tag == tidepool_heap::layout::TAG_CON {
             let con_tag = unsafe { *(fun_ptr.add(8) as *const u64) };
             let num_fields = unsafe { *(fun_ptr.add(16) as *const u16) };
-            eprintln!("[JIT]   Con tag={}, num_fields={}", con_tag, num_fields);
+            let _ = writeln!(stderr, "[JIT]   Con tag={}, num_fields={}", con_tag, num_fields);
         }
-        let _ = std::io::stderr().flush();
+        let _ = stderr.flush();
         std::process::abort();
     }
 }

--- a/tidepool-codegen/tests/emit_expr.rs
+++ b/tidepool-codegen/tests/emit_expr.rs
@@ -1306,18 +1306,28 @@ fn test_emit_primop_word8_ops() {
 
 #[test]
 fn test_emit_primop_clz8() {
-    let tree = RecursiveTree {
-        nodes: vec![
-            CoreFrame::Lit(Literal::LitWord(0x01)),
-            CoreFrame::PrimOp {
-                op: PrimOpKind::Clz8,
-                args: vec![0],
-            },
-        ],
-    };
-    let result = compile_and_run(&tree);
-    unsafe {
-        assert_eq!(read_lit_int(result.result_ptr), 7);
+    let cases = vec![
+        (0x01, 7),
+        (0x80, 0),
+        (0x00, 8),
+        (0xFF, 0),
+        (0x40, 1),
+    ];
+    for (input, expected) in cases {
+        let tree = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Lit(Literal::LitWord(input)),
+                CoreFrame::PrimOp {
+                    op: PrimOpKind::Clz8,
+                    args: vec![0],
+                },
+            ],
+        };
+        let result = compile_and_run(&tree);
+        unsafe {
+            // Note: clz8# returns Word#, but we read as int for convenience
+            assert_eq!(read_lit_int(result.result_ptr), expected as i64);
+        }
     }
 }
 

--- a/tidepool-codegen/tests/test_clz_logic.rs
+++ b/tidepool-codegen/tests/test_clz_logic.rs
@@ -1,0 +1,18 @@
+#[test]
+fn test_utf8_len_logic() {
+    fn clz8(v: u8) -> i64 {
+        let masked = v as u64;
+        let clz64 = masked.leading_zeros() as i64;
+        clz64 - 56
+    }
+    fn y_logic(r: u8) -> i64 {
+        let c = clz8(!r);
+        c ^ if c <= 0 { 1 } else { 0 }
+    }
+
+    assert_eq!(y_logic(0x61), 1); // 'a'
+    assert_eq!(y_logic(0xC3), 2); // start of 2-byte
+    assert_eq!(y_logic(0xE2), 3); // start of 3-byte
+    assert_eq!(y_logic(0xF0), 4); // start of 4-byte
+    assert_eq!(y_logic(0x20), 1); // space
+}

--- a/tidepool-runtime/tests/haskell/cmptest.hs
+++ b/tidepool-runtime/tests/haskell/cmptest.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
+module CmpTest where
+import GHC.Exts
+import Tidepool.Prelude
+
+-- Simulate the exact byte length logic for ':' (0x3A)
+result :: Int
+result = 
+  let r# = 58## -- 0x3A
+      c# = clz8# (and# (not# r#) 255##)
+      c1 = word2Int# c#
+      y = xorI# c1 (c1 <=# 0#)
+  in I# y

--- a/tidepool-runtime/tests/repro_split.rs
+++ b/tidepool-runtime/tests/repro_split.rs
@@ -1,0 +1,240 @@
+use frunk::HNil;
+use std::path::Path;
+use tidepool_runtime::compile_and_run_pure;
+
+fn prelude_path() -> std::path::PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().unwrap().join("haskell").join("lib")
+}
+
+fn run_plain(body: &str) -> serde_json::Value {
+    std::env::set_var("TIDEPOOL_DUMP_TREE", "1");
+    let src = format!(
+        r#"{{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, PartialTypeSignatures #-}}
+module Test where
+import Tidepool.Prelude
+import qualified Data.Text as T
+
+result :: _
+result = {body}
+"#
+    );
+    let pp = prelude_path();
+    let include = [pp.as_path()];
+    let val = tidepool_runtime::compile_and_run_pure(&src, "result", &include)
+        .expect("compile_and_run_pure failed");
+    val.to_json()
+}
+
+#[test]
+fn test_repro_split_hang() {
+    let json = run_plain("T.split (== 'x') \"abc\"");
+    assert_eq!(json, serde_json::json!(["abc"]));
+}
+
+#[test]
+fn test_repro_split_match() {
+    let json = run_plain("T.split (== ':') \"a:b:c\"");
+    assert_eq!(json, serde_json::json!(["a", "b", "c"]));
+}
+
+#[test]
+fn test_text_length() {
+    let json = run_plain("T.length \"hello\"");
+    assert_eq!(json, serde_json::json!(5));
+}
+
+#[test]
+fn test_text_length_empty() {
+    let json = run_plain("T.length \"\"");
+    assert_eq!(json, serde_json::json!(0));
+}
+
+#[test]
+fn test_text_length_pack() {
+    let json = run_plain("T.length (T.pack ['h', 'e', 'l', 'l', 'o'])");
+    assert_eq!(json, serde_json::json!(5));
+}
+
+#[test]
+fn test_text_null_empty() {
+    let json = run_plain("T.null \"\"");
+    assert_eq!(json, serde_json::json!(true));
+}
+
+#[test]
+fn test_text_null_t_empty() {
+    let json = run_plain("T.null T.empty");
+    assert_eq!(json, serde_json::json!(true));
+}
+
+#[test]
+fn test_text_null_nonempty() {
+    let json = run_plain("T.null \"abc\"");
+    assert_eq!(json, serde_json::json!(false));
+}
+
+#[test]
+fn test_text_drop() {
+    let json = run_plain("T.drop 2 \"hello\"");
+    assert_eq!(json, serde_json::json!("llo"));
+}
+
+#[test]
+fn test_text_drop_single() {
+    let json = run_plain("T.drop 1 \"a\"");
+    assert_eq!(json, serde_json::json!(""));
+}
+
+#[test]
+fn test_filter() {
+    let json = run_plain("T.filter (== 'a') \"abc\"");
+    assert_eq!(json, serde_json::json!("a"));
+}
+
+#[test]
+fn test_filter_list() {
+    let json = run_plain("filter (== 'a') (['a', 'b', 'c'] :: [Char])");
+    // [Char] is rendered as string
+    assert_eq!(json, serde_json::json!("a"));
+}
+
+#[test]
+fn test_break() {
+    let json = run_plain("T.break (== 'x') \"abc\"");
+    assert_eq!(json, serde_json::json!(["abc", ""]));
+}
+
+#[test]
+fn test_split_on() {
+    let json = run_plain("T.splitOn \":\" \"a:b:c\"");
+    assert_eq!(json, serde_json::json!(["a", "b", "c"]));
+}
+
+#[test]
+fn test_split_single() {
+    let json = run_plain("T.split (== 'a') \"a\"");
+    assert_eq!(json, serde_json::json!(["", ""]));
+}
+
+#[test]
+fn test_split_false() {
+    let json = run_plain("T.split (const False) \"abc\"");
+    assert_eq!(json, serde_json::json!(["abc"]));
+}
+
+#[test]
+fn test_split_true() {
+    let json = run_plain("T.split (const True) \"abc\"");
+    assert_eq!(json, serde_json::json!(["", "", "", ""]));
+}
+
+#[test]
+fn test_split_empty() {
+    let json = run_plain("T.split (== 'x') \"\"");
+    assert_eq!(json, serde_json::json!([""]));
+}
+
+#[test]
+fn test_split_first() {
+    let json = run_plain("T.split (== 'a') \"abc\"");
+    assert_eq!(json, serde_json::json!(["", "bc"]));
+}
+
+#[test]
+
+fn test_list_text() {
+
+    let json = run_plain("([\"a\", \"b\"] :: [T.Text])");
+
+    assert_eq!(json, serde_json::json!(["a", "b"]));
+
+}
+
+
+
+#[test]
+
+
+
+fn test_cmptest() {
+
+
+
+    let src = std::fs::read_to_string("tests/haskell/cmptest.hs").unwrap();
+
+
+
+    let pp = prelude_path();
+
+
+
+    let include = [pp.as_path()];
+
+
+
+    let val = tidepool_runtime::compile_and_run_pure(&src, "result", &include)
+
+
+
+        .expect("compile_and_run_pure failed");
+
+
+
+    assert_eq!(val.to_json(), serde_json::json!(1));
+
+
+
+}
+
+
+
+
+
+
+
+#[test]
+
+
+
+fn test_my_split() {
+
+
+
+
+
+    let src = r#"{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, PartialTypeSignatures #-}
+
+module Test where
+
+import Tidepool.Prelude
+
+import qualified Data.Text as T
+
+
+
+mySplit :: (Char -> Bool) -> T.Text -> [T.Text]
+
+mySplit p t | T.null t = [""]
+
+            | otherwise = let (l, r) = T.break p t
+
+                          in l : if T.null r then [] else mySplit p (T.drop 1 r)
+
+
+
+result = mySplit (const False) "abc"
+
+"#;
+
+    let pp = prelude_path();
+
+    let include = [pp.as_path()];
+
+    let val = tidepool_runtime::compile_and_run_pure(&src, "result", &include)
+
+        .expect("compile_and_run_pure failed");
+
+    assert_eq!(val.to_json(), serde_json::json!(["abc"]));
+
+}

--- a/tidepool-runtime/tests/repro_split.rs
+++ b/tidepool-runtime/tests/repro_split.rs
@@ -1,6 +1,4 @@
-use frunk::HNil;
 use std::path::Path;
-use tidepool_runtime::compile_and_run_pure;
 
 fn prelude_path() -> std::path::PathBuf {
     let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -8,7 +6,6 @@ fn prelude_path() -> std::path::PathBuf {
 }
 
 fn run_plain(body: &str) -> serde_json::Value {
-    std::env::set_var("TIDEPOOL_DUMP_TREE", "1");
     let src = format!(
         r#"{{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, PartialTypeSignatures #-}}
 module Test where

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -1220,8 +1220,8 @@ fn test_kv_keys_text_append() {
 }
 
 /// T.splitOn on a Text key from KvKeys.
-/// Bug: T.split infinite loop (pre-existing, not bridge-specific).
 #[test]
+#[ignore = "pre-existing: T.splitOn crashes on bridge text (ByteArray# layout mismatch)"]
 fn test_kv_keys_text_split_on() {
     let (json, _) = run_mcp_effectful(&[
         r#"send (KvSet "a:b:c" "v")"#,

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -1222,7 +1222,6 @@ fn test_kv_keys_text_append() {
 /// T.splitOn on a Text key from KvKeys.
 /// Bug: T.split infinite loop (pre-existing, not bridge-specific).
 #[test]
-#[ignore = "pre-existing: T.split infinite loop on all text"]
 fn test_kv_keys_text_split_on() {
     let (json, _) = run_mcp_effectful(&[
         r#"send (KvSet "a:b:c" "v")"#,


### PR DESCRIPTION
Fixes an infinite loop / segfault bug in recursive text functions like
`T.split`. The root cause was that top-level module bindings are compiled
as a single large LetRec group. During compilation, closures were
allocated in Phase 1 but their capture slots remained uninitialized until
Phase 3a'. If the evaluation of a deferred simple binding in Phase 3c
triggered an allocation (e.g. `newByteArray#`) and exhausted the JIT
nursery, the ensuing garbage collection root tracing would scan the
uninitialized closure capture slots and segfault.

This PR resolves the issue by zero-initializing closure capture
slots upon allocation and implementing a full transitive dependency
topological sort for LetRec deferred bindings. The capture slots are
now incrementally filled as their dependencies resolve, ensuring safe
execution and GC tracing.

Additionally:
- Corrects `Clz8#` primop implementation to narrow to I8 before clz.
- Adds comprehensive text splitting tests to `repro_split.rs`.

**Updates:**
- Addressed Copilot review feedback: removed unused imports, removed global env set `TIDEPOOL_DUMP_TREE` from test, optimized LetRec topo sort using DFS reachability instead of full transitive map building, refactored Phase 3c updates into O(1) map lookups, zero-initialized Con fields in Phase 1, and restored `#[ignore]` on `test_kv_keys_text_split_on` specifying the newly-identified bridge text mismatch issue.