### PR TITLE
feat: Wire gc_trigger to perform actual Cheney GC

### DIFF
--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -116,6 +116,45 @@ pub extern "C" fn gc_trigger(vmctx: *mut VMContext) {
                 // Walk frames starting from gc_trigger's own frame.
                 let roots = unsafe { frame_walker::walk_frames(rbp, registry, rsp) };
 
+                // ── Cheney copying GC ──────────────────────────────
+                GC_STATE.with(|gc_cell| {
+                    let mut gc_state = gc_cell.borrow_mut();
+                    if let Some(state) = gc_state.as_mut() {
+                        let from_start = state.active_start;
+                        let from_size = state.active_size;
+                        let from_end = unsafe { from_start.add(from_size) };
+
+                        let mut tospace = vec![0u8; from_size];
+
+                        // Convert StackRoot to raw slot pointers
+                        let root_slots: Vec<*mut *mut u8> = roots.iter()
+                            .map(|r| r.stack_slot_addr as *mut *mut u8)
+                            .collect();
+
+                        let result = unsafe {
+                            tidepool_heap::gc::raw::cheney_copy(
+                                &root_slots,
+                                from_start as *const u8,
+                                from_end as *const u8,
+                                &mut tospace,
+                            )
+                        };
+
+                        // Update GcState: swap to tospace
+                        let to_start = tospace.as_mut_ptr();
+                        state.active_start = to_start;
+                        // active_size stays the same
+                        state.active_buffer = Some(tospace); // drops old buffer if any
+
+                        // Update VMContext for resumed allocation
+                        unsafe {
+                            (*vmctx).alloc_ptr = to_start.add(result.bytes_copied);
+                            (*vmctx).alloc_limit = to_start.add(from_size) as *const u8;
+                        }
+                    }
+                });
+                // ── End GC ─────────────────────────────────────────
+
                 // Call test hook if present
                 HOOK.with(|hook_cell| {
                     if let Some(hook) = *hook_cell.borrow() {

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -95,6 +95,10 @@ impl JitEffectMachine {
         // Install registries
         crate::debug::set_lambda_registry(self.pipeline.build_lambda_registry());
         crate::host_fns::set_stack_map_registry(&self.pipeline.stack_maps);
+        crate::host_fns::set_gc_state(
+            self.nursery.start() as *mut u8,
+            self.nursery.size(),
+        );
 
         let func_ptr: unsafe extern "C" fn(*mut VMContext) -> *mut u8 =
             unsafe { std::mem::transmute(self.pipeline.get_function_ptr(self.func_id)) };
@@ -129,6 +133,7 @@ impl JitEffectMachine {
         };
 
         // Cleanup registries
+        crate::host_fns::clear_gc_state();
         crate::host_fns::clear_stack_map_registry();
         crate::debug::clear_lambda_registry();
 
@@ -144,6 +149,10 @@ impl JitEffectMachine {
         // Install registries
         crate::debug::set_lambda_registry(self.pipeline.build_lambda_registry());
         crate::host_fns::set_stack_map_registry(&self.pipeline.stack_maps);
+        crate::host_fns::set_gc_state(
+            self.nursery.start() as *mut u8,
+            self.nursery.size(),
+        );
 
         let func_ptr: unsafe extern "C" fn(*mut VMContext) -> *mut u8 =
             unsafe { std::mem::transmute(self.pipeline.get_function_ptr(self.func_id)) };
@@ -188,6 +197,7 @@ impl JitEffectMachine {
         };
 
         // Cleanup registries
+        crate::host_fns::clear_gc_state();
         crate::host_fns::clear_stack_map_registry();
         crate::debug::clear_lambda_registry();
 


### PR DESCRIPTION
## Summary

- gc_trigger now calls cheney_copy with roots from walk_frames, updates VMContext alloc_ptr/alloc_limit after GC, and swaps GcState to the new tospace buffer
- run_pure and run call set_gc_state/clear_gc_state around JIT execution so gc_trigger knows the nursery bounds
- Existing test hook and LAST_ROOTS storage preserved

## Test plan

- [x] cargo check --workspace passes
- [ ] cargo test -p tidepool-codegen passes  
- [ ] GC actually fires and programs survive nursery exhaustion (validated in Leaf 4)