### PR TITLE
fix(tide): resolve FsHandler paths and keep REPL alive on error

### DIFF
--- a/examples/tide/src/handlers.rs
+++ b/examples/tide/src/handlers.rs
@@ -325,7 +325,24 @@ pub enum FsReq {
     FsWrite(String, String),
 }
 
-pub struct FsHandler;
+pub struct FsHandler {
+    working_dir: PathBuf,
+}
+
+impl FsHandler {
+    pub fn new(working_dir: PathBuf) -> Self {
+        FsHandler { working_dir }
+    }
+
+    fn resolve(&self, path: &str) -> PathBuf {
+        let p = PathBuf::from(path);
+        if p.is_absolute() {
+            p
+        } else {
+            self.working_dir.join(p)
+        }
+    }
+}
 
 impl EffectHandler for FsHandler {
     type Request = FsReq;
@@ -333,13 +350,13 @@ impl EffectHandler for FsHandler {
     fn handle(&mut self, req: FsReq, cx: &EffectContext) -> Result<Value, EffectError> {
         match req {
             FsReq::FsRead(path) => {
-                let path = PathBuf::from(path);
+                let path = self.resolve(&path);
                 info!("Reading file: {}", path.display());
                 let contents = std::fs::read_to_string(&path).map_err(TideError::from)?;
                 cx.respond(contents)
             }
             FsReq::FsWrite(path, contents) => {
-                let path = PathBuf::from(path);
+                let path = self.resolve(&path);
                 info!("Writing file: {}", path.display());
                 std::fs::write(&path, &contents).map_err(TideError::from)?;
                 cx.respond(())

--- a/examples/tide/src/main.rs
+++ b/examples/tide/src/main.rs
@@ -63,12 +63,19 @@ fn run(args: Args) -> Result<()> {
         ConsoleHandler,
         EnvHandler::new(),
         NetHandler,
-        FsHandler,
+        FsHandler::new(std::env::current_dir()?),
     ];
 
     // Run: the JIT executes Haskell, yielding effect requests back to Rust.
-    vm.run(&table, &mut handlers, &())
-        .map_err(|e| anyhow::anyhow!("Runtime error: {}", e))?;
+    // Loop to keep the REPL alive on handler errors.
+    loop {
+        match vm.run(&table, &mut handlers, &()) {
+            Ok(_) => break,
+            Err(e) => {
+                eprintln!("Error: {}", e);
+            }
+        }
+    }
 
     Ok(())
 }

--- a/examples/tide/src/main.rs
+++ b/examples/tide/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use tidepool_codegen::jit_machine::JitEffectMachine;
+use tidepool_codegen::jit_machine::{JitEffectMachine, JitError};
+use tidepool_effect::EffectError;
 use tidepool_macro::haskell_inline;
 use tidepool_tide::handlers::{ConsoleHandler, EnvHandler, FsHandler, NetHandler, ReplHandler};
 
@@ -71,9 +72,10 @@ fn run(args: Args) -> Result<()> {
     loop {
         match vm.run(&table, &mut handlers, &()) {
             Ok(_) => break,
-            Err(e) => {
+            Err(JitError::Effect(EffectError::Handler(e))) => {
                 eprintln!("Error: {}", e);
             }
+            Err(e) => return Err(e.into()),
         }
     }
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,11 +83,14 @@
         };
       in {
         devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [
+            pkgs.pkg-config
+          ];
           buildInputs = [
             rust
             pkgs.haskell.compiler.ghc912
             pkgs.cabal-install
-            pkgs.pkg-config
+            pkgs.openssl
           ];
 
           shellHook = ''


### PR DESCRIPTION
This PR updates the `FsHandler` in the Tide REPL example to resolve relative paths against a configurable `working_dir` (defaulting to the current working directory). It also wraps the effect machine's execution in a loop to catch handler errors (like file-not-found) and re-prompt the user instead of exiting the REPL.

Updated based on review comments: The REPL loop now only retries specifically on `EffectError::Handler` runtime errors, ensuring that fatal machine or compilation errors are correctly propagated and don't lead to infinite loops.

Fixed CI failure: Added `pkgs.openssl` to `flake.nix` devShell to fix the `openssl-sys` compilation error caused by the `git2` dependency.

Key changes:
- `FsHandler` now stores a `working_dir: PathBuf`.
- Added `FsHandler::new(working_dir: PathBuf)` and `resolve(&self, path: &str) -> PathBuf`.
- Updated `FsRead` and `FsWrite` handlers to use `resolve`.
- Modified `examples/tide/src/main.rs` to pass `std::env::current_dir()` to `FsHandler`.
- Added a loop around `vm.run` in `main.rs` that only retries on `EffectError::Handler`.
- Verified that `examples/viz/` does not exist (it was already removed).
- Updated `flake.nix` with `openssl` and `pkg-config`.