### PR TITLE
Fix Group A SIGILL and memory faults via recursive unboxing and accurate translation

### DIFF
--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -641,7 +641,7 @@ translate expr =
         -- Build: case (IntLe i 0) of { DEFAULT -> <aCaseIdx>; 1# -> [] }
         iRef2 <- emitNode $ NVar iId
         lit0 <- emitNode $ NLit (LEInt 0)
-        leResult <- emitNode $ NPrimOp (T.pack "IntLe") [iRef2, lit0]
+        leResult <- emitOp (T.pack "IntLe") [iRef2, lit0]
         let leDefaultAlt = FlatAlt FDefault [] aCaseIdx
             leTrueAlt    = FlatAlt (FLitAlt (LEInt 1)) [] nilIdx
         leCaseIdx <- emitNode $ NCase leResult 0 [leDefaultAlt, leTrueAlt]
@@ -663,11 +663,9 @@ translate expr =
 
     -- DataCon wrapper Ids: the wrapper takes *boxed* args (e.g., ByteArray, Int)
     -- but we need *unboxed* args for the worker representation stored in NCon.
-    -- Strip single-field box constructors (I#, ByteArray, W#, etc.) from args.
-    -- This is needed because GHC unfoldings from .hi files may use the wrapper form
-    -- (e.g., Text (ByteArray ba#) (I# off#) (I# len#)) instead of the worker form
-    -- (Text ba# off# len#). Without stripping, the NCon fields would be nested Cons
-    -- instead of Lits, causing SIGSEGV when the JIT tries to unbox them.
+    -- We've updated the codegen's unbox_* helpers to handle both boxed and unboxed
+    -- values, so we can now leave the boxing in place. This ensures that Case
+    -- expressions matching on these fields (e.g. matching I# in Text offset) work.
     Var v | Just dc <- isDataConWrapId_maybe v
           , length args == valueRepArity dc -> do
         recordDC dc
@@ -727,7 +725,7 @@ translate expr =
     Var v | Just pop <- isPrimOpId_maybe v
           , length args == primOpArity pop -> do
         childIdxs <- mapM translate args
-        emitNode $ NPrimOp (mapPrimOp pop) childIdxs
+        emitOp (mapPrimOp pop) childIdxs
 
     Var v | Just arity <- isJoinId_maybe v
           , length allArgs == arity -> do
@@ -746,13 +744,16 @@ translate expr =
     Var v | isFCallId v -> do
         let pprName = showPprUnsafe v
         childIdxs <- mapM translate args
-        emitNode $ NPrimOp (mapFfiCall pprName) childIdxs
+        emitOp (mapFfiCall pprName) childIdxs
 
     _ -> do
       hIdx <- translateHead hd
       foldM (\fIdx arg -> do
         aIdx <- translate arg
         emitNode $ NApp fIdx aIdx) hIdx args
+
+emitOp :: Text -> [Int] -> TransM Int
+emitOp name args = emitNode $ NPrimOp name args
 
 translateHead :: CoreExpr -> TransM Int
 translateHead = \case
@@ -823,8 +824,9 @@ translateHead = \case
   --   case remInt# a b of r { DEFAULT ->
   --   body }}
   -- This ensures both components are forced and a/b are shared.
-  Case scrut _caseBinder _ty [Alt (DataAlt _dc) binders body]
-    | (Var v, allArgs) <- collectArgs scrut
+  Case scrut _caseBinder _ty [Alt (DataAlt dc) binders body]
+    | isUnboxedTupleDataCon dc
+    , (Var v, allArgs) <- collectArgs (stripTicksAndCasts scrut)
     , Just pop <- isPrimOpId_maybe v
     , Just (op1Name, op2Name) <- splitMultiReturnPrimOp pop
     , let valArgs = filter isValueArg allArgs
@@ -833,8 +835,8 @@ translateHead = \case
     , [qBinder, rBinder] <- vBinders -> do
         aIdx <- translate a
         bIdx <- translate b
-        qValIdx <- emitNode $ NPrimOp op1Name [aIdx, bIdx]
-        rValIdx <- emitNode $ NPrimOp op2Name [aIdx, bIdx]
+        qValIdx <- emitOp op1Name [aIdx, bIdx]
+        rValIdx <- emitOp op2Name [aIdx, bIdx]
         -- Bind q and r using Case to force them, then translate body
         bodyIdx <- translate body
         -- case rVal of rBinder { DEFAULT -> body }
@@ -842,8 +844,9 @@ translateHead = \case
         -- case qVal of qBinder { DEFAULT -> rCaseIdx }
         emitNode $ NCase qValIdx (varId qBinder) [FlatAlt FDefault [] rCaseIdx]
   -- Desugar triple-return primops: case timesInt2# a b of (# hi, lo, ovf #) -> body
-  Case scrut _caseBinder _ty [Alt (DataAlt _dc) binders body]
-    | (Var v, allArgs) <- collectArgs scrut
+  Case scrut _caseBinder _ty [Alt (DataAlt dc) binders body]
+    | isUnboxedTupleDataCon dc
+    , (Var v, allArgs) <- collectArgs (stripTicksAndCasts scrut)
     , Just pop <- isPrimOpId_maybe v
     , Just (op1Name, op2Name, op3Name) <- splitTripleReturnPrimOp pop
     , let valArgs = filter isValueArg allArgs
@@ -852,9 +855,9 @@ translateHead = \case
     , [b1, b2, b3] <- vBinders -> do
         aIdx <- translate a
         bIdx <- translate b
-        v1Idx <- emitNode $ NPrimOp op1Name [aIdx, bIdx]
-        v2Idx <- emitNode $ NPrimOp op2Name [aIdx, bIdx]
-        v3Idx <- emitNode $ NPrimOp op3Name [aIdx, bIdx]
+        v1Idx <- emitOp op1Name [aIdx, bIdx]
+        v2Idx <- emitOp op2Name [aIdx, bIdx]
+        v3Idx <- emitOp op3Name [aIdx, bIdx]
         bodyIdx <- translate body
         c3 <- emitNode $ NCase v3Idx (varId b3) [FlatAlt FDefault [] bodyIdx]
         c2 <- emitNode $ NCase v2Idx (varId b2) [FlatAlt FDefault [] c3]
@@ -868,7 +871,7 @@ translateHead = \case
   --   3. For 0 result binders (void ops like write): run op, then body
   Case scrut _caseBinder _ty [Alt (DataAlt dc) binders body]
     | isUnboxedTupleDataCon dc
-    , (Var v, allArgs) <- collectArgs scrut
+    , (Var v, allArgs) <- collectArgs (stripTicksAndCasts scrut)
     , isPrimOpId_maybe v /= Nothing || isFCallId v
     , let valArgs = filter isValueArg allArgs
     -- Only drop the last value arg if the first result binder has State# type
@@ -889,7 +892,7 @@ translateHead = \case
         opName <- case isPrimOpId_maybe v of
                     Just pop -> return (mapPrimOp pop)
                     Nothing  -> return (mapFfiCall (showPprUnsafe v))
-        primIdx <- emitNode $ NPrimOp opName childIdxs
+        primIdx <- emitOp opName childIdxs
         if hasStateBinder then do
           -- Stateful primop: bind s' (state token) to dummy, bind results to primop
           dummyState <- emitNode $ NLit (LEInt 0)
@@ -928,6 +931,23 @@ translateHead = \case
               c1 <- emitNode $ NCase primIdx (varId r2) [FlatAlt FDefault [] bodyIdx]
               emitNode $ NCase primIdx (varId r1) [FlatAlt FDefault [] c1]
             _ -> error $ "Unsupported pure unboxed tuple arity: " ++ show (length vBinders) ++ " binders"
+  Case scrut b _alts_ty [Alt (DataAlt dc) binders body]
+    | isUnboxedTupleDataCon dc -> do
+        scrutIdx <- translate scrut
+        let vBinders = filter (not . isTyVar) binders
+        bodyIdx <- translate body
+        case vBinders of
+          [valBinder] -> do
+            -- Single-element unboxed tuple: use FDefault to handle both Lit and Con.
+            -- This happens when a primop returns a raw literal that GHC wraps in (# #).
+            emitNode $ NCase scrutIdx (varId valBinder) [FlatAlt FDefault [] bodyIdx]
+          [] -> do
+            -- Zero-element unboxed tuple: use FDefault, bind to dummy.
+            emitNode $ NCase scrutIdx (varId b) [FlatAlt FDefault [] bodyIdx]
+          _ -> do
+            -- Multi-element: must be a heap box, use FDataAlt to bind fields.
+            recordDC dc
+            emitNode $ NCase scrutIdx (varId b) [FlatAlt (FDataAlt (varId (dataConWorkId dc))) (map varId vBinders) bodyIdx]
   Case scrut b _alts_ty alts -> do
     scrutIdx <- translate scrut
     altData <- mapM translateAlt alts
@@ -978,6 +998,11 @@ stableVarId name =
       fullStr = modStr ++ ":" ++ occStr
       Fingerprint h1 _ = fingerprintString fullStr
   in (0xFE `shiftL` 56) .|. (h1 .&. 0x00FFFFFFFFFFFFFF)
+
+stripTicksAndCasts :: CoreExpr -> CoreExpr
+stripTicksAndCasts (Tick _ e) = stripTicksAndCasts e
+stripTicksAndCasts (Cast e _) = stripTicksAndCasts e
+stripTicksAndCasts e          = e
 
 collectValueBinders :: Int -> CoreExpr -> ([Var], CoreExpr)
 collectValueBinders 0 e = ([], e)

--- a/tidepool-codegen/src/context.rs
+++ b/tidepool-codegen/src/context.rs
@@ -11,7 +11,7 @@ pub struct VMContext {
     /// End of the current nursery region.
     pub alloc_limit: *const u8,
     /// Host function called when alloc_ptr exceeds alloc_limit.
-    pub gc_trigger: extern "C" fn(*mut VMContext),
+    pub gc_trigger: unsafe extern "C" fn(*mut VMContext),
 }
 
 impl VMContext {
@@ -19,7 +19,7 @@ impl VMContext {
     pub fn new(
         nursery_start: *mut u8,
         nursery_end: *const u8,
-        gc_trigger: extern "C" fn(*mut VMContext),
+        gc_trigger: unsafe extern "C" fn(*mut VMContext),
     ) -> Self {
         Self {
             alloc_ptr: nursery_start,

--- a/tidepool-codegen/src/emit/primop.rs
+++ b/tidepool-codegen/src/emit/primop.rs
@@ -26,98 +26,99 @@ pub fn emit_primop(
         // Int arithmetic (binary)
         PrimOpKind::IntAdd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntSub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntMul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntNegate => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(builder.ins().ineg(a), LIT_TAG_INT))
         }
         PrimOpKind::IntQuot => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().sdiv(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntRem => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().srem(a, b), LIT_TAG_INT))
         }
 
         // Int bitwise
         PrimOpKind::IntAnd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().band(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntOr => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().bor(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntXor => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().bxor(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntNot => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(builder.ins().bnot(a), LIT_TAG_INT))
         }
 
         // Int shifts
         PrimOpKind::IntShl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().ishl(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntShra => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().sshr(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntShrl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().ushr(a, b), LIT_TAG_INT))
         }
 
-        // Int comparison → returns i64 (0=False, 1=True)
-        PrimOpKind::IntEq => emit_int_compare(builder, op, IntCC::Equal, args, LIT_TAG_INT),
-        PrimOpKind::IntNe => emit_int_compare(builder, op, IntCC::NotEqual, args, LIT_TAG_INT),
+        // Int comparison \u2192 returns i64 (0=False, 1=True)
+        PrimOpKind::IntEq => emit_int_compare(pipeline, builder, op, IntCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::IntNe => emit_int_compare(pipeline, builder, op, IntCC::NotEqual, args, LIT_TAG_INT),
         PrimOpKind::IntLt => {
-            emit_int_compare(builder, op, IntCC::SignedLessThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::SignedLessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::IntLe => {
-            emit_int_compare(builder, op, IntCC::SignedLessThanOrEqual, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::SignedLessThanOrEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::IntGt => {
-            emit_int_compare(builder, op, IntCC::SignedGreaterThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::SignedGreaterThan, args, LIT_TAG_INT)
         }
         PrimOpKind::IntGe => emit_int_compare(
+            pipeline,
             builder,
             op,
             IntCC::SignedGreaterThanOrEqual,
@@ -128,82 +129,83 @@ pub fn emit_primop(
         // Word arithmetic
         PrimOpKind::WordAdd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordSub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordMul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_WORD))
         }
 
         PrimOpKind::WordQuot => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().udiv(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordRem => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().urem(a, b), LIT_TAG_WORD))
         }
 
         // Word bitwise
         PrimOpKind::WordAnd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().band(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordOr => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().bor(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordXor => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().bxor(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordNot => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(builder.ins().bnot(a), LIT_TAG_WORD))
         }
 
         // Word shifts
         PrimOpKind::WordShl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().ishl(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordShrl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().ushr(a, b), LIT_TAG_WORD))
         }
 
         // Word comparison (unsigned)
-        PrimOpKind::WordEq => emit_int_compare(builder, op, IntCC::Equal, args, LIT_TAG_INT),
-        PrimOpKind::WordNe => emit_int_compare(builder, op, IntCC::NotEqual, args, LIT_TAG_INT),
+        PrimOpKind::WordEq => emit_int_compare(pipeline, builder, op, IntCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::WordNe => emit_int_compare(pipeline, builder, op, IntCC::NotEqual, args, LIT_TAG_INT),
         PrimOpKind::WordLt => {
-            emit_int_compare(builder, op, IntCC::UnsignedLessThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::UnsignedLessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::WordLe => emit_int_compare(
+            pipeline,
             builder,
             op,
             IntCC::UnsignedLessThanOrEqual,
@@ -211,9 +213,10 @@ pub fn emit_primop(
             LIT_TAG_INT,
         ),
         PrimOpKind::WordGt => {
-            emit_int_compare(builder, op, IntCC::UnsignedGreaterThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::UnsignedGreaterThan, args, LIT_TAG_INT)
         }
         PrimOpKind::WordGe => emit_int_compare(
+            pipeline,
             builder,
             op,
             IntCC::UnsignedGreaterThanOrEqual,
@@ -224,54 +227,55 @@ pub fn emit_primop(
         // Double arithmetic
         PrimOpKind::DoubleAdd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(builder, args[0]);
-            let b = unbox_double(builder, args[1]);
+            let a = unbox_double(pipeline, builder, args[0]);
+            let b = unbox_double(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().fadd(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleSub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(builder, args[0]);
-            let b = unbox_double(builder, args[1]);
+            let a = unbox_double(pipeline, builder, args[0]);
+            let b = unbox_double(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().fsub(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleMul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(builder, args[0]);
-            let b = unbox_double(builder, args[1]);
+            let a = unbox_double(pipeline, builder, args[0]);
+            let b = unbox_double(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().fmul(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleDiv => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(builder, args[0]);
-            let b = unbox_double(builder, args[1]);
+            let a = unbox_double(pipeline, builder, args[0]);
+            let b = unbox_double(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().fdiv(a, b), LIT_TAG_DOUBLE))
         }
 
         // Double comparison
-        PrimOpKind::DoubleEq => emit_float_compare(builder, op, FloatCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::DoubleEq => emit_float_compare(pipeline, builder, op, FloatCC::Equal, args, LIT_TAG_INT),
         PrimOpKind::DoubleNe => {
-            emit_float_compare(builder, op, FloatCC::NotEqual, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::NotEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::DoubleLt => {
-            emit_float_compare(builder, op, FloatCC::LessThan, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::LessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::DoubleLe => {
-            emit_float_compare(builder, op, FloatCC::LessThanOrEqual, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::LessThanOrEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::DoubleGt => {
-            emit_float_compare(builder, op, FloatCC::GreaterThan, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::GreaterThan, args, LIT_TAG_INT)
         }
         PrimOpKind::DoubleGe => {
-            emit_float_compare(builder, op, FloatCC::GreaterThanOrEqual, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::GreaterThanOrEqual, args, LIT_TAG_INT)
         }
 
         // Char comparison
-        PrimOpKind::CharEq => emit_int_compare(builder, op, IntCC::Equal, args, LIT_TAG_INT),
-        PrimOpKind::CharNe => emit_int_compare(builder, op, IntCC::NotEqual, args, LIT_TAG_INT),
+        PrimOpKind::CharEq => emit_int_compare(pipeline, builder, op, IntCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::CharNe => emit_int_compare(pipeline, builder, op, IntCC::NotEqual, args, LIT_TAG_INT),
         PrimOpKind::CharLt => {
-            emit_int_compare(builder, op, IntCC::UnsignedLessThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::UnsignedLessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::CharLe => emit_int_compare(
+            pipeline,
             builder,
             op,
             IntCC::UnsignedLessThanOrEqual,
@@ -279,9 +283,10 @@ pub fn emit_primop(
             LIT_TAG_INT,
         ),
         PrimOpKind::CharGt => {
-            emit_int_compare(builder, op, IntCC::UnsignedGreaterThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::UnsignedGreaterThan, args, LIT_TAG_INT)
         }
         PrimOpKind::CharGe => emit_int_compare(
+            pipeline,
             builder,
             op,
             IntCC::UnsignedGreaterThanOrEqual,
@@ -292,17 +297,17 @@ pub fn emit_primop(
         // Conversions
         PrimOpKind::Chr => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_CHAR))
         }
         PrimOpKind::Ord => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_INT))
         }
         PrimOpKind::Int2Word | PrimOpKind::Word2Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let tag = if matches!(op, PrimOpKind::Int2Word) {
                 LIT_TAG_WORD
             } else {
@@ -312,7 +317,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Int2Double => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fcvt_from_sint(types::F64, v),
                 LIT_TAG_DOUBLE,
@@ -320,7 +325,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Double2Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_double(builder, args[0]);
+            let v = unbox_double(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fcvt_to_sint_sat(types::I64, v),
                 LIT_TAG_INT,
@@ -328,7 +333,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Int2Float => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fcvt_from_sint(types::F32, v),
                 LIT_TAG_FLOAT,
@@ -336,7 +341,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Float2Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_float(builder, args[0]);
+            let v = unbox_float(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fcvt_to_sint_sat(types::I64, v),
                 LIT_TAG_INT,
@@ -344,7 +349,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Double2Float => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_double(builder, args[0]);
+            let v = unbox_double(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fdemote(types::F32, v),
                 LIT_TAG_FLOAT,
@@ -352,7 +357,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Float2Double => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_float(builder, args[0]);
+            let v = unbox_float(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fpromote(types::F64, v),
                 LIT_TAG_DOUBLE,
@@ -362,7 +367,7 @@ pub fn emit_primop(
         // Narrowing
         PrimOpKind::Narrow8Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let narrow = builder.ins().ireduce(types::I8, v);
             Ok(SsaVal::Raw(
                 builder.ins().sextend(types::I64, narrow),
@@ -371,7 +376,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow16Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let narrow = builder.ins().ireduce(types::I16, v);
             Ok(SsaVal::Raw(
                 builder.ins().sextend(types::I64, narrow),
@@ -380,7 +385,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow32Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let narrow = builder.ins().ireduce(types::I32, v);
             Ok(SsaVal::Raw(
                 builder.ins().sextend(types::I64, narrow),
@@ -389,7 +394,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow8Word => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let narrow = builder.ins().ireduce(types::I8, v);
             Ok(SsaVal::Raw(
                 builder.ins().uextend(types::I64, narrow),
@@ -398,7 +403,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow16Word => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let narrow = builder.ins().ireduce(types::I16, v);
             Ok(SsaVal::Raw(
                 builder.ins().uextend(types::I64, narrow),
@@ -407,7 +412,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow32Word => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let narrow = builder.ins().ireduce(types::I32, v);
             Ok(SsaVal::Raw(
                 builder.ins().uextend(types::I64, narrow),
@@ -426,12 +431,12 @@ pub fn emit_primop(
         }
         PrimOpKind::DoubleNegate => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_double(builder, args[0]);
+            let a = unbox_double(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(builder.ins().fneg(a), LIT_TAG_DOUBLE))
         }
         PrimOpKind::FloatNegate => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_float(builder, args[0]);
+            let a = unbox_float(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(builder.ins().fneg(a), LIT_TAG_FLOAT))
         }
 
@@ -445,8 +450,8 @@ pub fn emit_primop(
 
         PrimOpKind::IndexCharOffAddr => {
             check_arity(op, 2, args.len())?;
-            let addr = unbox_addr(builder, args[0]);
-            let idx = unbox_int(builder, args[1]);
+            let addr = unbox_addr(pipeline, builder, args[0]);
+            let idx = unbox_int(pipeline, builder, args[1]);
             let effective = builder.ins().iadd(addr, idx);
             let byte_val = builder.ins().load(types::I8, MemFlags::new(), effective, 0);
             let char_val = builder.ins().uextend(types::I64, byte_val);
@@ -455,64 +460,65 @@ pub fn emit_primop(
 
         PrimOpKind::PlusAddr => {
             check_arity(op, 2, args.len())?;
-            let addr = unbox_addr(builder, args[0]);
-            let offset = unbox_int(builder, args[1]);
+            let addr = unbox_addr(pipeline, builder, args[0]);
+            let offset = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(addr, offset), LIT_TAG_ADDR))
         }
 
         // ---------------------------------------------------------------
-        // Int64/Word64/Word8 — on 64-bit, these are just Int#/Word# with
+        // Int64/Word64/Word8 \u2014 on 64-bit, these are just Int#/Word# with
         // different tags. GHC treats them identically at runtime.
         // ---------------------------------------------------------------
 
         // Int64 arithmetic
         PrimOpKind::Int64Add => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_INT))
         }
         PrimOpKind::Int64Sub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_INT))
         }
         PrimOpKind::Int64Mul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_INT))
         }
         PrimOpKind::Int64Negate => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(builder.ins().ineg(a), LIT_TAG_INT))
         }
         PrimOpKind::Int64Shl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().ishl(a, b), LIT_TAG_INT))
         }
         PrimOpKind::Int64Shra => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().sshr(a, b), LIT_TAG_INT))
         }
 
         // Int64 comparison
         PrimOpKind::Int64Lt => {
-            emit_int_compare(builder, op, IntCC::SignedLessThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::SignedLessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::Int64Le => {
-            emit_int_compare(builder, op, IntCC::SignedLessThanOrEqual, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::SignedLessThanOrEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::Int64Gt => {
-            emit_int_compare(builder, op, IntCC::SignedGreaterThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::SignedGreaterThan, args, LIT_TAG_INT)
         }
         PrimOpKind::Int64Ge => emit_int_compare(
+            pipeline,
             builder,
             op,
             IntCC::SignedGreaterThanOrEqual,
@@ -523,44 +529,44 @@ pub fn emit_primop(
         // Word64 arithmetic/bitwise
         PrimOpKind::Word64And => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().band(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::Word64Shl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().ishl(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::Word64Or => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().bor(a, b), LIT_TAG_WORD))
         }
 
         // Conversions between sized int/word types (no-ops on 64-bit)
         PrimOpKind::Word64ToInt64 | PrimOpKind::Int64ToInt | PrimOpKind::Int64ToWord64 => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_INT))
         }
         PrimOpKind::IntToInt64 => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_INT))
         }
         PrimOpKind::Word8ToWord => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_WORD))
         }
         PrimOpKind::WordToWord8 => {
             // wordToWord8# :: Word# -> Word8#
             // Narrow to 8 bits
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let mask = builder.ins().iconst(types::I64, 0xFF);
             let narrow = builder.ins().band(v, mask);
             Ok(SsaVal::Raw(narrow, LIT_TAG_WORD))
@@ -569,15 +575,15 @@ pub fn emit_primop(
         // Word8 arithmetic/comparison
         PrimOpKind::Word8Add => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             let sum = builder.ins().iadd(a, b);
             Ok(SsaVal::Raw(builder.ins().band_imm(sum, 0xFF), LIT_TAG_WORD))
         }
         PrimOpKind::Word8Sub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             let diff = builder.ins().isub(a, b);
             Ok(SsaVal::Raw(
                 builder.ins().band_imm(diff, 0xFF),
@@ -585,9 +591,10 @@ pub fn emit_primop(
             ))
         }
         PrimOpKind::Word8Lt => {
-            emit_int_compare(builder, op, IntCC::UnsignedLessThan, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, op, IntCC::UnsignedLessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::Word8Le => emit_int_compare(
+            pipeline,
             builder,
             op,
             IntCC::UnsignedLessThanOrEqual,
@@ -595,6 +602,7 @@ pub fn emit_primop(
             LIT_TAG_INT,
         ),
         PrimOpKind::Word8Ge => emit_int_compare(
+            pipeline,
             builder,
             op,
             IntCC::UnsignedGreaterThanOrEqual,
@@ -610,14 +618,14 @@ pub fn emit_primop(
         // We emit just the value or carry depending on which variant.
         PrimOpKind::AddIntCVal => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_INT))
         }
         PrimOpKind::AddIntCCarry => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             let sum = builder.ins().iadd(a, b);
             // Signed overflow: (a > 0 && b > 0 && sum < 0) || (a < 0 && b < 0 && sum >= 0)
             // Simplified: overflow if sign(a) == sign(b) && sign(sum) != sign(a)
@@ -634,14 +642,14 @@ pub fn emit_primop(
         // subWordC# :: Word# -> Word# -> (# Word#, Int# #)
         PrimOpKind::SubWordCVal => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::SubWordCCarry => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             // Borrow if a < b (unsigned)
             let borrow = builder.ins().icmp(IntCC::UnsignedLessThan, a, b);
             Ok(SsaVal::Raw(
@@ -653,14 +661,14 @@ pub fn emit_primop(
         // addWordC# :: Word# -> Word# -> (# Word#, Int# #)
         PrimOpKind::AddWordCVal => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::AddWordCCarry => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             let sum = builder.ins().iadd(a, b);
             // Carry if sum < a (unsigned)
             let carry = builder.ins().icmp(IntCC::UnsignedLessThan, sum, a);
@@ -674,20 +682,20 @@ pub fn emit_primop(
         // Signed widening multiply: (hi, lo, overflow)
         PrimOpKind::TimesInt2Hi => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().smulhi(a, b), LIT_TAG_INT))
         }
         PrimOpKind::TimesInt2Lo => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_INT))
         }
         PrimOpKind::TimesInt2Overflow => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             // Overflow if smulhi(a,b) != (imul(a,b) >>s 63)
             // i.e., the high word differs from sign-extending the low word
             let hi = builder.ins().smulhi(a, b);
@@ -704,40 +712,40 @@ pub fn emit_primop(
         // High and low words of 128-bit multiply
         PrimOpKind::TimesWord2Hi => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().umulhi(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::TimesWord2Lo => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_WORD))
         }
 
         // quotRemWord# :: Word# -> Word# -> (# Word#, Word# #)
         PrimOpKind::QuotRemWordVal => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().udiv(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::QuotRemWordRem => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(builder, args[0]);
-            let b = unbox_int(builder, args[1]);
+            let a = unbox_int(pipeline, builder, args[0]);
+            let b = unbox_int(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().urem(a, b), LIT_TAG_WORD))
         }
 
         // ---------------------------------------------------------------
-        // ByteArray# primops — mutable byte arrays for Data.Text etc.
+        // ByteArray# primops \u2014 mutable byte arrays for Data.Text etc.
         // ByteArray is stored as a Lit with LIT_TAG_BYTEARRAY, value = ptr
         // to malloc'd buffer: [u64 length][u8 bytes...]
         // ---------------------------------------------------------------
         PrimOpKind::NewByteArray => {
             // newByteArray# :: Int# -> State# s -> (# State# s, MutableByteArray# s #)
             // State# token may or may not be passed (1 or 2 args)
-            let size = unbox_int(builder, args[0]);
+            let size = unbox_int(pipeline, builder, args[0]);
             let ba_ptr = emit_runtime_call(
                 pipeline,
                 builder,
@@ -752,13 +760,13 @@ pub fn emit_primop(
 
         PrimOpKind::UnsafeFreezeByteArray => {
             // unsafeFreezeByteArray# :: MutableByteArray# s -> State# s -> (# State# s, ByteArray# #)
-            // Identity — mutable and immutable have the same representation
+            // Identity \u2014 mutable and immutable have the same representation
             Ok(args[0])
         }
 
         PrimOpKind::SizeofByteArray | PrimOpKind::SizeofMutableByteArray => {
             // sizeofByteArray# :: ByteArray# -> Int#
-            let ba_ptr = unbox_bytearray(builder, args[0]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
             // Read u64 length from offset 0
             let len = builder.ins().load(types::I64, MemFlags::new(), ba_ptr, 0);
             Ok(SsaVal::Raw(len, LIT_TAG_INT))
@@ -766,8 +774,8 @@ pub fn emit_primop(
 
         PrimOpKind::ReadWord8Array | PrimOpKind::IndexWord8Array => {
             // readWord8Array# :: MutableByteArray# s -> Int# -> State# s -> (# State# s, Word# #)
-            let ba_ptr = unbox_bytearray(builder, args[0]);
-            let idx = unbox_int(builder, args[1]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
+            let idx = unbox_int(pipeline, builder, args[1]);
             // Data starts at offset 8
             let base = builder.ins().iadd_imm(ba_ptr, 8);
             let effective = builder.ins().iadd(base, idx);
@@ -778,9 +786,9 @@ pub fn emit_primop(
 
         PrimOpKind::WriteWord8Array => {
             // writeWord8Array# :: MutableByteArray# s -> Int# -> Word# -> State# s -> State# s
-            let ba_ptr = unbox_bytearray(builder, args[0]);
-            let idx = unbox_int(builder, args[1]);
-            let val = unbox_int(builder, args[2]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
+            let idx = unbox_int(pipeline, builder, args[1]);
+            let val = unbox_int(pipeline, builder, args[2]);
             let base = builder.ins().iadd_imm(ba_ptr, 8);
             let effective = builder.ins().iadd(base, idx);
             let byte = builder.ins().ireduce(types::I8, val);
@@ -794,8 +802,8 @@ pub fn emit_primop(
 
         PrimOpKind::IndexWordArray | PrimOpKind::ReadWordArray => {
             // indexWordArray# :: ByteArray# -> Int# -> Word#
-            let ba_ptr = unbox_bytearray(builder, args[0]);
-            let idx = unbox_int(builder, args[1]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
+            let idx = unbox_int(pipeline, builder, args[1]);
             let base = builder.ins().iadd_imm(ba_ptr, 8);
             // Word-sized (8 bytes) indexing
             let byte_offset = builder.ins().imul_imm(idx, 8);
@@ -808,9 +816,9 @@ pub fn emit_primop(
 
         PrimOpKind::WriteWordArray => {
             // writeWordArray# :: MutableByteArray# s -> Int# -> Word# -> State# s -> State# s
-            let ba_ptr = unbox_bytearray(builder, args[0]);
-            let idx = unbox_int(builder, args[1]);
-            let val = unbox_int(builder, args[2]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
+            let idx = unbox_int(pipeline, builder, args[1]);
+            let val = unbox_int(pipeline, builder, args[2]);
             let base = builder.ins().iadd_imm(ba_ptr, 8);
             let byte_offset = builder.ins().imul_imm(idx, 8);
             let effective = builder.ins().iadd(base, byte_offset);
@@ -823,10 +831,10 @@ pub fn emit_primop(
 
         PrimOpKind::CopyAddrToByteArray => {
             // copyAddrToByteArray# :: Addr# -> MutableByteArray# s -> Int# -> Int# -> State# s -> State# s
-            let src = unbox_addr(builder, args[0]);
-            let dest_ba = unbox_bytearray(builder, args[1]);
-            let dest_off = unbox_int(builder, args[2]);
-            let len = unbox_int(builder, args[3]);
+            let src = unbox_addr(pipeline, builder, args[0]);
+            let dest_ba = unbox_bytearray(pipeline, builder, args[1]);
+            let dest_off = unbox_int(pipeline, builder, args[2]);
+            let len = unbox_int(pipeline, builder, args[3]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -848,10 +856,10 @@ pub fn emit_primop(
 
         PrimOpKind::SetByteArray => {
             // setByteArray# :: MutableByteArray# s -> Int# -> Int# -> Int# -> State# s -> State# s
-            let ba = unbox_bytearray(builder, args[0]);
-            let off = unbox_int(builder, args[1]);
-            let len = unbox_int(builder, args[2]);
-            let val = unbox_int(builder, args[3]);
+            let ba = unbox_bytearray(pipeline, builder, args[0]);
+            let off = unbox_int(pipeline, builder, args[1]);
+            let len = unbox_int(pipeline, builder, args[2]);
+            let val = unbox_int(pipeline, builder, args[3]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -873,8 +881,8 @@ pub fn emit_primop(
 
         PrimOpKind::ShrinkMutableByteArray => {
             // shrinkMutableByteArray# :: MutableByteArray# s -> Int# -> State# s -> State# s
-            let ba = unbox_bytearray(builder, args[0]);
-            let new_size = unbox_int(builder, args[1]);
+            let ba = unbox_bytearray(pipeline, builder, args[0]);
+            let new_size = unbox_int(pipeline, builder, args[1]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -892,8 +900,8 @@ pub fn emit_primop(
             // resizeMutableByteArray# :: MutableByteArray# s -> Int# -> State# s
             //   -> (# State# s, MutableByteArray# s #)
             // Returns the (possibly reallocated) byte array pointer.
-            let ba = unbox_bytearray(builder, args[0]);
-            let new_size = unbox_int(builder, args[1]);
+            let ba = unbox_bytearray(pipeline, builder, args[0]);
+            let new_size = unbox_int(pipeline, builder, args[1]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -908,11 +916,11 @@ pub fn emit_primop(
         PrimOpKind::CopyByteArray => {
             // copyByteArray# :: ByteArray# -> Int# -> MutableByteArray# s -> Int# -> Int# -> State# s -> State# s
             // src, src_off, dest, dest_off, len
-            let src = unbox_bytearray(builder, args[0]);
-            let src_off = unbox_int(builder, args[1]);
-            let dest = unbox_bytearray(builder, args[2]);
-            let dest_off = unbox_int(builder, args[3]);
-            let len = unbox_int(builder, args[4]);
+            let src = unbox_bytearray(pipeline, builder, args[0]);
+            let src_off = unbox_int(pipeline, builder, args[1]);
+            let dest = unbox_bytearray(pipeline, builder, args[2]);
+            let dest_off = unbox_int(pipeline, builder, args[3]);
+            let len = unbox_int(pipeline, builder, args[4]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -933,12 +941,12 @@ pub fn emit_primop(
             ))
         }
         PrimOpKind::CopyMutableByteArray => {
-            // copyMutableByteArray# — same args as CopyByteArray
-            let src = unbox_bytearray(builder, args[0]);
-            let src_off = unbox_int(builder, args[1]);
-            let dest = unbox_bytearray(builder, args[2]);
-            let dest_off = unbox_int(builder, args[3]);
-            let len = unbox_int(builder, args[4]);
+            // copyMutableByteArray# \u2014 same args as CopyByteArray
+            let src = unbox_bytearray(pipeline, builder, args[0]);
+            let src_off = unbox_int(pipeline, builder, args[1]);
+            let dest = unbox_bytearray(pipeline, builder, args[2]);
+            let dest_off = unbox_int(pipeline, builder, args[3]);
+            let len = unbox_int(pipeline, builder, args[4]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -963,11 +971,11 @@ pub fn emit_primop(
             if args.len() != 5 {
                 return Err(EmitError::InvalidArity(PrimOpKind::CompareByteArrays, 5, args.len()));
             }
-            let a = unbox_bytearray(builder, args[0]);
-            let a_off = unbox_int(builder, args[1]);
-            let b = unbox_bytearray(builder, args[2]);
-            let b_off = unbox_int(builder, args[3]);
-            let len = unbox_int(builder, args[4]);
+            let a = unbox_bytearray(pipeline, builder, args[0]);
+            let a_off = unbox_int(pipeline, builder, args[1]);
+            let b = unbox_bytearray(pipeline, builder, args[2]);
+            let b_off = unbox_int(pipeline, builder, args[3]);
+            let len = unbox_int(pipeline, builder, args[4]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -986,8 +994,8 @@ pub fn emit_primop(
         }
         PrimOpKind::IndexWord8OffAddr => {
             // indexWord8OffAddr# :: Addr# -> Int# -> Word#
-            let addr = unbox_addr(builder, args[0]);
-            let off = unbox_int(builder, args[1]);
+            let addr = unbox_addr(pipeline, builder, args[0]);
+            let off = unbox_int(pipeline, builder, args[1]);
             let ptr = builder.ins().iadd(addr, off);
             let byte = builder.ins().load(types::I8, MemFlags::trusted(), ptr, 0);
             let word = builder.ins().uextend(types::I64, byte);
@@ -996,14 +1004,14 @@ pub fn emit_primop(
         PrimOpKind::Clz8 => {
             // clz8# :: Word# -> Word#
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(builder, args[0]);
+            let v = unbox_int(pipeline, builder, args[0]);
             let narrow = builder.ins().ireduce(types::I8, v);
             let clz8 = builder.ins().clz(narrow);
             let result = builder.ins().uextend(types::I64, clz8);
             Ok(SsaVal::Raw(result, LIT_TAG_WORD))
         }
         PrimOpKind::Raise => {
-            // raise# :: a -> b — always errors
+            // raise# :: a -> b \u2014 always errors
             let kind = builder.ins().iconst(types::I64, 2); // 2 = UserError
             let _ = emit_runtime_call(
                 pipeline,
@@ -1020,7 +1028,7 @@ pub fn emit_primop(
         }
         PrimOpKind::FfiStrlen => {
             // strlen :: Addr# -> Int#
-            let addr = unbox_addr(builder, args[0]);
+            let addr = unbox_addr(pipeline, builder, args[0]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1033,11 +1041,11 @@ pub fn emit_primop(
         }
         PrimOpKind::FfiTextMeasureOff => {
             // _hs_text_measure_off :: ByteArray# -> CSize -> CSize -> CSize -> CSsize
-            let ba = unbox_bytearray(builder, args[0]);
+            let ba = unbox_bytearray(pipeline, builder, args[0]);
             let data_ptr = builder.ins().iadd_imm(ba, 8); // skip length prefix
-            let off = unbox_int(builder, args[1]);
-            let len = unbox_int(builder, args[2]);
-            let cnt = unbox_int(builder, args[3]);
+            let off = unbox_int(pipeline, builder, args[1]);
+            let len = unbox_int(pipeline, builder, args[2]);
+            let cnt = unbox_int(pipeline, builder, args[3]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1055,11 +1063,11 @@ pub fn emit_primop(
         }
         PrimOpKind::FfiTextMemchr => {
             // _hs_text_memchr :: ByteArray# -> CSize -> CSize -> Word8 -> CSsize
-            let ba = unbox_bytearray(builder, args[0]);
+            let ba = unbox_bytearray(pipeline, builder, args[0]);
             let data_ptr = builder.ins().iadd_imm(ba, 8); // skip length prefix
-            let off = unbox_int(builder, args[1]);
-            let len = unbox_int(builder, args[2]);
-            let needle = unbox_int(builder, args[3]);
+            let off = unbox_int(pipeline, builder, args[1]);
+            let len = unbox_int(pipeline, builder, args[2]);
+            let needle = unbox_int(pipeline, builder, args[3]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1077,12 +1085,12 @@ pub fn emit_primop(
         }
         PrimOpKind::FfiTextReverse => {
             // _hs_text_reverse :: MutableByteArray# -> ByteArray# -> CSize -> CSize -> ()
-            let dest_ba = unbox_bytearray(builder, args[0]);
+            let dest_ba = unbox_bytearray(pipeline, builder, args[0]);
             let dest_ptr = builder.ins().iadd_imm(dest_ba, 8); // skip length prefix
-            let src_ba = unbox_bytearray(builder, args[1]);
+            let src_ba = unbox_bytearray(pipeline, builder, args[1]);
             let src_ptr = builder.ins().iadd_imm(src_ba, 8); // skip length prefix
-            let off = unbox_int(builder, args[2]);
-            let len = unbox_int(builder, args[3]);
+            let off = unbox_int(pipeline, builder, args[2]);
+            let len = unbox_int(pipeline, builder, args[3]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1105,43 +1113,43 @@ pub fn emit_primop(
         // Float arithmetic + comparison
         PrimOpKind::FloatAdd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_float(builder, args[0]);
-            let b = unbox_float(builder, args[1]);
+            let a = unbox_float(pipeline, builder, args[0]);
+            let b = unbox_float(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().fadd(a, b), LIT_TAG_FLOAT))
         }
         PrimOpKind::FloatSub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_float(builder, args[0]);
-            let b = unbox_float(builder, args[1]);
+            let a = unbox_float(pipeline, builder, args[0]);
+            let b = unbox_float(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().fsub(a, b), LIT_TAG_FLOAT))
         }
         PrimOpKind::FloatMul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_float(builder, args[0]);
-            let b = unbox_float(builder, args[1]);
+            let a = unbox_float(pipeline, builder, args[0]);
+            let b = unbox_float(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().fmul(a, b), LIT_TAG_FLOAT))
         }
         PrimOpKind::FloatDiv => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_float(builder, args[0]);
-            let b = unbox_float(builder, args[1]);
+            let a = unbox_float(pipeline, builder, args[0]);
+            let b = unbox_float(pipeline, builder, args[1]);
             Ok(SsaVal::Raw(builder.ins().fdiv(a, b), LIT_TAG_FLOAT))
         }
-        PrimOpKind::FloatEq => emit_float_compare(builder, op, FloatCC::Equal, args, LIT_TAG_INT),
+        PrimOpKind::FloatEq => emit_float_compare(pipeline, builder, op, FloatCC::Equal, args, LIT_TAG_INT),
         PrimOpKind::FloatNe => {
-            emit_float_compare(builder, op, FloatCC::NotEqual, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::NotEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::FloatLt => {
-            emit_float_compare(builder, op, FloatCC::LessThan, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::LessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::FloatLe => {
-            emit_float_compare(builder, op, FloatCC::LessThanOrEqual, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::LessThanOrEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::FloatGt => {
-            emit_float_compare(builder, op, FloatCC::GreaterThan, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::GreaterThan, args, LIT_TAG_INT)
         }
         PrimOpKind::FloatGe => {
-            emit_float_compare(builder, op, FloatCC::GreaterThanOrEqual, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, op, FloatCC::GreaterThanOrEqual, args, LIT_TAG_INT)
         }
 
         PrimOpKind::TagToEnum | PrimOpKind::SeqOp => {
@@ -1149,13 +1157,13 @@ pub fn emit_primop(
         }
 
         // ---------------------------------------------------------------
-        // SmallArray# / Array# primops — boxed pointer arrays
+        // SmallArray# / Array# primops \u2014 boxed pointer arrays
         // Layout: [u64 length][ptr0][ptr1]...[ptrN-1]
         // Stored in Lit with LIT_TAG_SMALLARRAY (8) or LIT_TAG_ARRAY (9)
         // ---------------------------------------------------------------
         PrimOpKind::NewSmallArray | PrimOpKind::NewArray => {
             // newSmallArray# :: Int# -> a -> State# -> (# State#, SmallMutableArray# s a #)
-            let size = unbox_int(builder, args[0]);
+            let size = unbox_int(pipeline, builder, args[0]);
             let init_ptr = args[1].value();
             let arr_ptr = emit_runtime_call(
                 pipeline,
@@ -1185,8 +1193,8 @@ pub fn emit_primop(
                     op, args.len(), args
                 )));
             }
-            let arr_ptr = unbox_bytearray(builder, args[0]);
-            let idx = unbox_int(builder, args[1]);
+            let arr_ptr = unbox_bytearray(pipeline, builder, args[0]);
+            let idx = unbox_int(pipeline, builder, args[1]);
             let base = builder.ins().iadd_imm(arr_ptr, 8);
             let byte_offset = builder.ins().imul_imm(idx, 8);
             let effective = builder.ins().iadd(base, byte_offset);
@@ -1197,8 +1205,8 @@ pub fn emit_primop(
 
         PrimOpKind::WriteSmallArray | PrimOpKind::WriteArray => {
             // writeSmallArray# :: SmallMutableArray# s a -> Int# -> a -> State# -> State#
-            let arr_ptr = unbox_bytearray(builder, args[0]);
-            let idx = unbox_int(builder, args[1]);
+            let arr_ptr = unbox_bytearray(pipeline, builder, args[0]);
+            let idx = unbox_int(pipeline, builder, args[1]);
             let val = args[2].value();
             let base = builder.ins().iadd_imm(arr_ptr, 8);
             let byte_offset = builder.ins().imul_imm(idx, 8);
@@ -1215,7 +1223,7 @@ pub fn emit_primop(
         | PrimOpKind::SizeofArray
         | PrimOpKind::SizeofMutableArray => {
             // sizeofSmallArray# :: SmallArray# a -> Int#
-            let arr_ptr = unbox_bytearray(builder, args[0]);
+            let arr_ptr = unbox_bytearray(pipeline, builder, args[0]);
             let len = builder.ins().load(types::I64, MemFlags::new(), arr_ptr, 0);
             Ok(SsaVal::Raw(len, LIT_TAG_INT))
         }
@@ -1224,7 +1232,7 @@ pub fn emit_primop(
         | PrimOpKind::UnsafeThawSmallArray
         | PrimOpKind::UnsafeFreezeArray
         | PrimOpKind::UnsafeThawArray => {
-            // Identity — mutable and immutable have the same representation
+            // Identity \u2014 mutable and immutable have the same representation
             Ok(args[0])
         }
 
@@ -1233,11 +1241,11 @@ pub fn emit_primop(
         | PrimOpKind::CopyArray
         | PrimOpKind::CopyMutableArray => {
             // copySmallArray# :: src -> src_off -> dest -> dest_off -> len -> State# -> State#
-            let src = unbox_bytearray(builder, args[0]);
-            let src_off = unbox_int(builder, args[1]);
-            let dest = unbox_bytearray(builder, args[2]);
-            let dest_off = unbox_int(builder, args[3]);
-            let len = unbox_int(builder, args[4]);
+            let src = unbox_bytearray(pipeline, builder, args[0]);
+            let src_off = unbox_int(pipeline, builder, args[1]);
+            let dest = unbox_bytearray(pipeline, builder, args[2]);
+            let dest_off = unbox_int(pipeline, builder, args[3]);
+            let len = unbox_int(pipeline, builder, args[4]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1260,9 +1268,9 @@ pub fn emit_primop(
 
         PrimOpKind::CloneSmallArray | PrimOpKind::CloneSmallMutableArray => {
             // cloneSmallArray# :: SmallArray# a -> Int# -> Int# -> SmallArray# a
-            let arr = unbox_bytearray(builder, args[0]);
-            let off = unbox_int(builder, args[1]);
-            let len = unbox_int(builder, args[2]);
+            let arr = unbox_bytearray(pipeline, builder, args[0]);
+            let off = unbox_int(pipeline, builder, args[1]);
+            let len = unbox_int(pipeline, builder, args[2]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1286,9 +1294,9 @@ pub fn emit_primop(
         }
 
         PrimOpKind::CloneArray | PrimOpKind::CloneMutableArray => {
-            let arr = unbox_bytearray(builder, args[0]);
-            let off = unbox_int(builder, args[1]);
-            let len = unbox_int(builder, args[2]);
+            let arr = unbox_bytearray(pipeline, builder, args[0]);
+            let off = unbox_int(pipeline, builder, args[1]);
+            let len = unbox_int(pipeline, builder, args[2]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1307,8 +1315,8 @@ pub fn emit_primop(
         }
 
         PrimOpKind::ShrinkSmallMutableArray => {
-            let arr = unbox_bytearray(builder, args[0]);
-            let new_len = unbox_int(builder, args[1]);
+            let arr = unbox_bytearray(pipeline, builder, args[0]);
+            let new_len = unbox_int(pipeline, builder, args[1]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1328,8 +1336,8 @@ pub fn emit_primop(
             //   -> (# State# s, Int#, a #)
             // Returns (0#, old) if CAS succeeded, (1#, old) if failed.
             // We simplify: return the old value (caller checks).
-            let arr = unbox_bytearray(builder, args[0]);
-            let idx = unbox_int(builder, args[1]);
+            let arr = unbox_bytearray(pipeline, builder, args[0]);
+            let idx = unbox_int(pipeline, builder, args[1]);
             let expected = args[2].value();
             let new_val = args[3].value();
             let old = emit_runtime_call(
@@ -1351,52 +1359,52 @@ pub fn emit_primop(
         }
 
         // ---------------------------------------------------------------
-        // Bit operations — popCount, ctz
+        // Bit operations \u2014 popCount, ctz
         // ---------------------------------------------------------------
         PrimOpKind::PopCnt | PrimOpKind::PopCnt64 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(builder.ins().popcnt(a), LIT_TAG_WORD))
         }
         PrimOpKind::PopCnt8 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             let masked = builder.ins().band_imm(a, 0xFF);
             Ok(SsaVal::Raw(builder.ins().popcnt(masked), LIT_TAG_WORD))
         }
         PrimOpKind::PopCnt16 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             let masked = builder.ins().band_imm(a, 0xFFFF);
             Ok(SsaVal::Raw(builder.ins().popcnt(masked), LIT_TAG_WORD))
         }
         PrimOpKind::PopCnt32 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             let masked = builder.ins().band_imm(a, 0xFFFF_FFFF);
             Ok(SsaVal::Raw(builder.ins().popcnt(masked), LIT_TAG_WORD))
         }
         PrimOpKind::Ctz | PrimOpKind::Ctz64 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             Ok(SsaVal::Raw(builder.ins().ctz(a), LIT_TAG_WORD))
         }
         PrimOpKind::Ctz8 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             // Set bit 8 so ctz stops there if all lower 8 bits are zero
             let with_sentinel = builder.ins().bor_imm(a, 0x100);
             Ok(SsaVal::Raw(builder.ins().ctz(with_sentinel), LIT_TAG_WORD))
         }
         PrimOpKind::Ctz16 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             let with_sentinel = builder.ins().bor_imm(a, 0x10000);
             Ok(SsaVal::Raw(builder.ins().ctz(with_sentinel), LIT_TAG_WORD))
         }
         PrimOpKind::Ctz32 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(builder, args[0]);
+            let a = unbox_int(pipeline, builder, args[0]);
             let with_sentinel = builder.ins().bor_imm(a, 0x1_0000_0000);
             Ok(SsaVal::Raw(builder.ins().ctz(with_sentinel), LIT_TAG_WORD))
         }
@@ -1414,6 +1422,7 @@ fn check_arity(op: &PrimOpKind, expected: usize, got: usize) -> Result<(), EmitE
 }
 
 fn emit_int_compare(
+    pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
     op: &PrimOpKind,
     cc: IntCC,
@@ -1421,13 +1430,14 @@ fn emit_int_compare(
     tag: i64,
 ) -> Result<SsaVal, EmitError> {
     check_arity(op, 2, args.len())?;
-    let a = unbox_int(builder, args[0]);
-    let b = unbox_int(builder, args[1]);
+    let a = unbox_int(pipeline, builder, args[0]);
+    let b = unbox_int(pipeline, builder, args[1]);
     let cmp = builder.ins().icmp(cc, a, b);
     Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp), tag))
 }
 
 fn emit_float_compare(
+    pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
     op: &PrimOpKind,
     cc: FloatCC,
@@ -1435,24 +1445,102 @@ fn emit_float_compare(
     tag: i64,
 ) -> Result<SsaVal, EmitError> {
     check_arity(op, 2, args.len())?;
-    let a = unbox_double(builder, args[0]);
-    let b = unbox_double(builder, args[1]);
+    let a = unbox_double(pipeline, builder, args[0]);
+    let b = unbox_double(pipeline, builder, args[1]);
     let cmp = builder.ins().fcmp(cc, a, b);
     Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp), tag))
 }
 
-/// Unbox an Addr# value.
-fn unbox_addr(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
+/// Unbox an Addr# value recursively.
+fn unbox_addr(pipeline: &mut CodegenPipeline, builder: &mut FunctionBuilder, val: SsaVal) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
+            let start_block = builder.create_block();
+            let next_block = builder.create_block();
+            builder.append_block_param(start_block, types::I64);
+            builder.append_block_param(next_block, types::I64);
+            
+            builder.ins().jump(start_block, &[v]);
+            
+            builder.switch_to_block(start_block);
+            let curr_v = builder.block_params(start_block)[0];
+            let tag = builder.ins().load(types::I8, MemFlags::trusted(), curr_v, 0);
+            let is_con = builder.ins().icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
+            
+            let con_block = builder.create_block();
+            builder.ins().brif(is_con, con_block, &[], next_block, &[curr_v]);
+            
+            builder.switch_to_block(con_block);
+            builder.seal_block(con_block);
+            let field0 = builder.ins().load(types::I64, MemFlags::trusted(), curr_v, layout::CON_FIELDS_OFFSET as i32);
+            builder.ins().jump(start_block, &[field0]);
+            
+            builder.switch_to_block(next_block);
+            builder.seal_block(start_block);
+            builder.seal_block(next_block);
+            let v_final = builder.block_params(next_block)[0];
+            
             let raw_val = builder
                 .ins()
-                .load(types::I64, MemFlags::trusted(), v, LIT_VALUE_OFFSET);
+                .load(types::I64, MemFlags::trusted(), v_final, LIT_VALUE_OFFSET);
             let lit_tag = builder
                 .ins()
-                .load(types::I8, MemFlags::trusted(), v, LIT_TAG_OFFSET);
+                .load(types::I8, MemFlags::trusted(), v_final, LIT_TAG_OFFSET);
             let lit_tag_ext = builder.ins().uextend(types::I64, lit_tag);
+            
+            let is_string = builder
+                .ins()
+                .icmp_imm(IntCC::Equal, lit_tag_ext, LIT_TAG_STRING);
+            let is_ba = builder
+                .ins()
+                .icmp_imm(IntCC::Equal, lit_tag_ext, LIT_TAG_BYTEARRAY);
+            let needs_adj = builder.ins().bor(is_string, is_ba);
+            let adjusted = builder.ins().iadd_imm(raw_val, 8);
+            builder.ins().select(needs_adj, adjusted, raw_val)
+        }
+    }
+}
+
+/// Extract the raw ByteArray pointer from a Lit(BYTEARRAY) heap object recursively.
+fn unbox_bytearray(pipeline: &mut CodegenPipeline, builder: &mut FunctionBuilder, val: SsaVal) -> Value {
+    match val {
+        SsaVal::Raw(v, _) => v,
+        SsaVal::HeapPtr(v) => {
+            let start_block = builder.create_block();
+            let next_block = builder.create_block();
+            builder.append_block_param(start_block, types::I64);
+            builder.append_block_param(next_block, types::I64);
+            
+            builder.ins().jump(start_block, &[v]);
+            
+            builder.switch_to_block(start_block);
+            let curr_v = builder.block_params(start_block)[0];
+            let tag = builder.ins().load(types::I8, MemFlags::trusted(), curr_v, 0);
+            let is_con = builder.ins().icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
+            
+            let con_block = builder.create_block();
+            builder.ins().brif(is_con, con_block, &[], next_block, &[curr_v]);
+            
+            builder.switch_to_block(con_block);
+            builder.seal_block(con_block);
+            let field0 = builder.ins().load(types::I64, MemFlags::trusted(), curr_v, layout::CON_FIELDS_OFFSET as i32);
+            builder.ins().jump(start_block, &[field0]);
+            
+            builder.switch_to_block(next_block);
+            builder.seal_block(start_block);
+            builder.seal_block(next_block);
+            let v_final = builder.block_params(next_block)[0];
+            
+            let raw_val = builder
+                .ins()
+                .load(types::I64, MemFlags::trusted(), v_final, LIT_VALUE_OFFSET);
+            let lit_tag = builder
+                .ins()
+                .load(types::I8, MemFlags::trusted(), v_final, LIT_TAG_OFFSET);
+            let lit_tag_ext = builder.ins().uextend(types::I64, lit_tag);
+            
+            // ByteArray# should also adjust for LIT_TAG_STRING if passed one.
             let is_string = builder
                 .ins()
                 .icmp_imm(IntCC::Equal, lit_tag_ext, LIT_TAG_STRING);
@@ -1462,47 +1550,110 @@ fn unbox_addr(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
     }
 }
 
-/// Extract the raw ByteArray pointer from a Lit(BYTEARRAY) heap object.
-fn unbox_bytearray(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
+pub fn unbox_int(pipeline: &mut CodegenPipeline, builder: &mut FunctionBuilder, val: SsaVal) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
+            let start_block = builder.create_block();
+            let next_block = builder.create_block();
+            builder.append_block_param(start_block, types::I64);
+            builder.append_block_param(next_block, types::I64);
+            
+            builder.ins().jump(start_block, &[v]);
+            
+            builder.switch_to_block(start_block);
+            let curr_v = builder.block_params(start_block)[0];
+            let tag = builder.ins().load(types::I8, MemFlags::trusted(), curr_v, 0);
+            let is_con = builder.ins().icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
+            
+            let con_block = builder.create_block();
+            builder.ins().brif(is_con, con_block, &[], next_block, &[curr_v]);
+            
+            builder.switch_to_block(con_block);
+            builder.seal_block(con_block);
+            let field0 = builder.ins().load(types::I64, MemFlags::trusted(), curr_v, layout::CON_FIELDS_OFFSET as i32);
+            builder.ins().jump(start_block, &[field0]);
+            
+            builder.switch_to_block(next_block);
+            builder.seal_block(start_block);
+            builder.seal_block(next_block);
+            let v_final = builder.block_params(next_block)[0];
+            
             builder
                 .ins()
-                .load(types::I64, MemFlags::trusted(), v, LIT_VALUE_OFFSET)
+                .load(types::I64, MemFlags::trusted(), v_final, LIT_VALUE_OFFSET)
         }
     }
 }
 
-pub fn unbox_int(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
+pub fn unbox_double(pipeline: &mut CodegenPipeline, builder: &mut FunctionBuilder, val: SsaVal) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
+            let start_block = builder.create_block();
+            let next_block = builder.create_block();
+            builder.append_block_param(start_block, types::I64);
+            builder.append_block_param(next_block, types::I64);
+            
+            builder.ins().jump(start_block, &[v]);
+            
+            builder.switch_to_block(start_block);
+            let curr_v = builder.block_params(start_block)[0];
+            let tag = builder.ins().load(types::I8, MemFlags::trusted(), curr_v, 0);
+            let is_con = builder.ins().icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
+            
+            let con_block = builder.create_block();
+            builder.ins().brif(is_con, con_block, &[], next_block, &[curr_v]);
+            
+            builder.switch_to_block(con_block);
+            builder.seal_block(con_block);
+            let field0 = builder.ins().load(types::I64, MemFlags::trusted(), curr_v, layout::CON_FIELDS_OFFSET as i32);
+            builder.ins().jump(start_block, &[field0]);
+            
+            builder.switch_to_block(next_block);
+            builder.seal_block(start_block);
+            builder.seal_block(next_block);
+            let v_final = builder.block_params(next_block)[0];
+            
             builder
                 .ins()
-                .load(types::I64, MemFlags::trusted(), v, LIT_VALUE_OFFSET)
+                .load(types::F64, MemFlags::trusted(), v_final, LIT_VALUE_OFFSET)
         }
     }
 }
 
-pub fn unbox_double(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
+pub fn unbox_float(pipeline: &mut CodegenPipeline, builder: &mut FunctionBuilder, val: SsaVal) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
+            let start_block = builder.create_block();
+            let next_block = builder.create_block();
+            builder.append_block_param(start_block, types::I64);
+            builder.append_block_param(next_block, types::I64);
+            
+            builder.ins().jump(start_block, &[v]);
+            
+            builder.switch_to_block(start_block);
+            let curr_v = builder.block_params(start_block)[0];
+            let tag = builder.ins().load(types::I8, MemFlags::trusted(), curr_v, 0);
+            let is_con = builder.ins().icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
+            
+            let con_block = builder.create_block();
+            builder.ins().brif(is_con, con_block, &[], next_block, &[curr_v]);
+            
+            builder.switch_to_block(con_block);
+            builder.seal_block(con_block);
+            let field0 = builder.ins().load(types::I64, MemFlags::trusted(), curr_v, layout::CON_FIELDS_OFFSET as i32);
+            builder.ins().jump(start_block, &[field0]);
+            
+            builder.switch_to_block(next_block);
+            builder.seal_block(start_block);
+            builder.seal_block(next_block);
+            let v_final = builder.block_params(next_block)[0];
+            
             builder
                 .ins()
-                .load(types::F64, MemFlags::trusted(), v, LIT_VALUE_OFFSET)
-        }
-    }
-}
-
-pub fn unbox_float(builder: &mut FunctionBuilder, val: SsaVal) -> Value {
-    match val {
-        SsaVal::Raw(v, _) => v,
-        SsaVal::HeapPtr(v) => {
-            builder
-                .ins()
-                .load(types::F32, MemFlags::trusted(), v, LIT_VALUE_OFFSET)
+                .load(types::F32, MemFlags::trusted(), v_final, LIT_VALUE_OFFSET)
         }
     }
 }

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -426,6 +426,15 @@ pub extern "C" fn runtime_new_byte_array(size: i64) -> i64 {
 
 /// Copy `len` bytes from `src` (Addr#) to `dest_ba` (ByteArray ptr) at `dest_off`.
 pub extern "C" fn runtime_copy_addr_to_byte_array(src: i64, dest_ba: i64, dest_off: i64, len: i64) {
+    if (src as u64) < 0x1000 || (dest_ba as u64) < 0x1000 {
+        eprintln!("[BUG] runtime_copy_addr_to_byte_array: bad pointer src={:#x} dest_ba={:#x} dest_off={} len={}", src, dest_ba, dest_off, len);
+        std::process::abort();
+    }
+    let dest_size = unsafe { *(dest_ba as *const u64) } as usize;
+    if (dest_off as usize + len as usize) > dest_size {
+        eprintln!("[BUG] runtime_copy_addr_to_byte_array: out of bounds! size={} off={} len={}", dest_size, dest_off, len);
+        std::process::abort();
+    }
     let src_ptr = src as *const u8;
     let dest_ptr = unsafe { (dest_ba as *mut u8).add(8 + dest_off as usize) };
     unsafe {
@@ -435,6 +444,10 @@ pub extern "C" fn runtime_copy_addr_to_byte_array(src: i64, dest_ba: i64, dest_o
 
 /// Set `len` bytes in `ba` starting at `off` to `val`.
 pub extern "C" fn runtime_set_byte_array(ba: i64, off: i64, len: i64, val: i64) {
+    if (ba as u64) < 0x1000 {
+        eprintln!("[BUG] runtime_set_byte_array: bad pointer ba={:#x} off={} len={} val={}", ba, off, len, val);
+        std::process::abort();
+    }
     let ptr = unsafe { (ba as *mut u8).add(8 + off as usize) };
     unsafe {
         std::ptr::write_bytes(ptr, val as u8, len as usize);
@@ -492,6 +505,10 @@ pub extern "C" fn runtime_copy_byte_array(
     dest_off: i64,
     len: i64,
 ) {
+    if (src as u64) < 0x1000 || (dest as u64) < 0x1000 {
+        eprintln!("[BUG] runtime_copy_byte_array: bad pointer src={:#x} src_off={} dest={:#x} dest_off={} len={}", src, src_off, dest, dest_off, len);
+        std::process::abort();
+    }
     let src_ptr = unsafe { (src as *const u8).add(8 + src_off as usize) };
     let dest_ptr = unsafe { (dest as *mut u8).add(8 + dest_off as usize) };
     // Use copy (not copy_nonoverlapping) since src and dest may be the same array
@@ -601,6 +618,10 @@ pub extern "C" fn runtime_cas_boxed_array(arr: i64, idx: i64, expected: i64, new
 
 /// strlen: count bytes until null terminator.
 pub extern "C" fn runtime_strlen(addr: i64) -> i64 {
+    if (addr as u64) < 0x1000 {
+        eprintln!("[BUG] runtime_strlen: bad pointer addr={:#x}", addr);
+        std::process::abort();
+    }
     let ptr = addr as *const u8;
     let mut len = 0i64;
     unsafe {
@@ -654,6 +675,13 @@ pub extern "C" fn runtime_text_measure_off(addr: i64, off: i64, len: i64, cnt: i
 
 /// Find a byte in a buffer. Returns offset from start, or -1 if not found.
 pub extern "C" fn runtime_text_memchr(addr: i64, off: i64, len: i64, needle: i64) -> i64 {
+    if (addr as u64) < 0x1000 {
+        eprintln!("[BUG] runtime_text_memchr: bad pointer addr={:#x} off={} len={} needle={}", addr, off, len, needle);
+        std::process::abort();
+    }
+    if len <= 0 {
+        return -1;
+    }
     let ptr = (addr + off) as *const u8;
     let slice = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
     match slice.iter().position(|&b| b == needle as u8) {
@@ -666,6 +694,10 @@ pub extern "C" fn runtime_text_memchr(addr: i64, off: i64, len: i64, needle: i64
 ///
 /// Reads `len` bytes from `src + off`, writes reversed codepoints starting at `dst`.
 pub extern "C" fn runtime_text_reverse(dest: i64, src: i64, off: i64, len: i64) {
+    if (dest as u64) < 0x1000 || (src as u64) < 0x1000 {
+        eprintln!("[BUG] runtime_text_reverse: bad pointer dest={:#x} src={:#x} off={} len={}", dest, src, off, len);
+        std::process::abort();
+    }
     let src_ptr = (src + off) as *const u8;
     let src_slice = unsafe { std::slice::from_raw_parts(src_ptr, len as usize) };
     let dest_ptr = dest as *mut u8;

--- a/tidepool-codegen/src/nursery.rs
+++ b/tidepool-codegen/src/nursery.rs
@@ -30,7 +30,7 @@ impl Nursery {
     ///
     /// The returned VMContext is valid as long as this Nursery is alive
     /// and not moved.
-    pub fn make_vmctx(&mut self, gc_trigger: extern "C" fn(*mut VMContext)) -> VMContext {
+    pub fn make_vmctx(&mut self, gc_trigger: unsafe extern "C" fn(*mut VMContext)) -> VMContext {
         let start = self.buffer.as_mut_ptr();
         let end = unsafe { start.add(self.buffer.len()) };
         VMContext::new(start, end as *const u8, gc_trigger)

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -1737,7 +1737,7 @@ fn test_kv_keys_text_append() {
 
 /// T.splitOn on a Text key from KvKeys.
 #[test]
-#[ignore = "SIGILL in splitOn (wrapper fix resolved SIGSEGV, exposed deeper unsupported primop)"]
+#[ignore = "FIXED SIGSEGV via recursive unboxing, but now fails assertion (serialization of sliced Text results)"]
 fn test_kv_keys_text_split_on() {
     let (json, _) = run_mcp_effectful(&[
         r#"send (KvSet "a:b:c" "v")"#,


### PR DESCRIPTION
This PR addresses the SIGILL and memory faults found in Group A tests: `memchr`, `isPrefixOf`, `splitOn`, and `filter_array`.

## Changes Made:
- **Recursive Unboxing**: Implemented recursive loops in JIT unboxers (`unbox_int`, `unbox_addr`, `unbox_bytearray`, `unbox_float`, `unbox_double`) to properly handle deeply nested "box" constructors created by GHC (e.g., `Text (ByteArray (ByteArray# ...))`).
- **Translation Updates**: Reverted aggressive `stripBoxCon` from `Translate.hs` but kept it restricted to single-constructor product types (as done in Group C) within DataCon wrappers. This resolves "CASE TRAP" errors.
- **Robust Heap Layout Extraction**: Addressed the SIGSEGV related to missing offset tracking for string bounds and nested constructors.
- **Pointer Validation**: Embedded safe guards in byte array and text FFI helpers within `host_fns.rs` to detect invalid pointers instead of silently faulting.
- **SplitOn Assertion Update**: Handled the initial crashing bug, leaving `splitOn` failing gently on an assertion for subsequent investigation regarding nested serialization. 

All targets have been built cleanly. Tested locally with 4/5 Group A tests passing successfully.