### PR TITLE
fix: clean signal error reporting on aarch64

### DIFF
--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -91,17 +91,7 @@ impl CompiledEffectMachine {
         // Check for runtime error FIRST (before null check), because runtime_error
         // now returns a "poison" non-null Lit object to prevent segfaults in JIT code.
         if let Some(err) = crate::host_fns::take_runtime_error() {
-            return Yield::Error(match err {
-                crate::host_fns::RuntimeError::DivisionByZero => YieldError::DivisionByZero,
-                crate::host_fns::RuntimeError::Overflow => YieldError::Overflow,
-                crate::host_fns::RuntimeError::UserError => YieldError::UserError,
-                crate::host_fns::RuntimeError::Undefined => YieldError::Undefined,
-                crate::host_fns::RuntimeError::TypeMetadata => YieldError::TypeMetadata,
-                crate::host_fns::RuntimeError::UnresolvedVar(id) => YieldError::UnresolvedVar(id),
-                crate::host_fns::RuntimeError::NullFunPtr => YieldError::NullFunPtr,
-                crate::host_fns::RuntimeError::BadFunPtrTag(tag) => YieldError::BadFunPtrTag(tag),
-                crate::host_fns::RuntimeError::HeapOverflow => YieldError::HeapOverflow,
-            });
+            return Yield::Error(YieldError::from(err));
         }
         if result.is_null() {
             return Yield::Error(YieldError::NullPointer);

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -105,7 +105,7 @@ impl JitEffectMachine {
         let mut yield_result =
             match unsafe { crate::signal_safety::with_signal_protection(|| machine.step()) } {
                 Ok(y) => y,
-                Err(e) => Yield::Error(crate::yield_type::YieldError::Signal(e.0)),
+                Err(e) => signal_error_to_yield(e),
             };
 
         let result = loop {
@@ -133,7 +133,7 @@ impl JitEffectMachine {
                         })
                     } {
                         Ok(y) => y,
-                        Err(e) => Yield::Error(crate::yield_type::YieldError::Signal(e.0)),
+                        Err(e) => signal_error_to_yield(e),
                     };
                 }
                 Yield::Error(e) => break Err(JitError::Yield(e)),
@@ -172,40 +172,14 @@ impl JitEffectMachine {
                 crate::host_fns::clear_gc_state();
                 crate::host_fns::clear_stack_map_registry();
                 crate::debug::clear_lambda_registry();
-                return Err(JitError::Yield(crate::yield_type::YieldError::Signal(e.0)));
+                return Err(JitError::Yield(runtime_error_or_signal(e.0)));
             }
         };
 
         // Check for runtime error FIRST — runtime_error now returns a poison
         // object instead of null, so we can't rely on null-check alone.
         let result = if let Some(err) = crate::host_fns::take_runtime_error() {
-            Err(JitError::Yield(match err {
-                crate::host_fns::RuntimeError::DivisionByZero => {
-                    crate::yield_type::YieldError::DivisionByZero
-                }
-                crate::host_fns::RuntimeError::Overflow => crate::yield_type::YieldError::Overflow,
-                crate::host_fns::RuntimeError::UserError => {
-                    crate::yield_type::YieldError::UserError
-                }
-                crate::host_fns::RuntimeError::Undefined => {
-                    crate::yield_type::YieldError::Undefined
-                }
-                crate::host_fns::RuntimeError::TypeMetadata => {
-                    crate::yield_type::YieldError::TypeMetadata
-                }
-                crate::host_fns::RuntimeError::UnresolvedVar(id) => {
-                    crate::yield_type::YieldError::UnresolvedVar(id)
-                }
-                crate::host_fns::RuntimeError::NullFunPtr => {
-                    crate::yield_type::YieldError::NullFunPtr
-                }
-                crate::host_fns::RuntimeError::BadFunPtrTag(tag) => {
-                    crate::yield_type::YieldError::BadFunPtrTag(tag)
-                }
-                crate::host_fns::RuntimeError::HeapOverflow => {
-                    crate::yield_type::YieldError::HeapOverflow
-                }
-            }))
+            Err(JitError::Yield(crate::yield_type::YieldError::from(err)))
         } else if result_ptr.is_null() {
             Err(JitError::Yield(crate::yield_type::YieldError::NullPointer))
         } else {
@@ -218,5 +192,53 @@ impl JitEffectMachine {
         crate::debug::clear_lambda_registry();
 
         result
+    }
+}
+
+/// Check for a pending RuntimeError (more specific) before falling back to the
+/// signal error. A runtime error like BadFunPtrTag is set by debug_app_check
+/// before the JIT continues and crashes — prefer it over the raw signal number.
+fn runtime_error_or_signal(sig: i32) -> crate::yield_type::YieldError {
+    if let Some(err) = crate::host_fns::take_runtime_error() {
+        crate::yield_type::YieldError::from(err)
+    } else {
+        crate::yield_type::YieldError::Signal(sig)
+    }
+}
+
+/// Convert a signal error into a Yield, preferring any pending RuntimeError.
+fn signal_error_to_yield(e: crate::signal_safety::SignalError) -> Yield {
+    Yield::Error(runtime_error_or_signal(e.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::yield_type::YieldError;
+
+    /// Regression test: when a RuntimeError is pending and a signal fires,
+    /// prefer the RuntimeError (more specific) over the raw signal number.
+    /// This prevents "JIT signal: unknown signal" when the real cause is
+    /// something like BadFunPtrTag(255).
+    #[test]
+    fn test_runtime_error_preferred_over_signal() {
+        // Set a pending runtime error via public API (kind=0 = DivisionByZero)
+        crate::host_fns::runtime_error(0);
+
+        // Signal fires after the runtime error was set
+        let err = runtime_error_or_signal(libc::SIGBUS);
+
+        // Should get DivisionByZero, not Signal(SIGBUS)
+        assert_eq!(err, YieldError::DivisionByZero);
+    }
+
+    /// When no RuntimeError is pending, the signal number comes through.
+    #[test]
+    fn test_signal_passthrough_without_runtime_error() {
+        // Ensure no pending error
+        crate::host_fns::take_runtime_error();
+
+        let err = runtime_error_or_signal(libc::SIGILL);
+        assert_eq!(err, YieldError::Signal(libc::SIGILL));
     }
 }

--- a/tidepool-codegen/src/signal_safety.rs
+++ b/tidepool-codegen/src/signal_safety.rs
@@ -48,7 +48,8 @@ mod inner {
                 libc::SIGILL => "SIGILL (illegal instruction — likely exhausted case branch)",
                 libc::SIGSEGV => "SIGSEGV (segmentation fault — likely invalid memory access)",
                 libc::SIGBUS => "SIGBUS (bus error)",
-                _ => "unknown signal",
+                libc::SIGTRAP => "SIGTRAP (trap — likely Cranelift trap instruction)",
+                _ => return write!(f, "JIT signal: signal {} (unknown)", self.0),
             };
             write!(f, "JIT signal: {}", name)
         }
@@ -189,6 +190,7 @@ mod inner {
             libc::sigaction(libc::SIGILL, &sa, ptr::null_mut());
             libc::sigaction(libc::SIGSEGV, &sa, ptr::null_mut());
             libc::sigaction(libc::SIGBUS, &sa, ptr::null_mut());
+            libc::sigaction(libc::SIGTRAP, &sa, ptr::null_mut());
         }
     }
 }

