### PR TITLE
feat(mcp): change eval tool schema from array-of-strings to single-string

### DIFF
--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -79,7 +79,9 @@ pub fn emit_case(
         // Default only
         let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, oom_func, tree, alt.body)?;
         let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, result);
-        builder.ins().jump(merge_block, &[BlockArg::Value(result_ptr)]);
+        builder
+            .ins()
+            .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
         // No alts? Trap.
         builder.ins().trap(TrapCode::unwrap_user(2));
@@ -200,7 +202,9 @@ fn emit_data_dispatch(
             let result =
                 ctx.emit_node(pipeline, builder, vmctx, gc_sig, oom_func, tree, alt.body)?;
             let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, result);
-            builder.ins().jump(merge_block, &[BlockArg::Value(result_ptr)]);
+            builder
+                .ins()
+                .jump(merge_block, &[BlockArg::Value(result_ptr)]);
 
             // Clean up
             for binder in bound_vars {
@@ -218,7 +222,9 @@ fn emit_data_dispatch(
         ctx.declare_env(builder);
         let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, oom_func, tree, alt.body)?;
         let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, result);
-        builder.ins().jump(merge_block, &[BlockArg::Value(result_ptr)]);
+        builder
+            .ins()
+            .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
         emit_case_trap(pipeline, builder, scrut_ptr, data_alts)?;
     }
@@ -370,7 +376,9 @@ fn emit_lit_dispatch(
         ctx.declare_env(builder);
         let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, oom_func, tree, alt.body)?;
         let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, result);
-        builder.ins().jump(merge_block, &[BlockArg::Value(result_ptr)]);
+        builder
+            .ins()
+            .jump(merge_block, &[BlockArg::Value(result_ptr)]);
 
         // Continue to next check
         builder.switch_to_block(next_check_block);
@@ -382,7 +390,9 @@ fn emit_lit_dispatch(
         ctx.declare_env(builder);
         let result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, oom_func, tree, alt.body)?;
         let result_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, result);
-        builder.ins().jump(merge_block, &[BlockArg::Value(result_ptr)]);
+        builder
+            .ins()
+            .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
         builder.ins().trap(TrapCode::unwrap_user(2));
     }

--- a/tidepool-codegen/src/emit/join.rs
+++ b/tidepool-codegen/src/emit/join.rs
@@ -68,9 +68,7 @@ pub fn emit_join(
 
     let rhs_result = ctx.emit_node(pipeline, builder, vmctx, gc_sig, oom_func, tree, rhs_idx)?;
     let rhs_val = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, rhs_result);
-    builder
-        .ins()
-        .jump(merge_block, &[BlockArg::Value(rhs_val)]);
+    builder.ins().jump(merge_block, &[BlockArg::Value(rhs_val)]);
 
     // 7. Seal blocks
     // Body is emitted, so all Jumps to join_block are known.

