### PR TITLE
feat: add Http effect to MCP server for JSON fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
 ]
 
 [[package]]

--- a/examples/mcp-server/Cargo.toml
+++ b/examples/mcp-server/Cargo.toml
@@ -19,6 +19,7 @@ tidepool-repr = { path = "../../tidepool-repr" }
 ast-grep-core = "0.41"
 ast-grep-language = "0.41"
 frunk = "0.4"
+ureq = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/mcp-server/Cargo.toml
+++ b/examples/mcp-server/Cargo.toml
@@ -20,6 +20,7 @@ ast-grep-core = "0.41"
 ast-grep-language = "0.41"
 frunk = "0.4"
 ureq = "2"
+url = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/mcp-server/src/main.rs
+++ b/examples/mcp-server/src/main.rs
@@ -473,14 +473,80 @@ impl EffectHandler<CapturedOutput> for HttpHandler {
         cx: &EffectContext<'_, CapturedOutput>,
     ) -> Result<Value, EffectError> {
         match req {
-            HttpReq::Get(url) => {
-                let resp = ureq::get(&url)
+            HttpReq::Get(url_str) => {
+                let url = url::Url::parse(&url_str).map_err(|e| {
+                    EffectError::Handler(format!("Invalid URL '{}': {}", url_str, e))
+                })?;
+
+                if url.scheme() != "http" && url.scheme() != "https" {
+                    return Err(EffectError::Handler(format!(
+                        "Unsupported protocol '{}' for URL '{}'. Only http and https are allowed.",
+                        url.scheme(),
+                        url_str
+                    )));
+                }
+
+                if let Some(host) = url.host() {
+                    match host {
+                        url::Host::Ipv4(ip) => {
+                            if ip.is_loopback() || ip.is_private() || ip.is_link_local() {
+                                return Err(EffectError::Handler(format!(
+                                    "Access to internal IP address '{}' is restricted.",
+                                    ip
+                                )));
+                            }
+                        }
+                        url::Host::Ipv6(ip) => {
+                            if ip.is_loopback() || ip.is_unspecified() {
+                                return Err(EffectError::Handler(format!(
+                                    "Access to internal IP address '{}' is restricted.",
+                                    ip
+                                )));
+                            }
+                            // Simplified IPv6 private check (Unique Local Address)
+                            let segments = ip.segments();
+                            if (segments[0] & 0xfe00) == 0xfc00 {
+                                return Err(EffectError::Handler(format!(
+                                    "Access to internal IP address '{}' is restricted.",
+                                    ip
+                                )));
+                            }
+                        }
+                        url::Host::Domain(domain) => {
+                            if domain == "localhost" {
+                                return Err(EffectError::Handler(
+                                    "Access to 'localhost' is restricted.".into(),
+                                ));
+                            }
+                        }
+                    }
+                }
+
+                let resp = match ureq::get(url.as_str())
                     .timeout(std::time::Duration::from_secs(30))
                     .call()
-                    .map_err(|e| EffectError::Handler(format!("HTTP GET failed: {}", e)))?;
-                let body = resp
-                    .into_string()
-                    .map_err(|e| EffectError::Handler(format!("Read body failed: {}", e)))?;
+                {
+                    Ok(resp) => resp,
+                    Err(err) => {
+                        let msg = match err {
+                            ureq::Error::Status(code, response) => format!(
+                                "HTTP GET to '{}' failed with status {} {}",
+                                url_str,
+                                code,
+                                response.status_text()
+                            ),
+                            ureq::Error::Transport(transport) => format!(
+                                "HTTP GET to '{}' failed due to transport error: {}",
+                                url_str, transport
+                            ),
+                        };
+                        return Err(EffectError::Handler(msg));
+                    }
+                };
+
+                let body = resp.into_string().map_err(|e| {
+                    EffectError::Handler(format!("Read body from '{}' failed: {}", url_str, e))
+                })?;
                 cx.respond(body)
             }
         }

--- a/examples/mcp-server/src/main.rs
+++ b/examples/mcp-server/src/main.rs
@@ -448,6 +448,45 @@ impl EffectHandler<CapturedOutput> for SgHandler {
     }
 }
 
+// === Tag 4: Http ===
+
+#[derive(FromCore)]
+enum HttpReq {
+    #[core(name = "HttpGet")]
+    Get(String),
+}
+
+#[derive(Clone)]
+struct HttpHandler;
+
+impl DescribeEffect for HttpHandler {
+    fn effect_decl() -> EffectDecl {
+        tidepool_mcp::http_decl()
+    }
+}
+
+impl EffectHandler<CapturedOutput> for HttpHandler {
+    type Request = HttpReq;
+    fn handle(
+        &mut self,
+        req: HttpReq,
+        cx: &EffectContext<'_, CapturedOutput>,
+    ) -> Result<Value, EffectError> {
+        match req {
+            HttpReq::Get(url) => {
+                let resp = ureq::get(&url)
+                    .timeout(std::time::Duration::from_secs(30))
+                    .call()
+                    .map_err(|e| EffectError::Handler(format!("HTTP GET failed: {}", e)))?;
+                let body = resp
+                    .into_string()
+                    .map_err(|e| EffectError::Handler(format!("Read body failed: {}", e)))?;
+                cx.respond(body)
+            }
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
@@ -463,7 +502,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ConsoleHandler,
         KvHandler::new(),
         FsHandler::new(cwd.clone()),
-        SgHandler::new(cwd.clone())
+        SgHandler::new(cwd.clone()),
+        HttpHandler
     ];
 
     // Prelude lives at haskell/lib/ relative to repo root, or via TIDEPOOL_PRELUDE_DIR.

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -93,6 +93,7 @@ pub fn clear_gc_state() {
 ///
 /// The frame walker in gc_trigger reads RBP to walk the JIT stack.
 #[inline(never)]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn gc_trigger(vmctx: *mut VMContext) {
     // Force a frame to be created
     let mut _dummy = [0u64; 2];
@@ -399,7 +400,6 @@ pub unsafe extern "C" fn debug_app_check(fun_ptr: *const u8) {
         RUNTIME_ERROR.with(|cell| {
             *cell.borrow_mut() = Some(RuntimeError::BadFunPtrTag(tag));
         });
-        return;
     }
 }
 

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -708,6 +708,17 @@ mod tests {
     }
 
     #[test]
+    fn test_standard_decls_includes_http() {
+        let decls = standard_decls();
+        assert_eq!(decls.len(), 5);
+        assert_eq!(decls[0].type_name, "Console");
+        assert_eq!(decls[1].type_name, "KV");
+        assert_eq!(decls[2].type_name, "Fs");
+        assert_eq!(decls[3].type_name, "SG");
+        assert_eq!(decls[4].type_name, "Http");
+    }
+
+    #[test]
     fn test_template_haskell() {
         let effects = vec![EffectDecl {
             type_name: "Console",

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -131,9 +131,25 @@ pub fn sg_decl() -> EffectDecl {
     }
 }
 
+/// Http effect: fetch JSON from HTTP endpoints.
+pub fn http_decl() -> EffectDecl {
+    EffectDecl {
+        type_name: "Http",
+        description: "Fetch JSON from HTTP endpoints. Returns response body as Text.",
+        constructors: &["HttpGet :: Text -> Http Text"],
+        type_defs: &[],
+    }
+}
+
 /// All standard effects in canonical order.
 pub fn standard_decls() -> Vec<EffectDecl> {
-    vec![console_decl(), kv_decl(), fs_decl(), sg_decl()]
+    vec![
+        console_decl(),
+        kv_decl(),
+        fs_decl(),
+        sg_decl(),
+        http_decl(),
+    ]
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds an `Http` effect to the tidepool MCP server that lets Haskell programs fetch JSON from URLs.

### Changes
- Added `ureq = "2"` dependency to `examples/mcp-server/Cargo.toml`
- Added `http_decl()` to `tidepool-mcp/src/lib.rs`
- Implemented `HttpHandler` in `examples/mcp-server/src/main.rs`
- Added `HttpHandler` to the handler HList in `main()`, positioned after `SgHandler` (Tag 4)

### Design
The `Http` effect provides a single constructor:
```haskell
HttpGet :: Text -> Http Text
```
It returns the raw JSON response body as `Text`, which can then be decoded using `aeson` on the Haskell side. The Rust handler uses `ureq` with a hardcoded 30s timeout.