### PR TITLE
feat: cap Run/RunIn exec output to prevent OOM

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,9 @@
             pkgs.haskell.compiler.ghc912
             pkgs.cabal-install
             pkgs.pkg-config
+            pkgs.openssl
+            pkgs.libssh2
+            pkgs.zlib
           ];
 
           shellHook = ''

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -2185,6 +2185,36 @@ mod tests {
         assert!(matches!(req, ExecReq::RunIn(ref d, ref c) if d == "/tmp" && c == "ls"));
     }
 
+    #[test]
+    fn test_exec_run_truncation() {
+        let table = full_effect_test_table();
+        let captured = CapturedOutput::new();
+        let cx = EffectContext::with_user(&table, &captured);
+        let mut handler = ExecHandler::new(std::env::current_dir().unwrap());
+
+        // Command that produces more than 2MB of output.
+        // 200,000 lines of ~20 bytes each is ~4MB.
+        let cmd = "for i in $(seq 1 200000); do echo \"hello world $i\"; done";
+
+        let result = handler.handle(ExecReq::Run(cmd.to_string()), &cx).unwrap();
+
+        // Exec result is (i64, String, String) -> (,,) I# Text Text
+        if let Value::Con(id, fields) = result {
+            assert_eq!(table.name_of(id).unwrap(), "(,,)");
+            assert_eq!(fields.len(), 3);
+
+            // fields[1] is stdout (Text)
+            let stdout: String = String::from_value(&fields[1], &table).unwrap();
+            assert!(stdout.len() >= ExecHandler::MAX_EXEC_OUTPUT_BYTES);
+            assert!(stdout.contains("...[truncated at 2MB]"));
+            // The length should be exactly MAX_EXEC_OUTPUT_BYTES + truncation message length
+            // but we use a range to be safe against small UTF-8 boundary variations.
+            assert!(stdout.len() < ExecHandler::MAX_EXEC_OUTPUT_BYTES + 100);
+        } else {
+            panic!("Expected (,,) Con, got {:?}", result);
+        }
+    }
+
     // === Meta roundtrip tests ===
 
     #[test]

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -788,6 +788,7 @@ impl ExecHandler {
     /// Maximum stdout size for RunJson (512 KB). Large JSON creates tens of
     /// thousands of Value nodes that can crash the JIT.
     const MAX_JSON_OUTPUT_BYTES: usize = 512 * 1024;
+    const MAX_EXEC_OUTPUT_BYTES: usize = 2 * 1024 * 1024; // 2MB cap for Run/RunIn
 
     fn run_command(
         &self,
@@ -803,8 +804,27 @@ impl ExecHandler {
             .output()
             .map_err(|e| EffectError::Handler(format!("exec failed: {}", e)))?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let mut stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let mut stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if stdout.len() > Self::MAX_EXEC_OUTPUT_BYTES {
+            let mut end = Self::MAX_EXEC_OUTPUT_BYTES;
+            while !stdout.is_char_boundary(end) {
+                end -= 1;
+            }
+            stdout.truncate(end);
+            stdout.push_str("\n...[truncated at 2MB]");
+        }
+
+        if stderr.len() > Self::MAX_EXEC_OUTPUT_BYTES {
+            let mut end = Self::MAX_EXEC_OUTPUT_BYTES;
+            while !stderr.is_char_boundary(end) {
+                end -= 1;
+            }
+            stderr.truncate(end);
+            stderr.push_str("\n...[truncated at 2MB]");
+        }
+
         let code = output.status.code().unwrap_or(-1) as i64;
         Ok((code, stdout, stderr))
     }


### PR DESCRIPTION
This PR implements the plan in `plans/plan-02-cap-exec-output.md`.

It adds a 2MB cap for `Run`/`RunIn` execution output to prevent OOM.
The `run_command` helper in `tidepool/src/main.rs` now truncates `stdout` and `stderr` if they exceed the cap, while ensuring UTF-8 char-boundary safety.

Changes:
- Added `MAX_EXEC_OUTPUT_BYTES: usize = 2 * 1024 * 1024` constant to `ExecHandler`.
- Updated `run_command` to truncate output and append a truncation message.
