### PR TITLE
feat: normalize constructor tags and fix Maybe unboxing

### DIFF
--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -671,7 +671,12 @@ translate expr =
     Var v | Just dc <- isDataConWrapId_maybe v
           , length args == valueRepArity dc -> do
         recordDC dc
-        childIdxs <- mapM stripBoxCon args
+        -- Only strip boxes for product types (single-constructor types like Text, Int, Word).
+        -- For sum types (e.g. Maybe), the worker expects pointer arguments.
+        let tc = dataConTyCon dc
+        childIdxs <- if isAlgTyCon tc && length (tyConDataCons tc) == 1
+                     then mapM stripBoxCon args
+                     else mapM translate args
         emitNode $ NCon (varId (dataConWorkId dc)) childIdxs
 
     -- unsafeEqualityProof → unit value (always matches the single UnsafeRefl alt)
@@ -954,7 +959,7 @@ mapAltCon = \case
 
 varId :: Var -> Word64
 varId v = case isDataConId_maybe v of
-  Just _  -> stableVarId (varName v)
+  Just dc -> stableVarId (varName (dataConWorkId dc))
   Nothing -> if isExternalName (varName v)
              then stableVarId (varName v)
              else fromIntegral (getKey (varUnique v))
@@ -964,12 +969,15 @@ stableVarId name =
   let modStr = case nameModule_maybe name of
         Just m  -> normalizeMod (moduleNameString (moduleName m))
         Nothing -> "WiredIn"
-      normalizeMod s = T.unpack $ T.replace ".Internal" "" (T.pack s)
+      normalizeMod s =
+        let t = T.pack s
+            t1 = T.replace ".Internal" "" t
+            t2 = T.replace "Internal." "" t1
+        in T.unpack t2
       occStr = occNameString (nameOccName name)
       fullStr = modStr ++ ":" ++ occStr
       Fingerprint h1 _ = fingerprintString fullStr
-      res = (0xFE `shiftL` 56) .|. (h1 .&. 0x00FFFFFFFFFFFFFF)
-  in trace ("stableVarId: " ++ fullStr ++ " -> 0x" ++ showHex res "") res
+  in (0xFE `shiftL` 56) .|. (h1 .&. 0x00FFFFFFFFFFFFFF)
 
 collectValueBinders :: Int -> CoreExpr -> ([Var], CoreExpr)
 collectValueBinders 0 e = ([], e)
@@ -996,7 +1004,8 @@ stripBoxCon expr =
       vArgs = filter isValueArg allArgs
   in case hd of
     Var w | Just innerDc <- isDataConWorkId_maybe w
-          , dataConRepArity innerDc == 1
+          , let tc = dataConTyCon innerDc
+          , isAlgTyCon tc && length (tyConDataCons tc) == 1
           , [inner] <- vArgs -> do
         recordDC innerDc  -- still record the box constructor for DataConTable
         translate inner

--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -962,8 +962,9 @@ varId v = case isDataConId_maybe v of
 stableVarId :: Name -> Word64
 stableVarId name =
   let modStr = case nameModule_maybe name of
-        Just m  -> moduleNameString (moduleName m)
+        Just m  -> normalizeMod (moduleNameString (moduleName m))
         Nothing -> "WiredIn"
+      normalizeMod s = T.unpack $ T.replace ".Internal" "" (T.pack s)
       occStr = occNameString (nameOccName name)
       fullStr = modStr ++ ":" ++ occStr
       Fingerprint h1 _ = fingerprintString fullStr

--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -29,6 +29,8 @@ import GHC.Builtin.PrimOps
 import GHC.Types.Literal
 import GHC.Types.Name (nameOccName, isExternalName, isSystemName, nameModule_maybe)
 import GHC.Types.Name.Occurrence (occNameString)
+import GHC.Unit.Module (moduleName, moduleNameString)
+import GHC.Utils.Fingerprint (fingerprintString, Fingerprint(..))
 import GHC.Core.TyCon
 import GHC.Core.Type (splitTyConApp_maybe, isCoercionTy)
 import GHC.Builtin.Types.Prim (statePrimTyCon)
@@ -951,7 +953,22 @@ mapAltCon = \case
   DEFAULT    -> return FDefault
 
 varId :: Var -> Word64
-varId v = fromIntegral (getKey (varUnique v))
+varId v = case isDataConId_maybe v of
+  Just _  -> stableVarId (varName v)
+  Nothing -> if isExternalName (varName v)
+             then stableVarId (varName v)
+             else fromIntegral (getKey (varUnique v))
+
+stableVarId :: Name -> Word64
+stableVarId name =
+  let modStr = case nameModule_maybe name of
+        Just m  -> moduleNameString (moduleName m)
+        Nothing -> "WiredIn"
+      occStr = occNameString (nameOccName name)
+      fullStr = modStr ++ ":" ++ occStr
+      Fingerprint h1 _ = fingerprintString fullStr
+      res = (0xFE `shiftL` 56) .|. (h1 .&. 0x00FFFFFFFFFFFFFF)
+  in trace ("stableVarId: " ++ fullStr ++ " -> 0x" ++ showHex res "") res
 
 collectValueBinders :: Int -> CoreExpr -> ([Var], CoreExpr)
 collectValueBinders 0 e = ([], e)

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -1264,7 +1264,6 @@ persist key filename = do
 // ===========================================================================
 
 #[test]
-#[ignore = "pre-existing: SIGILL in Map.differenceWith (likely unsupported primop)"]
 fn test_map_difference_with() {
     // Map.differenceWith uses fat interface bindings that may contain
     // Rec groups with join points. Previously failed with
@@ -1284,7 +1283,6 @@ fn test_map_difference_with() {
 }
 
 #[test]
-#[ignore = "pre-existing: SIGILL in Map.intersectionWith (likely unsupported primop)"]
 fn test_map_intersection_with() {
     // Another Map operation that exercises fat interface Rec groups.
     let json = run_mcp_with_imports(


### PR DESCRIPTION
This PR fixes the Group C issue where `Map` operations (and potentially other higher-order functions) failed with `SIGILL` or `CASE TRAP` due to constructor tag mismatches.

### Changes
1.  **Stable VarIds**: Implemented `stableVarId` in `Translate.hs` using GHC's `Fingerprint` on the fully-qualified name (Module + OccName). This ensures that the same logical constructor has the same tag regardless of whether it's compiled directly or loaded via a fat interface.
2.  **Module Normalization**: Added robust module name normalization to handle GHC 9.12's `GHC.Internal.*` module structure, ensuring that internal and public aliases of the same module hash to the same ID.
3.  **Worker/Wrapper Unification**: Updated `varId` to use the worker's stable ID for both DataCon workers and wrappers. This prevents tag mismatches when a constructor is applied via its wrapper but cased on using its worker tag.
4.  **Box Stripping Fix**: Fixed a bug in `stripBoxCon` that was incorrectly unboxing sum types like `Maybe`. By restricting stripping to single-constructor algebraic types (product types), we ensure that `Just` and other sum constructors retain their pointer arguments as expected by their workers.
5.  **Test Enablement**: Enabled `test_map_difference_with` and `test_map_intersection_with` in `tidepool-runtime`, which now pass.

### Verification
-   `cargo test -p tidepool-runtime --test sort_crash` passes with 220 tests.
-   Confirmed that `Maybe` and `Int` constructors now have consistent tags across different compilation contexts.
-   Verified that `test_map_difference_with` and `test_map_intersection_with` no longer trap.