### PR TITLE
feat: convert emit panic!() to Result errors & fix CI build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,8 @@
             pkgs.haskell.compiler.ghc912
             pkgs.cabal-install
             pkgs.pkg-config
+            pkgs.openssl
+            pkgs.zlib
           ];
 
           shellHook = ''

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -446,20 +446,16 @@ fn emit_lam(
 
     let captures: Vec<(VarId, SsaVal)> = sorted_fvs
         .iter()
-        .map(|v| {
-            let val = ctx.env.get(v).unwrap_or_else(|| {
-                panic!(
-                    "Lam capture: VarId({:#x}) not in env. env keys: {:?}",
-                    v.0,
-                    ctx.env
-                        .keys()
-                        .map(|k| format!("{:#x}", k.0))
-                        .collect::<Vec<_>>()
+        .map(|v| -> Result<(VarId, SsaVal), EmitError> {
+            let val = ctx.env.get(v).ok_or_else(|| {
+                EmitError::MissingCaptureVar(
+                    *v,
+                    format!("Lam capture: not in env (env has {} vars)", ctx.env.len()),
                 )
-            });
-            (*v, *val)
+            })?;
+            Ok((*v, *val))
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     let lambda_name = ctx.next_lambda_name();
     let mut closure_sig = Signature::new(pipeline.isa.default_call_conv());
@@ -1314,12 +1310,12 @@ impl EmitContext {
                     // These are captures of Lam/Con bindings (or trivial simple bindings)
                     // that were not in env during Phase 1 but are now in env.
                     for (var_id, updates) in pending_capture_updates {
-                        let ssaval = self.env.get(&var_id).unwrap_or_else(|| {
-                            panic!(
-                                "LetRec capture fill: VarId({:#x}) not in env after Phase 3c.",
-                                var_id.0
-                            );
-                        });
+                        let ssaval = self.env.get(&var_id).ok_or_else(|| {
+                            EmitError::MissingCaptureVar(
+                                var_id,
+                                "LetRec Phase 3a' capture fill: not in env after Phase 3c".into(),
+                            )
+                        })?;
                         let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, *ssaval);
                         for (closure_ptr, offset) in updates {
                             builder

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -68,6 +68,8 @@ pub enum EmitError {
     CraneliftError(String),
     Pipeline(crate::pipeline::PipelineError),
     InvalidArity(PrimOpKind, usize, usize),
+    /// A variable needed for closure capture was not found in the environment.
+    MissingCaptureVar(VarId, String),
 }
 
 impl std::fmt::Display for EmitError {
@@ -83,6 +85,9 @@ impl std::fmt::Display for EmitError {
                     "invalid arity for {:?}: expected {}, got {}",
                     op, expected, got
                 )
+            }
+            EmitError::MissingCaptureVar(v, ctx) => {
+                write!(f, "missing capture variable VarId({:#x}): {}", v.0, ctx)
             }
         }
     }


### PR DESCRIPTION
This PR implements Plan 4: Convert emit panic!() to Result errors.

Summary of changes:
- Added `MissingCaptureVar(VarId, String)` variant to `EmitError` in `tidepool-codegen/src/emit/mod.rs`.
- Replaced two `panic!` calls in `tidepool-codegen/src/emit/expr.rs` (in `emit_lam` and `emit_node`'s LetRec Phase 3a' capture fill) with `Result` errors returning `EmitError::MissingCaptureVar`.
- Explicitly specified the return type for the closure in `emit_lam`'s `map` to assist the compiler with type inference.
- Fixed a CI build failure by adding `openssl` and `zlib` to `flake.nix`. This was necessary because a recent commit on `main` added `git2` which requires these system libraries, but `flake.nix` hadn't been updated yet.

These changes make compiler bugs (missing VarId in environment) recoverable and provide clearer error messages instead of fatal panics that kill the evaluation thread.

Verified with `nix develop --command cargo test --workspace`.