### PR TITLE
feat: aarch64 (Apple Silicon) support for JIT runtime

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Frame pointers are required for the GC frame walker to traverse
+# the call stack and find GC roots. Without this, aarch64 Darwin
+# may omit frame pointers for leaf functions, breaking the FP chain.
+[build]
+rustflags = ["-C", "force-frame-pointers=yes"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,6 +2540,7 @@ dependencies = [
 name = "tidepool-codegen"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-jit",
@@ -2685,6 +2686,7 @@ dependencies = [
  "tidepool-optimize",
  "tidepool-repr",
  "tidepool-testing",
+ "tokio",
 ]
 
 [[package]]

--- a/tidepool-codegen/Cargo.toml
+++ b/tidepool-codegen/Cargo.toml
@@ -25,5 +25,8 @@ recursion = "0.5.4"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[build-dependencies]
+cc = "1"
+
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-codegen/build.rs
+++ b/tidepool-codegen/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    #[cfg(unix)]
+    {
+        cc::Build::new()
+            .file("csrc/sigsetjmp_wrapper.c")
+            .compile("sigsetjmp_wrapper");
+    }
+}

--- a/tidepool-codegen/build.rs
+++ b/tidepool-codegen/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     #[cfg(unix)]
     {
+        println!("cargo:rerun-if-changed=csrc/sigsetjmp_wrapper.c");
         cc::Build::new()
             .file("csrc/sigsetjmp_wrapper.c")
             .compile("sigsetjmp_wrapper");

--- a/tidepool-codegen/csrc/sigsetjmp_wrapper.c
+++ b/tidepool-codegen/csrc/sigsetjmp_wrapper.c
@@ -1,0 +1,37 @@
+/* sigsetjmp/siglongjmp wrapper for Rust FFI.
+ *
+ * sigsetjmp is a "returns_twice" function — it returns once normally (0)
+ * and again when siglongjmp jumps back to it (with the signal number).
+ * LLVM requires the `returns_twice` attribute on the caller for correct
+ * codegen, but Rust doesn't expose this attribute. Calling sigsetjmp
+ * directly from Rust can cause the optimizer to break the second-return
+ * path, especially on aarch64.
+ *
+ * Solution: call sigsetjmp from C where the compiler handles it correctly,
+ * and export a thin wrapper to Rust.
+ */
+
+#include <setjmp.h>
+#include <signal.h>
+#include <stdint.h>
+
+/* Run a callback with sigsetjmp/siglongjmp protection.
+ *
+ * Returns 0 if the callback completed normally.
+ * Returns the signal number (> 0) if siglongjmp was called from a handler.
+ *
+ * jmp_buf_out: filled with the sigjmp_buf pointer so the signal handler
+ *              can call siglongjmp on it.
+ */
+int tidepool_sigsetjmp_call(
+    sigjmp_buf *buf_out,
+    void (*callback)(void *),
+    void *userdata
+) {
+    int val = sigsetjmp(*buf_out, 1);
+    if (val != 0) {
+        return val;
+    }
+    callback(userdata);
+    return 0;
+}

--- a/tidepool-codegen/src/gc/frame_walker.rs
+++ b/tidepool-codegen/src/gc/frame_walker.rs
@@ -9,85 +9,58 @@ pub struct StackRoot {
     pub heap_ptr: *mut u8,
 }
 
-/// Walk JIT frames starting from the given RBP, collecting all GC roots.
+/// Walk JIT frames starting from the given frame pointer, collecting all GC roots.
+///
+/// Uses Cranelift's `frame_size` metadata (the FP-to-SP distance, aka `active_size()`)
+/// to compute SP at each safepoint: `SP = caller_FP - frame_size`. This is the same
+/// approach Wasmtime uses and is correct on both x86_64 and aarch64, regardless of
+/// prologue structure or callee-saved register layout.
 ///
 /// # Safety
-/// - `start_rbp` must be a valid frame pointer from within a JIT call chain.
+/// - `start_fp` must be a valid frame pointer from within a JIT call chain
+///   (typically gc_trigger's FP, read via inline asm).
 /// - `stack_maps` must contain entries for all JIT functions in the call chain.
-#[cfg(target_arch = "x86_64")]
+/// - All frames in the chain must have frame pointers (`force-frame-pointers = true`).
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub unsafe fn walk_frames(
-    start_rbp: usize,
+    start_fp: usize,
     stack_maps: &StackMapRegistry,
-    start_rsp: usize,
 ) -> Vec<StackRoot> {
     let mut roots = Vec::new();
-    let mut rbp = start_rbp;
-
-    // First, try to find the first JIT return address by searching up from RSP.
-    // This handles cases where gc_trigger doesn't have a frame pointer.
-    let mut current_return_addr = None;
-    let mut search_ptr = start_rsp;
-    // We search up to RBP + 16 (where the JIT return addr would be if gc_trigger has no frame).
-    while search_ptr < start_rbp + 16 {
-        let val = *(search_ptr as *const usize);
-        if stack_maps.contains_address(val) {
-            current_return_addr = Some(val);
-            // If we found a JIT return address, the RBP for this frame is the current RBP
-            // if gc_trigger has no frame, or it's the saved RBP if it does.
-            // Actually, if we found a JIT return address at search_ptr,
-            // then search_ptr + 8 is the SP at the safepoint!
-            break;
-        }
-        search_ptr += 8;
-    }
+    let mut fp = start_fp;
 
     loop {
-        if rbp == 0 {
+        if fp == 0 {
             break;
         }
 
-        // Determine return address for this frame
-        let return_addr = if let Some(addr) = current_return_addr.take() {
-            addr
-        } else {
-            *((rbp + 8) as *const usize)
-        };
+        // [FP+8] = return address (into the caller of this frame's function)
+        let return_addr = *((fp + 8) as *const usize);
 
         // Check if this return address is in JIT code
         if !stack_maps.contains_address(return_addr) {
             if !roots.is_empty() {
                 // We were in JIT territory and now we left it. Stop.
                 break;
-            } else {
-                // We haven't hit JIT territory yet. Skip this frame.
-                let next_rbp = *(rbp as *const usize);
-                if next_rbp == 0 || next_rbp == rbp || next_rbp < rbp {
-                    break;
-                }
-                rbp = next_rbp;
-                continue;
             }
+            // We haven't hit JIT territory yet. Skip this frame
+            // (e.g., gc_trigger → perform_gc before reaching JIT frames).
+            let next_fp = *(fp as *const usize);
+            if next_fp == 0 || next_fp == fp || next_fp <= fp {
+                break;
+            }
+            fp = next_fp;
+            continue;
         }
 
-        // Look up stack map for this return address
+        // Found a JIT return address. The stack map at this address describes
+        // the caller's GC roots at the point it made the call.
         if let Some(info) = stack_maps.lookup(return_addr) {
-            // Compute SP at safepoint.
-            // Cranelift stack map offsets are SP-relative at the safepoint.
-            // The return address we found is the one pushed by the 'call' in JIT code.
-            // The SP just before that 'call' was (addr_of_return_addr + 8).
-
-            // We need to find where this return_addr was on the stack.
-            //
-            // If this is the first frame we found, and it was found via the initial RSP search
-            // (proxied by `search_ptr < start_rbp + 16`), we use that search address.
-            // Otherwise, for any subsequent JIT frames, the return address is at [rbp + 8].
-            let addr_of_return_addr = if roots.is_empty() && search_ptr < start_rbp + 16 {
-                search_ptr
-            } else {
-                rbp + 8
-            };
-
-            let sp_at_safepoint = addr_of_return_addr + 8;
+            // The caller's FP is saved at [current_FP + 0].
+            let caller_fp = *(fp as *const usize);
+            // SP at the safepoint = caller's FP - caller's active frame size.
+            // Cranelift's frame_size is active_size(): the distance from FP down to SP.
+            let sp_at_safepoint = caller_fp - info.frame_size as usize;
 
             for &offset in &info.offsets {
                 let root_addr = (sp_at_safepoint + offset as usize) as *mut u64;
@@ -99,14 +72,14 @@ pub unsafe fn walk_frames(
             }
         }
 
-        // Walk to next frame: *(rbp) is the saved caller RBP
-        let next_rbp = *(rbp as *const usize);
+        // Walk to next frame: [FP+0] is the saved caller FP
+        let next_fp = *(fp as *const usize);
 
-        // Basic sanity checks to prevent infinite loops or jumping to null
-        if next_rbp == 0 || next_rbp == rbp || next_rbp < rbp {
+        // Sanity checks to prevent infinite loops
+        if next_fp == 0 || next_fp == fp || next_fp <= fp {
             break;
         }
-        rbp = next_rbp;
+        fp = next_fp;
     }
 
     roots

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -118,71 +118,83 @@ pub extern "C" fn gc_trigger(vmctx: *mut VMContext) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        let rbp: usize;
-        let rsp: usize;
+        let fp: usize;
         unsafe {
-            std::arch::asm!("mov {}, rbp", out(reg) rbp, options(nomem, nostack));
-            std::arch::asm!("mov {}, rsp", out(reg) rsp, options(nomem, nostack));
+            std::arch::asm!("mov {}, rbp", out(reg) fp, options(nomem, nostack));
         }
-
-        STACK_MAP_REGISTRY.with(|reg_cell| {
-            if let Some(registry_ptr) = *reg_cell.borrow() {
-                let registry = unsafe { &*registry_ptr };
-                // Walk frames starting from gc_trigger's own frame.
-                let roots = unsafe { frame_walker::walk_frames(rbp, registry, rsp) };
-
-                // ── Cheney copying GC ──────────────────────────────
-                GC_STATE.with(|gc_cell| {
-                    let mut gc_state = gc_cell.borrow_mut();
-                    if let Some(state) = gc_state.as_mut() {
-                        let from_start = state.active_start;
-                        let from_size = state.active_size;
-                        let from_end = unsafe { from_start.add(from_size) };
-
-                        let mut tospace = vec![0u8; from_size];
-
-                        // Convert StackRoot to raw slot pointers
-                        let root_slots: Vec<*mut *mut u8> = roots.iter()
-                            .map(|r| r.stack_slot_addr as *mut *mut u8)
-                            .collect();
-
-                        let result = unsafe {
-                            tidepool_heap::gc::raw::cheney_copy(
-                                &root_slots,
-                                from_start as *const u8,
-                                from_end as *const u8,
-                                &mut tospace,
-                            )
-                        };
-
-                        // Update GcState: swap to tospace
-                        let to_start = tospace.as_mut_ptr();
-                        state.active_start = to_start;
-                        // active_size stays the same
-                        state.active_buffer = Some(tospace); // drops old buffer if any
-
-                        // Update VMContext for resumed allocation
-                        unsafe {
-                            (*vmctx).alloc_ptr = to_start.add(result.bytes_copied);
-                            (*vmctx).alloc_limit = to_start.add(from_size) as *const u8;
-                        }
-                    }
-                });
-                // ── End GC ─────────────────────────────────────────
-
-                // Call test hook if present
-                HOOK.with(|hook_cell| {
-                    if let Some(hook) = *hook_cell.borrow() {
-                        hook(&roots);
-                    }
-                });
-
-                LAST_ROOTS.with(|roots_cell| {
-                    *roots_cell.borrow_mut() = roots;
-                });
-            }
-        });
+        perform_gc(fp, vmctx);
     }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        let fp: usize;
+        unsafe {
+            std::arch::asm!("mov {}, x29", out(reg) fp, options(nomem, nostack));
+        }
+        perform_gc(fp, vmctx);
+    }
+}
+
+/// Shared GC body: walk frames, run Cheney copy, call hooks.
+#[inline(never)]
+fn perform_gc(fp: usize, vmctx: *mut VMContext) {
+    STACK_MAP_REGISTRY.with(|reg_cell| {
+        if let Some(registry_ptr) = *reg_cell.borrow() {
+            let registry = unsafe { &*registry_ptr };
+            // Walk frames starting from gc_trigger's own frame.
+            let roots = unsafe { frame_walker::walk_frames(fp, registry) };
+
+            // ── Cheney copying GC ──────────────────────────────
+            GC_STATE.with(|gc_cell| {
+                let mut gc_state = gc_cell.borrow_mut();
+                if let Some(state) = gc_state.as_mut() {
+                    let from_start = state.active_start;
+                    let from_size = state.active_size;
+                    let from_end = unsafe { from_start.add(from_size) };
+
+                    let mut tospace = vec![0u8; from_size];
+
+                    // Convert StackRoot to raw slot pointers
+                    let root_slots: Vec<*mut *mut u8> = roots.iter()
+                        .map(|r| r.stack_slot_addr as *mut *mut u8)
+                        .collect();
+
+                    let result = unsafe {
+                        tidepool_heap::gc::raw::cheney_copy(
+                            &root_slots,
+                            from_start as *const u8,
+                            from_end as *const u8,
+                            &mut tospace,
+                        )
+                    };
+
+                    // Update GcState: swap to tospace
+                    let to_start = tospace.as_mut_ptr();
+                    state.active_start = to_start;
+                    // active_size stays the same
+                    state.active_buffer = Some(tospace); // drops old buffer if any
+
+                    // Update VMContext for resumed allocation
+                    unsafe {
+                        (*vmctx).alloc_ptr = to_start.add(result.bytes_copied);
+                        (*vmctx).alloc_limit = to_start.add(from_size) as *const u8;
+                    }
+                }
+            });
+            // ── End GC ─────────────────────────────────────────
+
+            // Call test hook if present
+            HOOK.with(|hook_cell| {
+                if let Some(hook) = *hook_cell.borrow() {
+                    hook(&roots);
+                }
+            });
+
+            LAST_ROOTS.with(|roots_cell| {
+                *roots_cell.borrow_mut() = roots;
+            });
+        }
+    });
 }
 
 /// Set a hook to be called during gc_trigger with the collected roots.

--- a/tidepool-codegen/src/signal_safety.rs
+++ b/tidepool-codegen/src/signal_safety.rs
@@ -1,12 +1,15 @@
 //! JIT signal safety via sigsetjmp/siglongjmp.
 //!
-//! JIT-compiled code can crash with SIGILL (case trap `ud2`) or SIGSEGV
+//! JIT-compiled code can crash with SIGILL (case trap) or SIGSEGV
 //! (bad memory access). This module provides `with_signal_protection` which
 //! wraps JIT calls so that these signals return a clean error instead of
 //! killing the process.
 //!
-//! This is the standard technique used by real JIT runtimes (Wasmtime, V8,
-//! SpiderMonkey) to recover from signals in generated code.
+//! The actual sigsetjmp call lives in C (`csrc/sigsetjmp_wrapper.c`) because
+//! sigsetjmp is a "returns_twice" function. LLVM requires the `returns_twice`
+//! attribute on the caller for correct codegen, but Rust doesn't expose this
+//! attribute. Calling sigsetjmp directly from Rust can cause the optimizer to
+//! break the second-return path, especially on aarch64.
 
 #[cfg(unix)]
 mod inner {
@@ -16,7 +19,7 @@ mod inner {
     // sigjmp_buf sizes vary by platform:
     //   - Linux x86_64 (glibc): __jmp_buf_tag[1] = 200 bytes
     //   - macOS x86_64: 37 ints + signal mask ≈ 296 bytes
-    //   - macOS aarch64: similar, ~304 bytes
+    //   - macOS aarch64: int[49] = 196 bytes
     // Use 512 bytes to cover all platforms with headroom.
     #[repr(C, align(16))]
     pub struct SigJmpBuf {
@@ -24,24 +27,15 @@ mod inner {
     }
 
     extern "C" {
-        // On Linux (glibc), sigsetjmp is a macro that calls __sigsetjmp.
-        // On macOS, sigsetjmp is a real function.
-        #[cfg(target_os = "linux")]
-        fn __sigsetjmp(env: *mut SigJmpBuf, savesigs: libc::c_int) -> libc::c_int;
-        #[cfg(not(target_os = "linux"))]
-        fn sigsetjmp(env: *mut SigJmpBuf, savesigs: libc::c_int) -> libc::c_int;
-
         fn siglongjmp(env: *mut SigJmpBuf, val: libc::c_int) -> !;
-    }
 
-    #[cfg(target_os = "linux")]
-    unsafe fn platform_sigsetjmp(env: *mut SigJmpBuf, savesigs: libc::c_int) -> libc::c_int {
-        unsafe { __sigsetjmp(env, savesigs) }
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    unsafe fn platform_sigsetjmp(env: *mut SigJmpBuf, savesigs: libc::c_int) -> libc::c_int {
-        unsafe { sigsetjmp(env, savesigs) }
+        /// C wrapper: calls sigsetjmp, then callback(userdata) if it returns 0.
+        /// Returns 0 on normal completion, or the signal number on siglongjmp.
+        fn tidepool_sigsetjmp_call(
+            buf: *mut SigJmpBuf,
+            callback: unsafe extern "C" fn(*mut libc::c_void),
+            userdata: *mut libc::c_void,
+        ) -> libc::c_int;
     }
 
     /// Signal number that caused the jump.
@@ -64,6 +58,13 @@ mod inner {
     /// (MCP server is single-eval).
     static JMP_BUF: AtomicPtr<SigJmpBuf> = AtomicPtr::new(ptr::null_mut());
 
+    /// Trampoline called from C after sigsetjmp returns 0.
+    /// Casts userdata back to a `Box<dyn FnOnce()>` and calls it.
+    unsafe extern "C" fn trampoline(userdata: *mut libc::c_void) {
+        let closure: Box<Box<dyn FnOnce()>> = Box::from_raw(userdata as *mut Box<dyn FnOnce()>);
+        (*closure)();
+    }
+
     /// Wrap a JIT call with signal protection.
     ///
     /// If SIGILL/SIGSEGV/SIGBUS fires during `f()`, returns `Err(SignalError)`
@@ -77,17 +78,42 @@ mod inner {
     where
         F: FnOnce() -> R,
     {
+        // We need to pass the closure through C's void* callback interface.
+        // Use an UnsafeCell to get the return value out of the type-erased closure.
+        let result_cell = std::cell::UnsafeCell::new(None::<R>);
+        let result_ptr = &result_cell as *const std::cell::UnsafeCell<Option<R>>;
+
+        let wrapper: Box<dyn FnOnce()> = Box::new(move || {
+            let r = f();
+            // SAFETY: we're the only writer, and the reader waits until after we return.
+            unsafe { *(*result_ptr).get() = Some(r) };
+        });
+
         let mut buf: SigJmpBuf = std::mem::zeroed();
-        let val = platform_sigsetjmp(&mut buf, 1); // savesigs=1
+
+        // Store the jump buffer so the signal handler can find it.
+        JMP_BUF.store(&mut buf, Ordering::Relaxed);
+
+        // Double-box: outer Box for the fat pointer, inner Box<dyn FnOnce()>.
+        let boxed: Box<Box<dyn FnOnce()>> = Box::new(wrapper);
+        let userdata = Box::into_raw(boxed) as *mut libc::c_void;
+
+        let val = tidepool_sigsetjmp_call(
+            &mut buf,
+            trampoline,
+            userdata,
+        );
+
+        JMP_BUF.store(null_mut(), Ordering::Relaxed);
+
         if val != 0 {
-            // Jumped back from signal handler
-            JMP_BUF.store(null_mut(), Ordering::Relaxed);
+            // Signal was caught. The closure was interrupted by siglongjmp,
+            // so the Box was leaked. We can't recover it safely.
             return Err(SignalError(val));
         }
-        JMP_BUF.store(&mut buf, Ordering::Relaxed);
-        let result = f();
-        JMP_BUF.store(null_mut(), Ordering::Relaxed);
-        Ok(result)
+
+        // Closure completed normally.
+        Ok(result_cell.into_inner().unwrap())
     }
 
     extern "C" fn handler(
@@ -111,35 +137,37 @@ mod inner {
 
     /// Install signal handlers for SIGILL, SIGSEGV, SIGBUS on an alternate stack.
     ///
-    /// Idempotent — safe to call multiple times. Uses `sigaltstack` so the handler
-    /// works even on stack overflow.
+    /// Safe to call multiple times. Uses `sigaltstack` so the handler works even
+    /// on stack overflow.
     pub fn install() {
         use std::alloc::{alloc, Layout};
         use std::sync::atomic::AtomicBool;
 
-        static INSTALLED: AtomicBool = AtomicBool::new(false);
-        if INSTALLED.swap(true, Ordering::SeqCst) {
-            return;
-        }
-
         const ALT_STACK_SIZE: usize = 64 * 1024;
 
-        unsafe {
-            // Allocate alternate signal stack
-            let layout = Layout::from_size_align(ALT_STACK_SIZE, 16).unwrap();
-            let alt_stack_ptr = alloc(layout);
-            if alt_stack_ptr.is_null() {
-                return;
+        // Allocate the alternate signal stack only once.
+        static ALT_STACK_ALLOCATED: AtomicBool = AtomicBool::new(false);
+        if !ALT_STACK_ALLOCATED.swap(true, Ordering::SeqCst) {
+            unsafe {
+                let layout = Layout::from_size_align(ALT_STACK_SIZE, 16).unwrap();
+                let alt_stack_ptr = alloc(layout);
+                if alt_stack_ptr.is_null() {
+                    ALT_STACK_ALLOCATED.store(false, Ordering::SeqCst);
+                    return;
+                }
+
+                let stack = libc::stack_t {
+                    ss_sp: alt_stack_ptr as *mut libc::c_void,
+                    ss_flags: 0,
+                    ss_size: ALT_STACK_SIZE,
+                };
+                libc::sigaltstack(&stack, ptr::null_mut());
             }
+        }
 
-            let stack = libc::stack_t {
-                ss_sp: alt_stack_ptr as *mut libc::c_void,
-                ss_flags: 0,
-                ss_size: ALT_STACK_SIZE,
-            };
-            libc::sigaltstack(&stack, ptr::null_mut());
-
-            // Install handler for SIGILL, SIGSEGV, SIGBUS
+        // Always (re)install signal handlers. Other code (Rust panic runtime,
+        // test harness) may overwrite them, so we reinstall on every call.
+        unsafe {
             let mut sa: libc::sigaction = std::mem::zeroed();
             sa.sa_flags = libc::SA_SIGINFO | libc::SA_ONSTACK;
             sa.sa_sigaction = handler as *const () as usize;

--- a/tidepool-codegen/src/signal_safety.rs
+++ b/tidepool-codegen/src/signal_safety.rs
@@ -60,9 +60,19 @@ mod inner {
 
     /// Trampoline called from C after sigsetjmp returns 0.
     /// Casts userdata back to a `Box<dyn FnOnce()>` and calls it.
+    /// Panics are caught to prevent unwinding across the C FFI boundary (which is UB).
     unsafe extern "C" fn trampoline(userdata: *mut libc::c_void) {
         let closure: Box<Box<dyn FnOnce()>> = Box::from_raw(userdata as *mut Box<dyn FnOnce()>);
-        (*closure)();
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            (*closure)();
+        }))
+        .is_err()
+        {
+            // Panic crossed into the trampoline. We can't propagate it across C,
+            // so abort. The caller (with_signal_protection) already wraps JIT calls
+            // in catch_unwind at a higher level, so this should never fire.
+            std::process::abort();
+        }
     }
 
     /// Wrap a JIT call with signal protection.
@@ -141,29 +151,34 @@ mod inner {
     /// on stack overflow.
     pub fn install() {
         use std::alloc::{alloc, Layout};
-        use std::sync::atomic::AtomicBool;
 
         const ALT_STACK_SIZE: usize = 64 * 1024;
 
-        // Allocate the alternate signal stack only once.
-        static ALT_STACK_ALLOCATED: AtomicBool = AtomicBool::new(false);
-        if !ALT_STACK_ALLOCATED.swap(true, Ordering::SeqCst) {
-            unsafe {
-                let layout = Layout::from_size_align(ALT_STACK_SIZE, 16).unwrap();
-                let alt_stack_ptr = alloc(layout);
-                if alt_stack_ptr.is_null() {
-                    ALT_STACK_ALLOCATED.store(false, Ordering::SeqCst);
-                    return;
-                }
-
-                let stack = libc::stack_t {
-                    ss_sp: alt_stack_ptr as *mut libc::c_void,
-                    ss_flags: 0,
-                    ss_size: ALT_STACK_SIZE,
-                };
-                libc::sigaltstack(&stack, ptr::null_mut());
-            }
+        // sigaltstack is per-thread, so each calling thread needs its own.
+        // Use a thread-local to allocate once per thread and leak (signal
+        // stacks must outlive the handler).
+        thread_local! {
+            static ALT_STACK_INSTALLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
         }
+        ALT_STACK_INSTALLED.with(|installed| {
+            if !installed.get() {
+                unsafe {
+                    let layout = Layout::from_size_align(ALT_STACK_SIZE, 16).unwrap();
+                    let alt_stack_ptr = alloc(layout);
+                    if alt_stack_ptr.is_null() {
+                        return;
+                    }
+
+                    let stack = libc::stack_t {
+                        ss_sp: alt_stack_ptr as *mut libc::c_void,
+                        ss_flags: 0,
+                        ss_size: ALT_STACK_SIZE,
+                    };
+                    libc::sigaltstack(&stack, ptr::null_mut());
+                }
+                installed.set(true);
+            }
+        });
 
         // Always (re)install signal handlers. Other code (Rust panic runtime,
         // test harness) may overwrite them, so we reinstall on every call.

--- a/tidepool-codegen/tests/signal_safety.rs
+++ b/tidepool-codegen/tests/signal_safety.rs
@@ -1,14 +1,22 @@
 //! Test that sigsetjmp/siglongjmp signal protection actually works.
 
+/// Trigger an illegal instruction (SIGILL).
+/// Separate function to prevent the compiler from optimizing away the fault.
+#[inline(never)]
+unsafe fn trigger_sigill() {
+    #[cfg(target_arch = "x86_64")]
+    std::arch::asm!("ud2");
+    #[cfg(target_arch = "aarch64")]
+    std::arch::asm!("udf #0");
+}
+
 #[test]
 fn test_sigill_returns_signal_error() {
     tidepool_codegen::signal_safety::install();
 
-    // Craft a minimal function that executes `ud2` (SIGILL on x86_64)
     let result = unsafe {
         tidepool_codegen::signal_safety::with_signal_protection(|| {
-            // ud2 = 0x0F 0x0B
-            std::arch::asm!("ud2");
+            trigger_sigill();
         })
     };
 
@@ -41,7 +49,7 @@ fn test_signal_recovery_allows_subsequent_calls() {
     // First call: crash
     let result1 = unsafe {
         tidepool_codegen::signal_safety::with_signal_protection(|| {
-            std::arch::asm!("ud2");
+            trigger_sigill();
         })
     };
     assert!(result1.is_err());

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -176,7 +176,7 @@ pub fn sg_decl() -> EffectDecl {
             "rAny :: [Value] -> Value\nrAny rs = object [\"any\" .= rs]",
             "rNot :: Value -> Value\nrNot r = object [\"not\" .= r]",
             // Object merge (primary combinator) — left-biased key union
-            "infixr 6 .+.\n(.+.) :: Value -> Value -> Value\n(.+.) (Aeson.Object a) (Aeson.Object b) = Aeson.Object (KM.unionWith const a b)\n(.+.) a _ = a",
+            "infixr 6 .+.\n(.+.) :: Value -> Value -> Value\n(.+.) (Object a) (Object b) = Object (KM.unionWith const a b)\n(.+.) a _ = a",
             // Conjunction / Disjunction
             "infixr 5 .&.\n(.&.) :: Value -> Value -> Value\na .&. b = object [\"all\" .= [a, b]]",
             "infixr 4 .|.\n(.|.) :: Value -> Value -> Value\na .|. b = object [\"any\" .= [a, b]]",

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -28,3 +28,4 @@ tidepool-bridge = { version = "0.1.0", path = "../tidepool-bridge" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-mcp = { version = "0.1.0", path = "../tidepool-mcp" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -1112,7 +1112,7 @@ async fn test_full_mcp_async_channel_pattern() {
     let (session_tx, mut session_rx) =
         tokio::sync::mpsc::unbounded_channel::<String>();
 
-    let _handle = std::thread::Builder::new()
+    let handle = std::thread::Builder::new()
         .name("tidepool-eval".into())
         .stack_size(8 * 1024 * 1024)
         .spawn(move || {
@@ -1157,6 +1157,7 @@ async fn test_full_mcp_async_channel_pattern() {
         Ok(None) => panic!("channel closed without message (thread crashed)"),
         Err(_) => panic!("TIMEOUT: eval did not complete in 30s"),
     }
+    handle.join().expect("eval thread panicked");
 }
 
 /// Full MCP preamble: pure string

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -1036,6 +1036,143 @@ fn test_replicate() {
 // MCP-style freer-simple tests (Eff '[Console, KV, Fs] _)
 // ===========================================================================
 
+// ---------------------------------------------------------------------------
+// Full MCP preamble (all 8 effects) — matches the real MCP server exactly
+// ---------------------------------------------------------------------------
+
+fn full_mcp_decls() -> Vec<tidepool_mcp::EffectDecl> {
+    tidepool_mcp::standard_decls()
+}
+
+fn full_mcp_source(lines: &[&str]) -> String {
+    let decls = full_mcp_decls();
+    let preamble = tidepool_mcp::build_preamble(&decls, false);
+    let stack = tidepool_mcp::build_effect_stack_type(&decls);
+    let lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+    let imports = tidepool_mcp::aeson_imports();
+    tidepool_mcp::template_haskell(&preamble, &stack, &lines, &imports, &[], None, None)
+}
+
+fn run_full_mcp(lines: &[&str]) -> serde_json::Value {
+    let src = full_mcp_source(lines);
+    let pp = prelude_path();
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            let include = [pp.as_path()];
+            eprintln!("[test] compile_and_run starting...");
+            let val = compile_and_run(&src, "result", &include, &mut HNil, &())
+                .expect("compile_and_run failed");
+            eprintln!("[test] compile_and_run succeeded");
+            val.to_json()
+        })
+        .unwrap()
+        .join()
+        .expect("thread panicked")
+}
+
+/// Full MCP preamble (all 8 effects): pure (42 :: Int)
+#[test]
+fn test_full_mcp_pure_42() {
+    let json = run_full_mcp(&["pure (42 :: Int)"]);
+    assert_eq!(json, serde_json::json!(42));
+}
+
+/// Full MCP preamble with signal_safety::install() — matches real MCP server
+#[test]
+fn test_full_mcp_with_signal_install() {
+    let src = full_mcp_source(&["pure (42 :: Int)"]);
+    let pp = prelude_path();
+    let json = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            // This is what the MCP server does before compile_and_run
+            tidepool_codegen::signal_safety::install();
+            let include = [pp.as_path()];
+            eprintln!("[test+signal] compile_and_run starting...");
+            let val = compile_and_run(&src, "result", &include, &mut HNil, &())
+                .expect("compile_and_run failed");
+            eprintln!("[test+signal] compile_and_run succeeded");
+            val.to_json()
+        })
+        .unwrap()
+        .join()
+        .expect("thread panicked");
+    assert_eq!(json, serde_json::json!(42));
+}
+
+/// Full MCP preamble with the same tokio+channel pattern the MCP server uses.
+/// This exactly mirrors tidepool-mcp/src/lib.rs:1142-1222.
+#[tokio::test]
+async fn test_full_mcp_async_channel_pattern() {
+    let src = full_mcp_source(&["pure (42 :: Int)"]);
+    let pp = prelude_path();
+
+    // Same channel types as MCP server
+    let (session_tx, mut session_rx) =
+        tokio::sync::mpsc::unbounded_channel::<String>();
+
+    let _handle = std::thread::Builder::new()
+        .name("tidepool-eval".into())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            tidepool_codegen::signal_safety::install();
+            let include = [pp.as_path()];
+            eprintln!("[test+async] compile_and_run starting...");
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                compile_and_run(&src, "result", &include, &mut HNil, &())
+            }));
+            eprintln!("[test+async] compile_and_run finished");
+            match result {
+                Ok(Ok(val)) => {
+                    let json = val.to_json();
+                    let _ = session_tx.send(format!("OK:{}", json));
+                }
+                Ok(Err(e)) => {
+                    let _ = session_tx.send(format!("ERR:{}", e));
+                }
+                Err(panic) => {
+                    let msg = if let Some(s) = panic.downcast_ref::<String>() {
+                        s.clone()
+                    } else if let Some(s) = panic.downcast_ref::<&str>() {
+                        s.to_string()
+                    } else {
+                        "unknown panic".into()
+                    };
+                    let _ = session_tx.send(format!("PANIC:{}", msg));
+                }
+            }
+        })
+        .unwrap();
+
+    // Same timeout pattern as MCP server (30s)
+    let eval_timeout = tokio::time::Duration::from_secs(30);
+    match tokio::time::timeout(eval_timeout, session_rx.recv()).await {
+        Ok(Some(msg)) => {
+            eprintln!("[test+async] received: {}", msg);
+            assert!(msg.starts_with("OK:"), "expected OK, got: {}", msg);
+            let json: serde_json::Value = serde_json::from_str(&msg[3..]).unwrap();
+            assert_eq!(json, serde_json::json!(42));
+        }
+        Ok(None) => panic!("channel closed without message (thread crashed)"),
+        Err(_) => panic!("TIMEOUT: eval did not complete in 30s"),
+    }
+}
+
+/// Full MCP preamble: pure string
+#[test]
+fn test_full_mcp_pure_string() {
+    let json = run_full_mcp(&["pure \"hello\""]);
+    assert_eq!(json, serde_json::json!("hello"));
+}
+
+/// Full MCP preamble: pure list
+#[test]
+fn test_full_mcp_pure_list() {
+    let json = run_full_mcp(&["pure [1,2,3 :: Int]"]);
+    assert_eq!(json, serde_json::json!([1, 2, 3]));
+}
+
 #[test]
 
 fn test_mcp_pure_lit() {

--- a/tools/mcp-wrapper.py
+++ b/tools/mcp-wrapper.py
@@ -181,7 +181,7 @@ class State:
             # Send initialized notification
             self.write_to_child(json.dumps({
                 "jsonrpc": "2.0",
-                "method": "initialized",
+                "method": "notifications/initialized",
             }))
 
         # Notify client that tools may have changed


### PR DESCRIPTION
## Summary

- **GC frame walker**: Replace x86_64-specific `addr_of_return_addr + 8` with architecture-neutral `SP = caller_FP - frame_size` using Cranelift's `active_size()` metadata (same approach as Wasmtime)
- **Signal safety**: Move `sigsetjmp` into a C wrapper because LLVM doesn't apply `returns_twice` to Rust FFI, breaking the second-return path on aarch64
- **MCP fixes**: Fix `.+.` operator's qualified `Aeson.Object` pattern and fix `mcp-wrapper.py` restart sending wrong `initialized` method name (root cause of MCP eval hanging after `cargo install`)
- **Testing**: Full 8-effect MCP preamble tests, signal safety integration tests, tokio+channel async pattern test mirroring the real MCP server flow

All 8 effects verified working on arm64 via MCP eval: Console, KV, Fs, SG, Http, Exec, Meta, Ask.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `test_full_mcp_pure_42` — full 8-effect preamble through JIT
- [x] `test_full_mcp_with_signal_install` — with signal handler installation
- [x] `test_full_mcp_async_channel_pattern` — tokio+channel pattern matching real MCP server
- [x] Signal safety tests pass (`--test-threads=1`)
- [x] Direct MCP binary test: init → eval → restart → eval → eval
- [x] Live MCP eval via Claude Code: `pure (42 :: Int)`, KV accumulation, Fs glob, SG find, Exec uname, Meta introspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)