--- a/tidepool-codegen/src/yield_type.rs
+++ b/tidepool-codegen/src/yield_type.rs
@@ -66,7 +66,7 @@ pub enum YieldError {
     BadFunPtrTag(u8),
     /// Heap overflow after GC.
     HeapOverflow,
-    /// Fatal signal during JIT execution (SIGILL=4, SIGSEGV=11, SIGBUS=7).
+    /// Fatal signal during JIT execution (SIGILL, SIGSEGV, SIGBUS, SIGTRAP).
     Signal(i32),
 }
 
@@ -101,16 +101,41 @@ impl std::fmt::Display for YieldError {
             YieldError::BadFunPtrTag(tag) => write!(f, "application of non-closure (tag={})", tag),
             YieldError::HeapOverflow => write!(f, "heap overflow (nursery exhausted after GC)"),
             YieldError::Signal(sig) => {
-                let name = match *sig {
-                    4 => "SIGILL (illegal instruction — likely exhausted case branch)",
-                    11 => "SIGSEGV (segmentation fault — likely invalid memory access)",
-                    7 => "SIGBUS (bus error)",
-                    _ => "unknown signal",
-                };
-                write!(f, "JIT signal: {}", name)
+                #[cfg(unix)]
+                {
+                    let name = match *sig {
+                        libc::SIGILL => "SIGILL (illegal instruction — likely exhausted case branch)",
+                        libc::SIGSEGV => {
+                            "SIGSEGV (segmentation fault — likely invalid memory access)"
+                        }
+                        libc::SIGBUS => "SIGBUS (bus error)",
+                        libc::SIGTRAP => "SIGTRAP (trap — likely Cranelift trap instruction)",
+                        _ => return write!(f, "JIT signal: signal {} (unknown)", sig),
+                    };
+                    write!(f, "JIT signal: {}", name)
+                }
+                #[cfg(not(unix))]
+                write!(f, "JIT signal: signal {}", sig)
             }
         }
     }
 }
 
 impl std::error::Error for YieldError {}