--- a/tidepool-codegen/src/emit/primop.rs
+++ b/tidepool-codegen/src/emit/primop.rs
@@ -1710,9 +1710,13 @@ fn unbox_addr(
                 .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
 
             let con_block = builder.create_block();
-            builder
-                .ins()
-                .brif(is_con, con_block, &[], next_block, &[BlockArg::Value(curr_v)]);
+            builder.ins().brif(
+                is_con,
+                con_block,
+                &[],
+                next_block,
+                &[BlockArg::Value(curr_v)],
+            );
 
             builder.switch_to_block(con_block);
             builder.seal_block(con_block);
@@ -1778,9 +1782,13 @@ fn unbox_bytearray(
                 .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
 
             let con_block = builder.create_block();
-            builder
-                .ins()
-                .brif(is_con, con_block, &[], next_block, &[BlockArg::Value(curr_v)]);
+            builder.ins().brif(
+                is_con,
+                con_block,
+                &[],
+                next_block,
+                &[BlockArg::Value(curr_v)],
+            );
 
             builder.switch_to_block(con_block);
             builder.seal_block(con_block);
@@ -1842,9 +1850,13 @@ pub fn unbox_int(
                 .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
 
             let con_block = builder.create_block();
-            builder
-                .ins()
-                .brif(is_con, con_block, &[], next_block, &[BlockArg::Value(curr_v)]);
+            builder.ins().brif(
+                is_con,
+                con_block,
+                &[],
+                next_block,
+                &[BlockArg::Value(curr_v)],
+            );
 
             builder.switch_to_block(con_block);
             builder.seal_block(con_block);
@@ -1893,9 +1905,13 @@ pub fn unbox_double(
                 .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
 
             let con_block = builder.create_block();
-            builder
-                .ins()
-                .brif(is_con, con_block, &[], next_block, &[BlockArg::Value(curr_v)]);
+            builder.ins().brif(
+                is_con,
+                con_block,
+                &[],
+                next_block,
+                &[BlockArg::Value(curr_v)],
+            );
 
             builder.switch_to_block(con_block);
             builder.seal_block(con_block);
@@ -1944,9 +1960,13 @@ pub fn unbox_float(
                 .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
 
             let con_block = builder.create_block();
-            builder
-                .ins()
-                .brif(is_con, con_block, &[], next_block, &[BlockArg::Value(curr_v)]);
+            builder.ins().brif(
+                is_con,
+                con_block,
+                &[],
+                next_block,
+                &[BlockArg::Value(curr_v)],
+            );
 
             builder.switch_to_block(con_block);
             builder.seal_block(con_block);

--- a/tidepool-codegen/src/yield_type.rs
+++ b/tidepool-codegen/src/yield_type.rs
@@ -104,7 +104,9 @@ impl std::fmt::Display for YieldError {
                 #[cfg(unix)]
                 {
                     let name = match *sig {
-                        libc::SIGILL => "SIGILL (illegal instruction — likely exhausted case branch)",
+                        libc::SIGILL => {
+                            "SIGILL (illegal instruction — likely exhausted case branch)"
+                        }
                         libc::SIGSEGV => {
                             "SIGSEGV (segmentation fault — likely invalid memory access)"
                         }

--- a/tidepool-heap/src/gc/compact.rs
+++ b/tidepool-heap/src/gc/compact.rs
@@ -71,7 +71,11 @@ fn rewrite_value(val: &Value, table: &ForwardingTable) -> Value {
         Value::Closure(env, binder, expr) => {
             Value::Closure(rewrite_env(env, table), *binder, expr.clone())
         }
-        Value::ThunkRef(id) => Value::ThunkRef(table.lookup(*id).expect("Thunk must be reachable during compact")),
+        Value::ThunkRef(id) => Value::ThunkRef(
+            table
+                .lookup(*id)
+                .expect("Thunk must be reachable during compact"),
+        ),
         Value::JoinCont(binders, expr, env) => {
             Value::JoinCont(binders.clone(), expr.clone(), rewrite_env(env, table))
         }

--- a/tidepool-heap/src/lib.rs
+++ b/tidepool-heap/src/lib.rs
@@ -8,5 +8,5 @@ pub mod gc;
 pub mod layout;
 
 pub use arena::*;
-pub use layout::*;
 pub use gc::trace::GcError;
+pub use layout::*;

--- a/tidepool-macro/src/expand.rs
+++ b/tidepool-macro/src/expand.rs
@@ -529,10 +529,7 @@ fn strip_module_header(source: &str) -> HaskellHeader {
                 }
                 continue;
             }
-            if trimmed.starts_with("{-#")
-                || trimmed.starts_with("module ")
-                || trimmed.is_empty()
-            {
+            if trimmed.starts_with("{-#") || trimmed.starts_with("module ") || trimmed.is_empty() {
                 continue;
             }
             if trimmed.starts_with("import ") {

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -970,7 +970,7 @@ pub fn template_haskell(
     if !imports.is_empty() {
         let insert_point = preamble.find("default (Int").unwrap_or(preamble.len());
         out.push_str(&preamble[..insert_point]);
-        for imp in imports.lines().filter(|l| !l.trim().is_empty()) {
+        for imp in imports.lines().map(|l| l.trim()).filter(|l| !l.is_empty()) {
             out.push_str(&format!("import {}\n", imp));
         }
         out.push_str(&preamble[insert_point..]);
@@ -981,9 +981,11 @@ pub fn template_haskell(
     // Marker for user code section (used by error formatting to trim preamble)
     out.push_str("-- [user]\n");
 
-    out.push_str(helpers);
-    out.push('\n');
     if !helpers.is_empty() {
+        out.push_str(helpers);
+        if !helpers.ends_with('\n') {
+            out.push('\n');
+        }
         out.push('\n');
     }
 
@@ -1290,7 +1292,7 @@ impl TidepoolMcpServerImpl {
         self.cleanup_stale_continuations();
 
         // Reject unsafe/IO imports before compilation
-        for imp in req.imports.lines() {
+        for imp in req.imports.lines().map(|l| l.trim()).filter(|l| !l.is_empty()) {
             if let Some(module) = rejected_import(imp) {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
                     "Blocked import: `{}` is not available in the Tidepool sandbox.",

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -1200,8 +1200,8 @@ impl DispatchEffect<CapturedOutput> for AskDispatcher {
             })?;
 
             // Parse response as JSON → aeson Value; plain text wraps as Aeson.String
-            let json_val: serde_json::Value = serde_json::from_str(&response)
-                .unwrap_or(serde_json::Value::String(response));
+            let json_val: serde_json::Value =
+                serde_json::from_str(&response).unwrap_or(serde_json::Value::String(response));
             let core_val = json_val
                 .to_value(cx.table())
                 .map_err(tidepool_effect::error::EffectError::Bridge)?;
@@ -1292,7 +1292,12 @@ impl TidepoolMcpServerImpl {
         self.cleanup_stale_continuations();
 
         // Reject unsafe/IO imports before compilation
-        for imp in req.imports.lines().map(|l| l.trim()).filter(|l| !l.is_empty()) {
+        for imp in req
+            .imports
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+        {
             if let Some(module) = rejected_import(imp) {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
                     "Blocked import: `{}` is not available in the Tidepool sandbox.",
@@ -1733,10 +1738,12 @@ where
     }
 
     /// Start the MCP server on streamable HTTP transport.
-    pub async fn serve_http(self, addr: std::net::SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn serve_http(
+        self,
+        addr: std::net::SocketAddr,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         use rmcp::transport::streamable_http_server::{
-            StreamableHttpService, StreamableHttpServerConfig,
-            session::local::LocalSessionManager,
+            session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
         };
         use std::sync::Arc;
 
@@ -1995,7 +2002,9 @@ mod tests {
         let preamble = build_preamble(&decls, false);
         assert!(preamble.contains("data Ask a where"));
         assert!(preamble.contains("  Ask :: Text -> Ask Value"));
-        assert!(preamble.contains("type M = Eff '[Console, KV, Fs, SG, Http, Exec, Meta, Git, Ask]"));
+        assert!(
+            preamble.contains("type M = Eff '[Console, KV, Fs, SG, Http, Exec, Meta, Git, Ask]")
+        );
     }
 
     #[test]
@@ -2127,7 +2136,8 @@ mod tests {
 
     #[test]
     fn test_parse_constructor_nested_types() {
-        let p = parse_constructor("HttpRequest :: Text -> Text -> [(Text,Text)] -> Text -> Http Value");
+        let p =
+            parse_constructor("HttpRequest :: Text -> Text -> [(Text,Text)] -> Text -> Http Value");
         assert_eq!(
             p,
             ParsedConstructor {
@@ -2187,7 +2197,9 @@ mod tests {
         let result = template_haskell(&preamble, &stack, source, "", "", Some(&input), None);
 
         assert!(result.contains("input :: Aeson.Value"));
-        assert!(result.contains("input = object [\"val\" .= Aeson.Number (fromIntegral (123 :: Int))]"));
+        assert!(
+            result.contains("input = object [\"val\" .= Aeson.Number (fromIntegral (123 :: Int))]")
+        );
     }
 
     #[test]
@@ -2253,6 +2265,8 @@ mod tests {
         assert!(haskell.contains("\"null\" .= Aeson.Null"));
         assert!(haskell.contains("\"num\" .= Aeson.Number (fromIntegral (42 :: Int))"));
         assert!(haskell.contains("\"arr\" .= toJSON [Aeson.Number (fromIntegral (1 :: Int)), Aeson.Number (fromIntegral (2 :: Int))]"));
-        assert!(haskell.contains("\"obj\" .= object [\"a\" .= Aeson.Number (fromIntegral (1 :: Int))]"));
+        assert!(
+            haskell.contains("\"obj\" .= object [\"a\" .= Aeson.Number (fromIntegral (1 :: Int))]")
+        );
     }
 }

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -340,17 +340,13 @@ pub struct EvalRequest {
     /// Haskell do-notation code. Each line is indented into a do-block.
     /// Use `pure x` as the last line to return a value.
     /// Use `send (Constructor args)` to invoke effects.
-    /// Accepts either a single string (preferred) or array of lines (legacy).
-    #[serde(deserialize_with = "deserialize_code")]
-    pub code: Vec<String>,
+    pub code: String,
     /// Additional Haskell imports, one per line (e.g. "Data.List (sort)").
-    /// Accepts a string (one import per line, preferred) or array of strings.
-    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
-    pub imports: Vec<String>,
+    #[serde(default)]
+    pub imports: String,
     /// Top-level helper definitions placed before the main do-block.
-    /// Accepts a string (raw Haskell, preferred) or array of definition strings.
-    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
-    pub helpers: Vec<String>,
+    #[serde(default)]
+    pub helpers: String,
     /// Optional JSON input injected as `input :: Aeson.Value` binding.
     #[serde(default)]
     pub input: Option<serde_json::Value>,
@@ -359,40 +355,6 @@ pub struct EvalRequest {
     /// Default: 4096.
     #[serde(default)]
     pub max_len: Option<u32>,
-}
-
-/// Deserialize `code` from either a string (split on newlines) or array of strings.
-fn deserialize_code<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Vec<String>, D::Error> {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum StringOrVec {
-        Str(String),
-        Vec(Vec<String>),
-    }
-    match StringOrVec::deserialize(d)? {
-        StringOrVec::Str(s) => Ok(s.lines().map(String::from).collect()),
-        StringOrVec::Vec(v) => Ok(v),
-    }
-}
-
-/// Deserialize from either a string (split on newlines, empty lines filtered) or array of strings.
-fn deserialize_string_or_vec<'de, D: serde::Deserializer<'de>>(
-    d: D,
-) -> Result<Vec<String>, D::Error> {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum StringOrVec {
-        Str(String),
-        Vec(Vec<String>),
-    }
-    match StringOrVec::deserialize(d)? {
-        StringOrVec::Str(s) => Ok(s
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .map(String::from)
-            .collect()),
-        StringOrVec::Vec(v) => Ok(v),
-    }
 }
 
 /// Request parameters for the `resume` tool.
@@ -921,11 +883,12 @@ pub fn build_preamble(effects: &[EffectDecl], user_library: bool) -> String {
 /// Qualified aeson imports for MCP eval. Unqualified symbols now come from Tidepool.Prelude.
 /// These provide `Aeson.` prefix (used by json_to_haskell for input injection) and
 /// qualified access to KeyMap/Vector for power users.
-pub fn aeson_imports() -> Vec<String> {
-    vec![
-        "qualified Tidepool.Aeson as Aeson".into(),
-        "qualified Tidepool.Aeson.KeyMap as KM".into(),
-    ]
+pub fn aeson_imports() -> String {
+    concat!(
+        "qualified Tidepool.Aeson as Aeson\n",
+        "qualified Tidepool.Aeson.KeyMap as KM\n",
+    )
+    .into()
 }
 
 pub fn build_effect_stack_type(effects: &[EffectDecl]) -> String {
@@ -993,9 +956,9 @@ fn build_eval_tool_description(effects: &[EffectDecl]) -> String {
 pub fn template_haskell(
     preamble: &str,
     effect_stack: &str,
-    code: &[String],
-    imports: &[String],
-    helpers: &[String],
+    code: &str,
+    imports: &str,
+    helpers: &str,
     input: Option<&serde_json::Value>,
     budget: Option<u32>,
 ) -> String {
@@ -1007,7 +970,7 @@ pub fn template_haskell(
     if !imports.is_empty() {
         let insert_point = preamble.find("default (Int").unwrap_or(preamble.len());
         out.push_str(&preamble[..insert_point]);
-        for imp in imports {
+        for imp in imports.lines().filter(|l| !l.trim().is_empty()) {
             out.push_str(&format!("import {}\n", imp));
         }
         out.push_str(&preamble[insert_point..]);
@@ -1018,10 +981,8 @@ pub fn template_haskell(
     // Marker for user code section (used by error formatting to trim preamble)
     out.push_str("-- [user]\n");
 
-    for helper in helpers {
-        out.push_str(helper);
-        out.push('\n');
-    }
+    out.push_str(helpers);
+    out.push('\n');
     if !helpers.is_empty() {
         out.push('\n');
     }
@@ -1038,7 +999,7 @@ pub fn template_haskell(
         out.push_str("  kvSet \"__sayChars\" (toJSON (0 :: Int))\n");
     }
     out.push_str("  _r <- do\n");
-    for line in code {
+    for line in code.lines() {
         out.push_str(&format!("    {}\n", line));
     }
     if let Some(b) = budget {
@@ -1325,11 +1286,11 @@ impl TidepoolMcpServerImpl {
     }
 
     async fn eval(&self, req: EvalRequest) -> Result<CallToolResult, McpError> {
-        tracing::info!(lines = req.code.len(), "eval request");
+        tracing::info!(len = req.code.len(), "eval request");
         self.cleanup_stale_continuations();
 
         // Reject unsafe/IO imports before compilation
-        for imp in &req.imports {
+        for imp in req.imports.lines() {
             if let Some(module) = rejected_import(imp) {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
                     "Blocked import: `{}` is not available in the Tidepool sandbox.",
@@ -1339,7 +1300,7 @@ impl TidepoolMcpServerImpl {
         }
 
         let mut all_imports = aeson_imports();
-        all_imports.extend(req.imports);
+        all_imports.push_str(&req.imports);
         let source: Arc<str> = template_haskell(
             &self.haskell_preamble,
             &self.effect_stack_type,
@@ -1820,23 +1781,16 @@ mod tests {
     fn test_eval_request_string_code() {
         let json = serde_json::json!({"code": "let x = 1\npure x"});
         let req: EvalRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(req.code, vec!["let x = 1", "pure x"]);
+        assert_eq!(req.code, "let x = 1\npure x");
         assert!(req.imports.is_empty());
         assert!(req.helpers.is_empty());
-    }
-
-    #[test]
-    fn test_eval_request_array_code() {
-        let json = serde_json::json!({"code": ["pure 42"]});
-        let req: EvalRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(req.code, vec!["pure 42"]);
     }
 
     #[test]
     fn test_eval_request_string_imports() {
         let json = serde_json::json!({"code": "pure 42", "imports": "Data.List (sort)\nData.Char"});
         let req: EvalRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(req.imports, vec!["Data.List (sort)", "Data.Char"]);
+        assert_eq!(req.imports, "Data.List (sort)\nData.Char");
     }
 
     #[test]
@@ -1922,9 +1876,9 @@ mod tests {
         }];
         let preamble = build_preamble(&effects, false);
         let stack = build_effect_stack_type(&effects);
-        let source = vec!["let x = 42".into(), "pure x".into()];
+        let source = "let x = 42\npure x";
 
-        let result = template_haskell(&preamble, &stack, &source, &[], &[], None, None);
+        let result = template_haskell(&preamble, &stack, source, "", "", None, None);
 
         assert!(result.contains("module Expr where"));
         assert!(result.contains("import Control.Monad.Freer hiding (run)"));
@@ -2202,15 +2156,15 @@ mod tests {
         }];
         let preamble = build_preamble(&effects, false);
         let stack = build_effect_stack_type(&effects);
-        let source = vec!["pure 42".into()];
+        let source = "pure 42";
 
         // With budget
-        let result = template_haskell(&preamble, &stack, &source, &[], &[], None, Some(1024));
+        let result = template_haskell(&preamble, &stack, source, "", "", None, Some(1024));
         assert!(result.contains("kvSet \"__sayChars\" (toJSON (0 :: Int))"));
         assert!(result.contains("paginateResult (max' 100 (1024 - _sayC)) (toJSON _r)"));
 
         // Without budget (defaults to 4096)
-        let result = template_haskell(&preamble, &stack, &source, &[], &[], None, None);
+        let result = template_haskell(&preamble, &stack, source, "", "", None, None);
         assert!(result.contains("paginateResult 4096 (toJSON _r)"));
     }
 
@@ -2225,10 +2179,10 @@ mod tests {
         }];
         let preamble = build_preamble(&effects, false);
         let stack = build_effect_stack_type(&effects);
-        let source = vec!["pure 42".into()];
+        let source = "pure 42";
         let input = serde_json::json!({"val": 123});
 
-        let result = template_haskell(&preamble, &stack, &source, &[], &[], Some(&input), None);
+        let result = template_haskell(&preamble, &stack, source, "", "", Some(&input), None);
 
         assert!(result.contains("input :: Aeson.Value"));
         assert!(result.contains("input = object [\"val\" .= Aeson.Number (fromIntegral (123 :: Int))]"));
@@ -2265,7 +2219,7 @@ mod tests {
             "helpers": "foo :: Int -> Int\nfoo x = x + 1"
         });
         let req: EvalRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(req.helpers, vec!["foo :: Int -> Int", "foo x = x + 1"]);
+        assert_eq!(req.helpers, "foo :: Int -> Int\nfoo x = x + 1");
     }
 
     #[test]

--- a/tidepool-optimize/tests/proptest_partial_eval.rs
+++ b/tidepool-optimize/tests/proptest_partial_eval.rs
@@ -172,50 +172,50 @@ fn nested_let_propagation() {
             runner
                 .run(&(any::<i64>(), any::<i64>(), any::<i64>()), |(a, b, c)| {
                     let mut builder = TreeBuilder::new();
-                    
-                    // let VarId(1) = Lit(a) in 
-                    // let VarId(2) = PrimOp(IntAdd, [Var(VarId(1)), Lit(b)]) in 
+
+                    // let VarId(1) = Lit(a) in
+                    // let VarId(2) = PrimOp(IntAdd, [Var(VarId(1)), Lit(b)]) in
                     // PrimOp(IntMul, [Var(VarId(2)), Lit(c)])
-                    
+
                     let lit_a = builder.push(CoreFrame::Lit(Literal::LitInt(a)));
                     let lit_b = builder.push(CoreFrame::Lit(Literal::LitInt(b)));
                     let lit_c = builder.push(CoreFrame::Lit(Literal::LitInt(c)));
-                    
+
                     let var1 = builder.push(CoreFrame::Var(VarId(1)));
                     let add = builder.push(CoreFrame::PrimOp {
                         op: PrimOpKind::IntAdd,
                         args: vec![var1, lit_b],
                     });
-                    
+
                     let var2 = builder.push(CoreFrame::Var(VarId(2)));
                     let mul = builder.push(CoreFrame::PrimOp {
                         op: PrimOpKind::IntMul,
                         args: vec![var2, lit_c],
                     });
-                    
+
                     let let2 = builder.push(CoreFrame::LetNonRec {
                         binder: VarId(2),
                         rhs: add,
                         body: mul,
                     });
-                    
+
                     builder.push(CoreFrame::LetNonRec {
                         binder: VarId(1),
                         rhs: lit_a,
                         body: let2,
                     });
-                    
+
                     let expr = builder.build();
-                    
+
                     // Expected value: (a.wrapping_add(b)).wrapping_mul(c)
                     let expected = (a.wrapping_add(b)).wrapping_mul(c);
-                    
+
                     let mut optimized = expr.clone();
                     pass.run(&mut optimized);
-                    
+
                     prop_assert_eq!(optimized.nodes.len(), 1, "Should have folded completely");
                     prop_assert!(matches!(optimized.nodes[0], CoreFrame::Lit(Literal::LitInt(v)) if v == expected));
-                    
+
                     check_pass_preserves_eval(&pass, expr)
                 })
                 .unwrap();
@@ -234,7 +234,7 @@ fn primop_fold_all_foldable_ops() {
                 ..Config::default()
             });
             let pass = PartialEval;
-            
+
             let ops = vec![
                 PrimOpKind::IntAdd,
                 PrimOpKind::IntSub,
@@ -258,7 +258,7 @@ fn primop_fold_all_foldable_ops() {
                         args: vec![lit_a, lit_b],
                     });
                     let expr = builder.build();
-                    
+
                     let expected = match op {
                         PrimOpKind::IntAdd => a.wrapping_add(b),
                         PrimOpKind::IntSub => a.wrapping_sub(b),
@@ -271,13 +271,13 @@ fn primop_fold_all_foldable_ops() {
                         PrimOpKind::IntGe => if a >= b { 1 } else { 0 },
                         _ => unreachable!(),
                     };
-                    
+
                     let mut optimized = expr.clone();
                     pass.run(&mut optimized);
-                    
+
                     prop_assert_eq!(optimized.nodes.len(), 1, "Should have folded {:?} completely", op);
                     prop_assert!(matches!(optimized.nodes[0], CoreFrame::Lit(Literal::LitInt(v)) if v == expected));
-                    
+
                     check_pass_preserves_eval(&pass, expr)
                 })
                 .unwrap();
@@ -305,15 +305,15 @@ fn primop_fold_negate() {
                         args: vec![lit_a],
                     });
                     let expr = builder.build();
-                    
+
                     let expected = a.wrapping_neg();
-                    
+
                     let mut optimized = expr.clone();
                     pass.run(&mut optimized);
-                    
+
                     prop_assert_eq!(optimized.nodes.len(), 1, "Should have folded IntNegate completely");
                     prop_assert!(matches!(optimized.nodes[0], CoreFrame::Lit(Literal::LitInt(v)) if v == expected));
-                    
+
                     check_pass_preserves_eval(&pass, expr)
                 })
                 .unwrap();

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -661,7 +661,6 @@ fn test_aeson_input_transform() {
 #[test]
 fn test_aeson_input_with_effect() {
     let input_val = serde_json::json!({"greeting": "Hello from JSON!"});
-    let imports: Vec<&str> = aeson_import_strs();
     let decls = test_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
@@ -2946,7 +2945,6 @@ fn test_vendored_effect_json_conditional() {
 #[test]
 fn test_vendored_input_with_effects() {
     let input_val = serde_json::json!({"items": ["task1", "task2", "task3"]});
-    let imports: Vec<&str> = aeson_import_strs();
     let decls = test_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -376,15 +376,8 @@ fn run_aeson_with_input(lines: &[&str], input: serde_json::Value) -> serde_json:
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
     let code = lines.join("\n");
     let imports = aeson_import_strs().join("\n");
-    let src = tidepool_mcp::template_haskell(
-        &preamble,
-        &stack,
-        &code,
-        &imports,
-        "",
-        Some(&input),
-        None,
-    );
+    let src =
+        tidepool_mcp::template_haskell(&preamble, &stack, &code, &imports, "", Some(&input), None);
     let pp = prelude_path();
     std::thread::Builder::new()
         .stack_size(8 * 1024 * 1024)

--- a/tidepool-runtime/tests/sort_crash.rs
+++ b/tidepool-runtime/tests/sort_crash.rs
@@ -39,19 +39,19 @@ fn mcp_source_with_helpers(lines: &[&str], helpers: &[&str]) -> String {
     let decls = test_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
-    let lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-    let helpers: Vec<String> = helpers.iter().map(|s| s.to_string()).collect();
-    tidepool_mcp::template_haskell(&preamble, &stack, &lines, &[], &helpers, None, None)
+    let code = lines.join("\n");
+    let helpers = helpers.join("\n");
+    tidepool_mcp::template_haskell(&preamble, &stack, &code, "", &helpers, None, None)
 }
 
 fn mcp_source_with_imports(lines: &[&str], helpers: &[&str], imports: &[&str]) -> String {
     let decls = test_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
-    let lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-    let helpers: Vec<String> = helpers.iter().map(|s| s.to_string()).collect();
-    let imports: Vec<String> = imports.iter().map(|s| s.to_string()).collect();
-    tidepool_mcp::template_haskell(&preamble, &stack, &lines, &imports, &helpers, None, None)
+    let code = lines.join("\n");
+    let helpers = helpers.join("\n");
+    let imports = imports.join("\n");
+    tidepool_mcp::template_haskell(&preamble, &stack, &code, &imports, &helpers, None, None)
 }
 
 fn run_mcp_with_imports(lines: &[&str], helpers: &[&str], imports: &[&str]) -> serde_json::Value {
@@ -339,15 +339,15 @@ fn run_aeson_effectful_with_input(
     let decls = test_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
-    let lines_owned: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-    let imports: Vec<String> = aeson_import_strs().iter().map(|s| s.to_string()).collect();
-    let helpers_owned: Vec<String> = helpers.iter().map(|s| s.to_string()).collect();
+    let code = lines.join("\n");
+    let imports = aeson_import_strs().join("\n");
+    let helpers = helpers.join("\n");
     let src = tidepool_mcp::template_haskell(
         &preamble,
         &stack,
-        &lines_owned,
+        &code,
         &imports,
-        &helpers_owned,
+        &helpers,
         Some(&input),
         None,
     );
@@ -374,14 +374,14 @@ fn run_aeson_with_input(lines: &[&str], input: serde_json::Value) -> serde_json:
     let decls = test_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
-    let lines_owned: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-    let imports: Vec<String> = aeson_import_strs().iter().map(|s| s.to_string()).collect();
+    let code = lines.join("\n");
+    let imports = aeson_import_strs().join("\n");
     let src = tidepool_mcp::template_haskell(
         &preamble,
         &stack,
-        &lines_owned,
+        &code,
         &imports,
-        &[],
+        "",
         Some(&input),
         None,
     );
@@ -666,18 +666,19 @@ fn test_aeson_input_with_effect() {
     let preamble = tidepool_mcp::build_preamble(&decls, false);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
     let lines = vec![
-        r#"case input ^? key "greeting" . _String of"#.to_string(),
-        r#"  Just g  -> send (Print g)"#.to_string(),
-        r#"  Nothing -> pure ()"#.to_string(),
-        r#"pure (input ^? key "greeting" . _String)"#.to_string(),
+        r#"case input ^? key "greeting" . _String of"#,
+        r#"  Just g  -> send (Print g)"#,
+        r#"  Nothing -> pure ()"#,
+        r#"pure (input ^? key "greeting" . _String)"#,
     ];
-    let imports_owned: Vec<String> = imports.iter().map(|s| s.to_string()).collect();
+    let code = lines.join("\n");
+    let imports = aeson_import_strs().join("\n");
     let src = tidepool_mcp::template_haskell(
         &preamble,
         &stack,
-        &lines,
-        &imports_owned,
-        &[],
+        &code,
+        &imports,
+        "",
         Some(&input_val),
         None,
     );
@@ -1052,9 +1053,9 @@ fn full_mcp_source(lines: &[&str]) -> String {
     let decls = full_mcp_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
-    let lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+    let code = lines.join("\n");
     let imports = tidepool_mcp::aeson_imports();
-    tidepool_mcp::template_haskell(&preamble, &stack, &lines, &imports, &[], None, None)
+    tidepool_mcp::template_haskell(&preamble, &stack, &code, &imports, "", None, None)
 }
 
 fn run_full_mcp(lines: &[&str]) -> serde_json::Value {
@@ -2954,13 +2955,14 @@ fn test_vendored_input_with_effects() {
         r#"mapM_ (send . Print) items"#.to_string(),
         r#"pure (length items)"#.to_string(),
     ];
-    let imports_owned: Vec<String> = imports.iter().map(|s| s.to_string()).collect();
+    let code = lines.join("\n");
+    let imports = aeson_import_strs().join("\n");
     let src = tidepool_mcp::template_haskell(
         &preamble,
         &stack,
-        &lines,
-        &imports_owned,
-        &[],
+        &code,
+        &imports,
+        "",
         Some(&input_val),
         None,
     );

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -85,14 +85,20 @@ impl KvHandler {
     fn flush(&self, store: &HashMap<String, serde_json::Value>) {
         if let Some(parent) = self.path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
-                eprintln!("[tidepool] KV flush: failed to create dir {:?}: {}", parent, e);
+                eprintln!(
+                    "[tidepool] KV flush: failed to create dir {:?}: {}",
+                    parent, e
+                );
                 return;
             }
         }
         match serde_json::to_string_pretty(store) {
             Ok(json) => {
                 if let Err(e) = std::fs::write(&self.path, json) {
-                    eprintln!("[tidepool] KV flush: failed to write {:?}: {}", self.path, e);
+                    eprintln!(
+                        "[tidepool] KV flush: failed to write {:?}: {}",
+                        self.path, e
+                    );
                 }
             }
             Err(e) => {
@@ -397,7 +403,10 @@ impl SgHandler {
             let entry = entry.map_err(|e| EffectError::Handler(e.to_string()))?;
             let path = entry.path();
             if path.is_dir() {
-                let name = path.file_name().map(|n| n.to_string_lossy()).unwrap_or_default();
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy())
+                    .unwrap_or_default();
                 if name.starts_with('.') || matches!(name.as_ref(), "target" | "node_modules") {
                     continue;
                 }
@@ -819,13 +828,17 @@ impl ExecHandler {
         let mut stderr = String::from_utf8_lossy(&output.stderr).to_string();
         if stdout.len() > Self::MAX_EXEC_OUTPUT_BYTES {
             let mut end = Self::MAX_EXEC_OUTPUT_BYTES;
-            while !stdout.is_char_boundary(end) { end -= 1; }
+            while !stdout.is_char_boundary(end) {
+                end -= 1;
+            }
             stdout.truncate(end);
             stdout.push_str("\n...[truncated at 2MB]");
         }
         if stderr.len() > Self::MAX_EXEC_OUTPUT_BYTES {
             let mut end = Self::MAX_EXEC_OUTPUT_BYTES;
-            while !stderr.is_char_boundary(end) { end -= 1; }
+            while !stderr.is_char_boundary(end) {
+                end -= 1;
+            }
             stderr.truncate(end);
             stderr.push_str("\n...[truncated at 2MB]");
         }
@@ -939,9 +952,9 @@ impl EffectHandler<CapturedOutput> for GitHandler {
         let repo = self.open_repo()?;
         match req {
             GitReq::Log(refspec, count) => {
-                let obj = repo
-                    .revparse_single(&refspec)
-                    .map_err(|e| EffectError::Handler(format!("git log: bad ref '{}': {}", refspec, e)))?;
+                let obj = repo.revparse_single(&refspec).map_err(|e| {
+                    EffectError::Handler(format!("git log: bad ref '{}': {}", refspec, e))
+                })?;
                 let mut revwalk = repo
                     .revwalk()
                     .map_err(|e| EffectError::Handler(format!("git log: revwalk: {}", e)))?;
@@ -956,8 +969,9 @@ impl EffectHandler<CapturedOutput> for GitHandler {
                     }
                     let oid = oid_result
                         .map_err(|e| EffectError::Handler(format!("git log: walk: {}", e)))?;
-                    let commit = repo.find_commit(oid)
-                        .map_err(|e| EffectError::Handler(format!("git log: find commit: {}", e)))?;
+                    let commit = repo.find_commit(oid).map_err(|e| {
+                        EffectError::Handler(format!("git log: find commit: {}", e))
+                    })?;
                     entries.push(serde_json::json!({
                         "hash": oid.to_string(),
                         "subject": commit.summary().unwrap_or(""),
@@ -970,9 +984,12 @@ impl EffectHandler<CapturedOutput> for GitHandler {
             GitReq::Show(hash) => {
                 let oid = repo
                     .revparse_single(&hash)
-                    .map_err(|e| EffectError::Handler(format!("git show: bad ref '{}': {}", hash, e)))?
+                    .map_err(|e| {
+                        EffectError::Handler(format!("git show: bad ref '{}': {}", hash, e))
+                    })?
                     .id();
-                let commit = repo.find_commit(oid)
+                let commit = repo
+                    .find_commit(oid)
                     .map_err(|e| EffectError::Handler(format!("git show: {}", e)))?;
                 let parents: Vec<String> = commit.parent_ids().map(|id| id.to_string()).collect();
                 let result = serde_json::json!({
@@ -988,17 +1005,26 @@ impl EffectHandler<CapturedOutput> for GitHandler {
             GitReq::Diff(hash) => {
                 let oid = repo
                     .revparse_single(&hash)
-                    .map_err(|e| EffectError::Handler(format!("git diff: bad ref '{}': {}", hash, e)))?
+                    .map_err(|e| {
+                        EffectError::Handler(format!("git diff: bad ref '{}': {}", hash, e))
+                    })?
                     .id();
-                let commit = repo.find_commit(oid)
+                let commit = repo
+                    .find_commit(oid)
                     .map_err(|e| EffectError::Handler(format!("git diff: {}", e)))?;
-                let tree = commit.tree()
+                let tree = commit
+                    .tree()
                     .map_err(|e| EffectError::Handler(format!("git diff: tree: {}", e)))?;
                 let parent_tree = if commit.parent_count() > 0 {
-                    Some(commit.parent(0)
-                        .map_err(|e| EffectError::Handler(format!("git diff: parent: {}", e)))?
-                        .tree()
-                        .map_err(|e| EffectError::Handler(format!("git diff: parent tree: {}", e)))?)
+                    Some(
+                        commit
+                            .parent(0)
+                            .map_err(|e| EffectError::Handler(format!("git diff: parent: {}", e)))?
+                            .tree()
+                            .map_err(|e| {
+                                EffectError::Handler(format!("git diff: parent tree: {}", e))
+                            })?,
+                    )
                 } else {
                     None
                 };
@@ -1065,20 +1091,21 @@ impl EffectHandler<CapturedOutput> for GitHandler {
                 cx.respond(hunks)
             }
             GitReq::Tree(commitish, path) => {
-                let obj = repo
-                    .revparse_single(&commitish)
-                    .map_err(|e| EffectError::Handler(format!("git tree: bad ref '{}': {}", commitish, e)))?;
+                let obj = repo.revparse_single(&commitish).map_err(|e| {
+                    EffectError::Handler(format!("git tree: bad ref '{}': {}", commitish, e))
+                })?;
                 let commit = obj
                     .peel_to_commit()
                     .map_err(|e| EffectError::Handler(format!("git tree: peel: {}", e)))?;
-                let tree = commit.tree()
+                let tree = commit
+                    .tree()
                     .map_err(|e| EffectError::Handler(format!("git tree: {}", e)))?;
                 let target_tree = if path == "." || path.is_empty() {
                     tree
                 } else {
-                    let entry = tree
-                        .get_path(std::path::Path::new(&path))
-                        .map_err(|e| EffectError::Handler(format!("git tree: path '{}': {}", path, e)))?;
+                    let entry = tree.get_path(std::path::Path::new(&path)).map_err(|e| {
+                        EffectError::Handler(format!("git tree: path '{}': {}", path, e))
+                    })?;
                     repo.find_tree(entry.id())
                         .map_err(|e| EffectError::Handler(format!("git tree: subtree: {}", e)))?
                 };
@@ -1105,12 +1132,7 @@ impl EffectHandler<CapturedOutput> for GitHandler {
                 for branch_result in branches {
                     let (branch, _branch_type) = branch_result
                         .map_err(|e| EffectError::Handler(format!("git branches: iter: {}", e)))?;
-                    let name = branch
-                        .name()
-                        .ok()
-                        .flatten()
-                        .unwrap_or("")
-                        .to_string();
+                    let name = branch.name().ok().flatten().unwrap_or("").to_string();
                     let is_head = branch.is_head();
                     let commit_hash = branch
                         .get()
@@ -1473,8 +1495,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         use rmcp::ServiceExt;
         if let Some(addr) = http_addr {
             use rmcp::transport::streamable_http_server::{
-                StreamableHttpService, StreamableHttpServerConfig,
-                session::local::LocalSessionManager,
+                session::local::LocalSessionManager, StreamableHttpServerConfig,
+                StreamableHttpService,
             };
             let config = StreamableHttpServerConfig::default();
             let cancel = config.cancellation_token.clone();
@@ -1857,7 +1879,9 @@ mod tests {
         let captured = CapturedOutput::new();
         let cx = EffectContext::with_user(&table, &captured);
         let (mut handler, _) = git_handler();
-        let result = handler.handle(GitReq::Tree("HEAD".into(), ".".into()), &cx).unwrap();
+        let result = handler
+            .handle(GitReq::Tree("HEAD".into(), ".".into()), &cx)
+            .unwrap();
         assert_is_haskell_list(&result, &table);
     }
 
@@ -1867,7 +1891,9 @@ mod tests {
         let captured = CapturedOutput::new();
         let cx = EffectContext::with_user(&table, &captured);
         let (mut handler, _) = git_handler();
-        let result = handler.handle(GitReq::Blame("Cargo.toml".into(), 1, 5), &cx).unwrap();
+        let result = handler
+            .handle(GitReq::Blame("Cargo.toml".into(), 1, 5), &cx)
+            .unwrap();
         assert_is_haskell_list(&result, &table);
     }
 
@@ -2007,9 +2033,7 @@ mod tests {
         let decls = tidepool_mcp::standard_decls();
         // HList order from main(): Console(0), KV(1), Fs(2), SG(3), Http(4), Exec(5), Meta(6), Git(7)
         // Ask(8) is handled by MCP server, not in main HList
-        let expected = [
-            "Console", "KV", "Fs", "SG", "Http", "Exec", "Meta", "Git",
-        ];
+        let expected = ["Console", "KV", "Fs", "SG", "Http", "Exec", "Meta", "Git"];
         for (i, name) in expected.iter().enumerate() {
             assert_eq!(
                 decls[i].type_name, *name,
@@ -2157,7 +2181,10 @@ mod tests {
     fn test_http_from_core_post() {
         let table = full_effect_test_table();
         let con_id = table.get_by_name("HttpPost").unwrap();
-        let url = "https://example.com/api".to_string().to_value(&table).unwrap();
+        let url = "https://example.com/api"
+            .to_string()
+            .to_value(&table)
+            .unwrap();
         // Use a Null JSON value as body
         let null_id = table.get_by_name("Null").unwrap();
         let body = Value::Con(null_id, vec![]);
@@ -2318,15 +2345,16 @@ mod tests {
     #[test]
     fn test_jit_meta_version_roundtrip() {
         let result = jit_eval(&["v <- metaVersion", "pure (toJSON v)"]);
-        assert!(result.is_string(), "metaVersion should return a string, got {:?}", result);
+        assert!(
+            result.is_string(),
+            "metaVersion should return a string, got {:?}",
+            result
+        );
     }
 
     #[test]
     fn test_jit_meta_primops_roundtrip() {
-        let result = jit_eval(&[
-            "ops <- metaPrimOps",
-            "pure (toJSON (length ops > 0))",
-        ]);
+        let result = jit_eval(&["ops <- metaPrimOps", "pure (toJSON (length ops > 0))"]);
         assert_eq!(result, serde_json::json!(true));
     }
 
@@ -2337,7 +2365,11 @@ mod tests {
             "pure (toJSON (length commits))",
         ]);
         let n = result.as_i64().unwrap();
-        assert!(n > 0 && n <= 3, "gitLog should return 1-3 commits, got {}", n);
+        assert!(
+            n > 0 && n <= 3,
+            "gitLog should return 1-3 commits, got {}",
+            n
+        );
     }
 
     #[test]
@@ -2346,24 +2378,26 @@ mod tests {
             "c <- gitShow \"HEAD\"",
             "pure (toJSON (c ^? key \"subject\" . _String))",
         ]);
-        assert!(result.is_string(), "gitShow HEAD subject should be a string, got {:?}", result);
+        assert!(
+            result.is_string(),
+            "gitShow HEAD subject should be a string, got {:?}",
+            result
+        );
     }
 
     #[test]
     fn test_jit_git_diff_roundtrip() {
-        let result = jit_eval(&[
-            "diffs <- gitDiff \"HEAD\"",
-            "pure (toJSON (length diffs))",
-        ]);
-        assert!(result.is_number(), "gitDiff should return a count, got {:?}", result);
+        let result = jit_eval(&["diffs <- gitDiff \"HEAD\"", "pure (toJSON (length diffs))"]);
+        assert!(
+            result.is_number(),
+            "gitDiff should return a count, got {:?}",
+            result
+        );
     }
 
     #[test]
     fn test_jit_git_branches_roundtrip() {
-        let result = jit_eval(&[
-            "bs <- gitBranches",
-            "pure (toJSON (length bs > 0))",
-        ]);
+        let result = jit_eval(&["bs <- gitBranches", "pure (toJSON (length bs > 0))"]);
         assert_eq!(result, serde_json::json!(true));
     }
 
@@ -2462,7 +2496,9 @@ mod tests {
             .collect();
         assert!(!entries.is_empty(), "root tree should have entries");
         assert!(
-            entries.iter().any(|e| e == "Cargo.toml" || e == "CLAUDE.md"),
+            entries
+                .iter()
+                .any(|e| e == "Cargo.toml" || e == "CLAUDE.md"),
             "root tree should contain known files, got: {:?}",
             entries
         );

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -1571,8 +1571,8 @@ mod tests {
         let decls = tidepool_mcp::standard_decls();
         let preamble = tidepool_mcp::build_preamble(&decls, false);
         let stack = tidepool_mcp::build_effect_stack_type(&decls);
-        let code_lines: Vec<String> = code.iter().map(|s| s.to_string()).collect();
-        tidepool_mcp::template_haskell(&preamble, &stack, &code_lines, &[], &[], None, None)
+        let code_str = code.join("\n");
+        tidepool_mcp::template_haskell(&preamble, &stack, &code_str, "", "", None, None)
     }
 
     /// Compile and run a Haskell snippet through the JIT with the full handler stack.


### PR DESCRIPTION
This PR changes the `tidepool-mcp` eval tool schema from array-of-strings to a single string for the `code`, `helpers`, and `imports` fields in `EvalRequest`. This is a breaking change that removes array support for these fields.

Address Copilot review feedback:
- Remove unused `imports` bindings in `tidepool-runtime/tests/sort_crash.rs`.
- Trim and skip empty lines in `EvalRequest.imports` before checking against the blocklist in `eval` and before rendering in `template_haskell`.
- Improve `helpers` rendering in `template_haskell` to ensure consistent trailing newlines and avoid redundant blank lines when empty.

Fix CI failures:
- Fix workspace-wide formatting issues using `cargo fmt --all`.
- Fix trailing whitespace in `tidepool-optimize/tests/proptest_partial_eval.rs` that was causing `rustfmt` to fail.
- Add `openssl` to `flake.nix` devShell `buildInputs` to resolve `openssl-sys` compilation failure.

Verified with `cargo check -p tidepool-mcp` and `cargo test -p tidepool-mcp`.