### PR TITLE
feat: iterative deep_force to avoid stack overflow

### DIFF
--- a/haskell/test/Suite.hs
+++ b/haskell/test/Suite.hs
@@ -35,7 +35,7 @@ lit_char_newline :: Char
 lit_char_newline = '\n'
 
 lit_double_pi :: Double
-lit_double_pi = 3.1
+lit_double_pi = 3.14159
 
 lit_double_neg :: Double
 lit_double_neg = -2.5

--- a/haskell/test/Suite.hs
+++ b/haskell/test/Suite.hs
@@ -35,7 +35,7 @@ lit_char_newline :: Char
 lit_char_newline = '\n'
 
 lit_double_pi :: Double
-lit_double_pi = 3.14159
+lit_double_pi = 3.1
 
 lit_double_neg :: Double
 lit_double_neg = -2.5

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -720,6 +720,7 @@ impl EmitContext {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn emit_node(
         &mut self,
         pipeline: &mut CodegenPipeline,

--- a/tidepool-eval/src/error.rs
+++ b/tidepool-eval/src/error.rs
@@ -56,6 +56,8 @@ pub enum EvalError {
     UserError,
     /// Haskell `undefined` forced
     Undefined,
+    /// Recursion depth limit exceeded during deep_force
+    DepthLimit,
 }
 
 impl std::fmt::Display for EvalError {
@@ -84,6 +86,7 @@ impl std::fmt::Display for EvalError {
             EvalError::UnboundJoin(id) => write!(f, "jump to unbound join point: j_{}", id.0),
             EvalError::UserError => write!(f, "Haskell error called"),
             EvalError::Undefined => write!(f, "Haskell undefined forced"),
+            EvalError::DepthLimit => write!(f, "recursion depth limit exceeded"),
         }
     }
 }

--- a/tidepool-eval/src/error.rs
+++ b/tidepool-eval/src/error.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for EvalError {
             EvalError::UnboundJoin(id) => write!(f, "jump to unbound join point: j_{}", id.0),
             EvalError::UserError => write!(f, "Haskell error called"),
             EvalError::Undefined => write!(f, "Haskell undefined forced"),
-            EvalError::DepthLimit => write!(f, "recursion depth limit exceeded"),
+            EvalError::DepthLimit => write!(f, "deep_force depth limit exceeded"),
         }
     }
 }
@@ -116,6 +116,9 @@ mod tests {
             EvalError::HeapExhausted,
             EvalError::NotAFunction,
             EvalError::UnboundJoin(JoinId(7)),
+            EvalError::UserError,
+            EvalError::Undefined,
+            EvalError::DepthLimit,
         ];
 
         for err in errs {

--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -66,28 +66,60 @@ pub fn force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
 
 /// Recursively force a value — forces all thunks inside constructors,
 /// producing a fully-evaluated tree with no `ThunkRef` values.
+/// This implementation is iterative to avoid stack overflow on deep structures.
 pub fn deep_force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
-    match val {
-        Value::ThunkRef(id) => {
-            let forced = force(Value::ThunkRef(id), heap)?;
-            deep_force(forced, heap)
-        }
-        Value::Con(tag, fields) => {
-            let mut forced_fields = Vec::with_capacity(fields.len());
-            for f in fields {
-                forced_fields.push(deep_force(f, heap)?);
-            }
-            Ok(Value::Con(tag, forced_fields))
-        }
-        Value::ConFun(tag, arity, args) => {
-            let mut forced_args = Vec::with_capacity(args.len());
-            for a in args {
-                forced_args.push(deep_force(a, heap)?);
-            }
-            Ok(Value::ConFun(tag, arity, forced_args))
-        }
-        other => Ok(other), // Lit, Closure, JoinCont — already values
+    const MAX_DEPTH: usize = 100_000;
+
+    enum Work {
+        Force(Value),
+        BuildCon(DataConId, usize),           // (tag, num_fields)
+        BuildConFun(DataConId, usize, usize), // (tag, arity, num_args)
     }
+
+    let mut stack: Vec<Work> = vec![Work::Force(val)];
+    let mut results: Vec<Value> = Vec::new();
+
+    while let Some(work) = stack.pop() {
+        if stack.len() > MAX_DEPTH {
+            return Err(EvalError::DepthLimit);
+        }
+        match work {
+            Work::Force(v) => match v {
+                Value::ThunkRef(id) => {
+                    let forced = force(Value::ThunkRef(id), heap)?;
+                    stack.push(Work::Force(forced));
+                }
+                Value::Con(tag, fields) => {
+                    let n = fields.len();
+                    stack.push(Work::BuildCon(tag, n));
+                    // Push fields in reverse so they're processed in order
+                    for f in fields.into_iter().rev() {
+                        stack.push(Work::Force(f));
+                    }
+                }
+                Value::ConFun(tag, arity, args) => {
+                    let n = args.len();
+                    stack.push(Work::BuildConFun(tag, arity, n));
+                    for a in args.into_iter().rev() {
+                        stack.push(Work::Force(a));
+                    }
+                }
+                other => results.push(other),
+            },
+            Work::BuildCon(tag, n) => {
+                let start = results.len() - n;
+                let fields = results.split_off(start);
+                results.push(Value::Con(tag, fields));
+            }
+            Work::BuildConFun(tag, arity, n) => {
+                let start = results.len() - n;
+                let args = results.split_off(start);
+                results.push(Value::ConFun(tag, arity, args));
+            }
+        }
+    }
+
+    Ok(results.pop().expect("deep_force produced no result"))
 }
 
 /// Evaluate the node at `idx` in the expression tree.
@@ -2481,5 +2513,35 @@ mod tests {
         // Now y is forced, should FAIL
         let res = eval(&expr, &Env::new(), &mut heap);
         assert!(matches!(res, Err(EvalError::UnboundVar(VarId(999)))));
+    }
+
+    #[test]
+    fn test_deep_force_iterative() {
+        // Construct a 200-deep chain of Con(DataConId(1), [prev])
+        // This would overflow the old recursive deep_force (~50 limit)
+        let mut current = Value::Lit(Literal::LitInt(42));
+        for _ in 0..200 {
+            current = Value::Con(DataConId(1), vec![current]);
+        }
+
+        let mut heap = crate::heap::VecHeap::new();
+        let forced = deep_force(current, &mut heap).unwrap();
+
+        // Verify we can traverse it
+        let mut current = forced;
+        for _ in 0..200 {
+            if let Value::Con(tag, fields) = current {
+                assert_eq!(tag.0, 1);
+                assert_eq!(fields.len(), 1);
+                current = fields.into_iter().next().unwrap();
+            } else {
+                panic!("Expected Con at depth");
+            }
+        }
+        if let Value::Lit(Literal::LitInt(n)) = current {
+            assert_eq!(n, 42);
+        } else {
+            panic!("Expected LitInt(42) at bottom");
+        }
     }
 }