+
+impl From<crate::host_fns::RuntimeError> for YieldError {
+    fn from(err: crate::host_fns::RuntimeError) -> Self {
+        use crate::host_fns::RuntimeError;
+        match err {
+            RuntimeError::DivisionByZero => YieldError::DivisionByZero,
+            RuntimeError::Overflow => YieldError::Overflow,
+            RuntimeError::UserError => YieldError::UserError,
+            RuntimeError::Undefined => YieldError::Undefined,
+            RuntimeError::TypeMetadata => YieldError::TypeMetadata,
+            RuntimeError::UnresolvedVar(id) => YieldError::UnresolvedVar(id),
+            RuntimeError::NullFunPtr => YieldError::NullFunPtr,
+            RuntimeError::BadFunPtrTag(tag) => YieldError::BadFunPtrTag(tag),
+            RuntimeError::HeapOverflow => YieldError::HeapOverflow,
+        }
+    }
+}

--- a/tidepool-codegen/tests/signal_safety.rs
+++ b/tidepool-codegen/tests/signal_safety.rs
@@ -1,4 +1,12 @@
 //! Test that sigsetjmp/siglongjmp signal protection actually works.
+//!
+//! These tests MUST NOT run concurrently: the signal protection uses a global
+//! JMP_BUF, so concurrent signal-catching tests will race and crash.
+//! A shared mutex serializes them.
+
+use std::sync::Mutex;
+
+static SIGNAL_LOCK: Mutex<()> = Mutex::new(());
 
 /// Trigger an illegal instruction (SIGILL).
 /// Separate function to prevent the compiler from optimizing away the fault.
@@ -12,6 +20,7 @@ unsafe fn trigger_sigill() {
 
 #[test]
 fn test_sigill_returns_signal_error() {
+    let _lock = SIGNAL_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     tidepool_codegen::signal_safety::install();
 
     let result = unsafe {
@@ -31,6 +40,7 @@ fn test_sigill_returns_signal_error() {
 
 #[test]
 fn test_normal_execution_returns_ok() {
+    let _lock = SIGNAL_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     tidepool_codegen::signal_safety::install();
 
     let result = unsafe { tidepool_codegen::signal_safety::with_signal_protection(|| 42i32) };
@@ -40,6 +50,7 @@ fn test_normal_execution_returns_ok() {
 
 #[test]
 fn test_signal_recovery_allows_subsequent_calls() {
+    let _lock = SIGNAL_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     tidepool_codegen::signal_safety::install();
 
     // First call: crash


### PR DESCRIPTION
## Summary
- Use `libc` constants instead of hardcoded signal numbers in `yield_type.rs` — SIGBUS is 10 on macOS, not 7 (Linux). This was causing "unknown signal" errors on macOS aarch64.
- When a signal fires after `debug_app_check` sets a `RuntimeError` (e.g. `BadFunPtrTag(255)`), prefer the more specific error over the raw signal number. Previously the `BadFunPtrTag` was silently dropped.
- Serialize signal safety tests with a mutex — they race on the global `JMP_BUF` when cargo runs them in parallel.
- Install `SIGTRAP` handler (Cranelift may emit `brk` on aarch64).

## Test plan
- [x] `cargo test --package tidepool-codegen` — 240/240 pass (signal_safety tests no longer flaky)
- [x] `cargo test --package tidepool-runtime` — 286/287 pass (1 pre-existing timeout in `test_full_mcp_async_channel_pattern`)
- [x] MCP eval verified on arm64: all 8 effects working

🤖 Generated with [Claude Code](https://claude.com/claude-code)