### PR TITLE
Capture JIT stderr diagnostics into MCP error responses

### DIFF
--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -56,6 +56,19 @@ thread_local! {
     static RUNTIME_ERROR: RefCell<Option<RuntimeError>> = const { RefCell::new(None) };
 
     pub(crate) static GC_STATE: RefCell<Option<GcState>> = const { RefCell::new(None) };
+
+    /// Captured JIT diagnostics.
+    static DIAGNOSTICS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Push a diagnostic message to the thread-local buffer.
+pub fn push_diagnostic(msg: String) {
+    DIAGNOSTICS.with(|d| d.borrow_mut().push(msg));
+}
+
+/// Drain all accumulated diagnostics.
+pub fn drain_diagnostics() -> Vec<String> {
+    DIAGNOSTICS.with(|d| d.borrow_mut().drain(..).collect())
 }
 
 /// Thread-local state for the copying garbage collector.
@@ -275,10 +288,12 @@ pub fn gc_trigger_last_vmctx() -> usize {
 pub extern "C" fn unresolved_var_trap(var_id: u64) -> *mut u8 {
     let tag_char = (var_id >> 56) as u8 as char;
     let key = var_id & ((1u64 << 56) - 1);
-    eprintln!(
+    let msg = format!(
         "[JIT] Forced unresolved external variable: VarId({:#x}) [tag='{}', key={}]",
         var_id, tag_char, key
     );
+    eprintln!("{}", msg);
+    push_diagnostic(msg);
     RUNTIME_ERROR.with(|cell| {
         *cell.borrow_mut() = Some(RuntimeError::UnresolvedVar(var_id));
     });
@@ -300,7 +315,9 @@ pub extern "C" fn runtime_error(kind: u64) -> *mut u8 {
         4 => "TypeMetadata",
         _ => "Unknown",
     };
-    eprintln!("[JIT] runtime_error called: kind={} ({})", kind, err_name);
+    let msg = format!("[JIT] runtime_error called: kind={} ({})", kind, err_name);
+    eprintln!("{}", msg);
+    push_diagnostic(msg);
     let err = match kind {
         0 => RuntimeError::DivisionByZero,
         1 => RuntimeError::Overflow,
@@ -393,7 +410,9 @@ pub unsafe extern "C" fn debug_app_check(fun_ptr: *const u8) {
         if has_error {
             return; // Error already flagged, just continue
         }
-        eprintln!("[JIT] App: fun_ptr is NULL — unresolved binding");
+        let msg = "[JIT] App: fun_ptr is NULL — unresolved binding".to_string();
+        eprintln!("{}", msg);
+        push_diagnostic(msg);
         RUNTIME_ERROR.with(|cell| {
             *cell.borrow_mut() = Some(RuntimeError::NullFunPtr);
         });
@@ -413,15 +432,18 @@ pub unsafe extern "C" fn debug_app_check(fun_ptr: *const u8) {
             3 => "Lit",
             _ => "UNKNOWN",
         };
-        let _ = writeln!(
-            stderr,
+        let msg = format!(
             "[JIT] App: fun_ptr={:p} has tag {} ({}) — expected Closure!",
             fun_ptr, tag, tag_name
         );
+        let _ = writeln!(stderr, "{}", msg);
+        push_diagnostic(msg);
         if tag == tidepool_heap::layout::TAG_CON {
             let con_tag = unsafe { *(fun_ptr.add(8) as *const u64) };
             let num_fields = unsafe { *(fun_ptr.add(16) as *const u16) };
-            let _ = writeln!(stderr, "[JIT]   Con tag={}, num_fields={}", con_tag, num_fields);
+            let msg2 = format!("[JIT]   Con tag={}, num_fields={}", con_tag, num_fields);
+            let _ = writeln!(stderr, "{}", msg2);
+            push_diagnostic(msg2);
         }
         let _ = stderr.flush();
         RUNTIME_ERROR.with(|cell| {
@@ -1328,6 +1350,21 @@ mod tests {
         let m = runtime_decode_double_mantissa(bits);
         let e = runtime_decode_double_exponent(bits);
         assert_eq!(m as f64 * (2.0f64).powi(e as i32), 3.14);
+    }
+
+    #[test]
+    fn test_diagnostics() {
+        // Clear any leftover diagnostics
+        let _ = drain_diagnostics();
+        
+        push_diagnostic("test1".to_string());
+        push_diagnostic("test2".to_string());
+        
+        let d = drain_diagnostics();
+        assert_eq!(d, vec!["test1".to_string(), "test2".to_string()]);
+        
+        let d2 = drain_diagnostics();
+        assert!(d2.is_empty());
     }
 }
 

--- a/tidepool-mcp/Cargo.toml
+++ b/tidepool-mcp/Cargo.toml
@@ -23,3 +23,4 @@ frunk = "0.4"
 schemars = "=1.2.1"
 serde_json = "1"
 tidepool-bridge = { version = "0.0.1", path = "../tidepool-bridge" }
+tidepool-codegen = { version = "0.0.1", path = "../tidepool-codegen" }

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -703,13 +703,31 @@ impl TidepoolMcpServerImpl {
                         });
                     }
                     Ok(Err(e)) => {
+                        let diagnostics = tidepool_codegen::host_fns::drain_diagnostics();
+                        let mut error_detail = e.to_string();
+                        if !diagnostics.is_empty() {
+                            error_detail.push_str("\n\n## JIT Diagnostics\n");
+                            for d in &diagnostics {
+                                error_detail.push_str(d);
+                                error_detail.push('\n');
+                            }
+                        }
                         let _ = thread_session_tx.send(SessionMessage::Error {
-                            error: e.to_string(),
+                            error: error_detail,
                         });
                     }
                     Err(panic_payload) => {
+                        let diagnostics = tidepool_codegen::host_fns::drain_diagnostics();
+                        let mut error_detail = format_panic_payload(panic_payload);
+                        if !diagnostics.is_empty() {
+                            error_detail.push_str("\n\n## JIT Diagnostics\n");
+                            for d in &diagnostics {
+                                error_detail.push_str(d);
+                                error_detail.push('\n');
+                            }
+                        }
                         let _ = thread_session_tx.send(SessionMessage::Error {
-                            error: format_panic_payload(panic_payload),
+                            error: error_detail,
                         });
                     }
                 }
@@ -761,7 +779,7 @@ impl TidepoolMcpServerImpl {
                 Ok(CallToolResult::error(vec![Content::text(error_msg)]))
             }
             None => Err(McpError::internal_error(
-                "eval thread died unexpectedly",
+                "Eval thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.",
                 None,
             )),
         }
@@ -835,7 +853,7 @@ impl TidepoolMcpServerImpl {
                 Ok(CallToolResult::error(vec![Content::text(error_msg)]))
             }
             None => Err(McpError::internal_error(
-                "eval thread died unexpectedly",
+                "Eval thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.",
                 None,
             )),
         }


### PR DESCRIPTION
This PR adds a thread-local diagnostic buffer in tidepool-codegen/src/host_fns.rs to capture JIT diagnostics that were previously only sent to stderr. These diagnostics are then drained and included in MCP error responses in tidepool-mcp, providing better context for JIT-related failures.

Key changes:
- Added thread-local `DIAGNOSTICS` buffer and `push_diagnostic`/`drain_diagnostics` API in `host_fns.rs`.
- Updated JIT `eprintln!` calls to also push to the diagnostic buffer.
- Updated `tidepool-mcp` to drain diagnostics on error/panic and include them in the response.
- Improved the 'eval thread died unexpectedly' message with specific crash guidance.
- Added a unit test for the diagnostic buffer in `host_fns.rs`.