--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -64,54 +64,58 @@ pub fn force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
     }
 }
 
-/// Recursively force a value — forces all thunks inside constructors,
-/// producing a fully-evaluated tree with no `ThunkRef` values.
-/// This implementation is iterative to avoid stack overflow on deep structures.
+/// Fully force a value — forces all thunks inside constructors,
+/// producing a fully evaluated tree with no `ThunkRef` values.
+/// Implemented iteratively to avoid stack overflow on deep structures.
 pub fn deep_force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
     const MAX_DEPTH: usize = 100_000;
 
     enum Work {
-        Force(Value),
+        Force(Value, usize),                  // (value, current_depth)
         BuildCon(DataConId, usize),           // (tag, num_fields)
         BuildConFun(DataConId, usize, usize), // (tag, arity, num_args)
     }
 
-    let mut stack: Vec<Work> = vec![Work::Force(val)];
+    let mut stack: Vec<Work> = vec![Work::Force(val, 0)];
     let mut results: Vec<Value> = Vec::new();
 
     while let Some(work) = stack.pop() {
-        if stack.len() > MAX_DEPTH {
-            return Err(EvalError::DepthLimit);
-        }
         match work {
-            Work::Force(v) => match v {
-                Value::ThunkRef(id) => {
-                    let forced = force(Value::ThunkRef(id), heap)?;
-                    stack.push(Work::Force(forced));
+            Work::Force(v, depth) => {
+                if depth > MAX_DEPTH {
+                    return Err(EvalError::DepthLimit);
                 }
-                Value::Con(tag, fields) => {
-                    let n = fields.len();
-                    stack.push(Work::BuildCon(tag, n));
-                    // Push fields in reverse so they're processed in order
-                    for f in fields.into_iter().rev() {
-                        stack.push(Work::Force(f));
+                match v {
+                    Value::ThunkRef(id) => {
+                        let forced = force(Value::ThunkRef(id), heap)?;
+                        stack.push(Work::Force(forced, depth));
                     }
-                }
-                Value::ConFun(tag, arity, args) => {
-                    let n = args.len();
-                    stack.push(Work::BuildConFun(tag, arity, n));
-                    for a in args.into_iter().rev() {
-                        stack.push(Work::Force(a));
+                    Value::Con(tag, fields) => {
+                        let n = fields.len();
+                        stack.push(Work::BuildCon(tag, n));
+                        // Push fields in reverse so they're processed in order
+                        for f in fields.into_iter().rev() {
+                            stack.push(Work::Force(f, depth + 1));
+                        }
                     }
+                    Value::ConFun(tag, arity, args) => {
+                        let n = args.len();
+                        stack.push(Work::BuildConFun(tag, arity, n));
+                        for a in args.into_iter().rev() {
+                            stack.push(Work::Force(a, depth + 1));
+                        }
+                    }
+                    other => results.push(other),
                 }
-                other => results.push(other),
-            },
+            }
             Work::BuildCon(tag, n) => {
+                debug_assert!(results.len() >= n, "deep_force: not enough fields for BuildCon");
                 let start = results.len() - n;
                 let fields = results.split_off(start);
                 results.push(Value::Con(tag, fields));
             }
             Work::BuildConFun(tag, arity, n) => {
+                debug_assert!(results.len() >= n, "deep_force: not enough args for BuildConFun");
                 let start = results.len() - n;
                 let args = results.split_off(start);
                 results.push(Value::ConFun(tag, arity, args));
@@ -119,7 +123,8 @@ pub fn deep_force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
         }
     }
 
-    Ok(results.pop().expect("deep_force produced no result"))
+    debug_assert_eq!(results.len(), 1, "deep_force: expected exactly one result");
+    results.pop().ok_or(EvalError::DepthLimit)
 }
 
 /// Evaluate the node at `idx` in the expression tree.

--- a/tidepool-eval/src/value.rs
+++ b/tidepool-eval/src/value.rs
@@ -109,7 +109,7 @@ mod tests {
             Value::Lit(Literal::LitString(b"with \"quotes\"".to_vec())).to_string(),
             "\"with \\\"quotes\\\"\""
         );
-        assert_eq!(Value::Lit(Literal::from(3.14f64)).to_string(), "3.14");
+        assert_eq!(Value::Lit(Literal::from(1.23f64)).to_string(), "1.23");
         assert_eq!(
             Value::Lit(Literal::LitFloat(0xFFFF_FFFF_FFFF_FFFF)).to_string(),
             "<invalid f32 bits=0xffffffffffffffff>"

--- a/tidepool-eval/src/value.rs
+++ b/tidepool-eval/src/value.rs
@@ -92,6 +92,7 @@ mod tests {
     use tidepool_repr::{CoreFrame, RecursiveTree};
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_value_display() {
         let env = Env::new();
         let expr = RecursiveTree {
@@ -109,7 +110,7 @@ mod tests {
             Value::Lit(Literal::LitString(b"with \"quotes\"".to_vec())).to_string(),
             "\"with \\\"quotes\\\"\""
         );
-        assert_eq!(Value::Lit(Literal::from(1.23f64)).to_string(), "1.23");
+        assert_eq!(Value::Lit(Literal::from(3.14f64)).to_string(), "3.14");
         assert_eq!(
             Value::Lit(Literal::LitFloat(0xFFFF_FFFF_FFFF_FFFF)).to_string(),
             "<invalid f32 bits=0xffffffffffffffff>"

--- a/tidepool-eval/tests/haskell_suite.rs
+++ b/tidepool-eval/tests/haskell_suite.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::approx_constant)]
 //! End-to-end tests: Haskell source → GHC → Translate → CBOR → Rust deser → eval
 //!
 //! Each test loads a pre-compiled CBOR fixture from haskell/test/suite_cbor/,
@@ -242,7 +243,8 @@ suite_int!(lit_neg_large, -999_999);
 suite_char!(lit_char_a, 'a');
 suite_char!(lit_char_z, 'z');
 suite_char!(lit_char_newline, '\n');
-suite_double!(lit_double_pi, 3.1);
+
+suite_double!(lit_double_pi, 3.14159);
 suite_double!(lit_double_neg, -2.5);
 
 // =============================================================================

--- a/tidepool-eval/tests/haskell_suite.rs
+++ b/tidepool-eval/tests/haskell_suite.rs
@@ -242,7 +242,7 @@ suite_int!(lit_neg_large, -999_999);
 suite_char!(lit_char_a, 'a');
 suite_char!(lit_char_z, 'z');
 suite_char!(lit_char_newline, '\n');
-suite_double!(lit_double_pi, 3.14159);
+suite_double!(lit_double_pi, 3.1);
 suite_double!(lit_double_neg, -2.5);
 
 // =============================================================================

--- a/tidepool-mcp/Cargo.toml
+++ b/tidepool-mcp/Cargo.toml
@@ -17,7 +17,7 @@ tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }
 rmcp = { version = "0.16", features = ["server", "transport-io", "transport-streamable-http-server"] }
 axum = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-util", "signal"] }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 dyn-clone = "1.0"

--- a/tidepool-repr/src/serial/read.rs
+++ b/tidepool-repr/src/serial/read.rs
@@ -171,13 +171,10 @@ fn parse_warnings(val: &Value) -> MetaWarnings {
     if let Value::Map(pairs) = val {
         for (k, v) in pairs {
             if let Value::Text(key) = k {
-                match key.as_str() {
-                    "has_io" => {
-                        if let Value::Bool(b) = v {
-                            warnings.has_io = *b;
-                        }
+                if key.as_str() == "has_io" {
+                    if let Value::Bool(b) = v {
+                        warnings.has_io = *b;
                     }
-                    _ => {} // ignore unknown keys for forward compat
                 }
             }
         }


### PR DESCRIPTION
This PR converts the `deep_force` function in `tidepool-eval` from a recursive implementation to an iterative one using an explicit work stack. This avoids stack overflows on deep structures (like long lists) which was occurring at ~50 iterations.

Changes:
- Added `EvalError::DepthLimit` to handle cases where the structure is too deep (currently set to 100,000).
- Rewrote `deep_force` to use a post-order traversal with an explicit stack.
- Added a test case `test_deep_force_iterative` with 200-deep nesting to verify the fix.

Verified with `cargo test -p tidepool-eval`.