### PR TITLE
Fix SIGSEGV in JIT by preventing heap_force from forcing TAG_CLOSURE

### DIFF
--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -270,82 +270,54 @@ pub extern "C" fn heap_force(vmctx: *mut VMContext, obj: *mut u8) -> *mut u8 {
         loop {
             let tag = layout::read_tag(current);
 
-            if tag >= 2 {
-                return current; // Con or Lit — already WHNF
+            if tag != layout::TAG_THUNK {
+                return current; // WHNF (Closure, Con, Lit) or unknown
             }
 
-            if tag == layout::TAG_THUNK {
-                let state = *current.add(layout::THUNK_STATE_OFFSET);
-                match state {
-                    layout::THUNK_UNEVALUATED => {
-                        // 1. Eager blackhole
-                        *current.add(layout::THUNK_STATE_OFFSET) = layout::THUNK_BLACKHOLE;
+            let state = *current.add(layout::THUNK_STATE_OFFSET);
+            match state {
+                layout::THUNK_UNEVALUATED => {
+                    // 1. Eager blackhole
+                    *current.add(layout::THUNK_STATE_OFFSET) = layout::THUNK_BLACKHOLE;
 
-                        // 2. Read code pointer
-                        let code_ptr =
-                            *(current.add(layout::THUNK_CODE_PTR_OFFSET) as *const usize);
+                    // 2. Read code pointer
+                    let code_ptr =
+                        *(current.add(layout::THUNK_CODE_PTR_OFFSET) as *const usize);
 
-                        if code_ptr == 0 {
-                            RUNTIME_ERROR.with(|cell| {
-                                *cell.borrow_mut() = Some(RuntimeError::NullFunPtr);
-                            });
-                            return error_poison_ptr();
-                        }
-
-                        // 3. Call thunk entry function
-                        // Signature: fn(vmctx, thunk_ptr) -> whnf_ptr
-                        let f: extern "C" fn(*mut VMContext, *mut u8) -> *mut u8 =
-                            std::mem::transmute(code_ptr);
-                        let result = f(vmctx, current);
-
-                        // 4. Write indirection (offset 16, overwriting code_ptr)
-                        *(current.add(layout::THUNK_INDIRECTION_OFFSET) as *mut *mut u8) = result;
-
-                        // 5. Set state = Evaluated
-                        *current.add(layout::THUNK_STATE_OFFSET) = layout::THUNK_EVALUATED;
-
-                        // Result may be another thunk — loop to force it
-                        current = result;
-                        continue;
+                    if code_ptr == 0 {
+                        RUNTIME_ERROR.with(|cell| {
+                            *cell.borrow_mut() = Some(RuntimeError::NullFunPtr);
+                        });
+                        return error_poison_ptr();
                     }
-                    layout::THUNK_BLACKHOLE => {
-                        return runtime_blackhole_trap(vmctx);
-                    }
-                    layout::THUNK_EVALUATED => {
-                        // Follow indirection — result may be another thunk
-                        current =
-                            *(current.add(layout::THUNK_INDIRECTION_OFFSET) as *const *mut u8);
-                        continue;
-                    }
-                    other => return runtime_bad_thunk_state_trap(vmctx, other),
+
+                    // 3. Call thunk entry function
+                    // Signature: fn(vmctx, thunk_ptr) -> whnf_ptr
+                    let f: extern "C" fn(*mut VMContext, *mut u8) -> *mut u8 =
+                        std::mem::transmute(code_ptr);
+                    let result = f(vmctx, current);
+
+                    // 4. Write indirection (offset 16, overwriting code_ptr)
+                    *(current.add(layout::THUNK_INDIRECTION_OFFSET) as *mut *mut u8) = result;
+
+                    // 5. Set state = Evaluated
+                    *current.add(layout::THUNK_STATE_OFFSET) = layout::THUNK_EVALUATED;
+
+                    // Result may be another thunk — loop to force it
+                    current = result;
+                    continue;
                 }
+                layout::THUNK_BLACKHOLE => {
+                    return runtime_blackhole_trap(vmctx);
+                }
+                layout::THUNK_EVALUATED => {
+                    // Follow indirection — result may be another thunk
+                    current =
+                        *(current.add(layout::THUNK_INDIRECTION_OFFSET) as *const *mut u8);
+                    continue;
+                }
+                other => return runtime_bad_thunk_state_trap(vmctx, other),
             }
-
-            if tag != layout::TAG_CLOSURE {
-                return current; // Unknown — not handled here
-            }
-
-            // Closure: read code_ptr
-            let code_ptr_val = *(current.add(layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
-
-            if code_ptr_val == 0 {
-                RUNTIME_ERROR.with(|cell| {
-                    *cell.borrow_mut() = Some(RuntimeError::NullFunPtr);
-                });
-                return error_poison_ptr();
-            }
-
-            // Force the closure. In a data-case scrutinee position, GHC Core
-            // guarantees the result must be a data constructor, so any closure
-            // here is a thunk (suspended computation) regardless of capture count.
-            // SAFETY: code_ptr is a JIT-compiled function pointer. The JIT guarantees
-            // it points to a function with this exact signature (closure calling convention).
-            let f: extern "C" fn(*mut VMContext, *mut u8, *mut u8) -> *mut u8 =
-                std::mem::transmute(code_ptr_val);
-            let result = f(vmctx, current, std::ptr::null_mut());
-
-            // Closure result may be a thunk — loop to force it
-            current = result;
         }
     }
 }


### PR DESCRIPTION
`test_jit_console_roundtrip` (and likely other complex JIT tests involving closures within effect handlers) was failing with a `SIGSEGV` during execution.

The root cause was that `heap_force` in `tidepool-codegen/src/host_fns.rs` was still attempting to force `TAG_CLOSURE` objects. It did this by reading the closure's `code_ptr` and invoking it with a `null` argument. 

Since the addition of lazy thunk codegen (`TAG_THUNK`), `TAG_CLOSURE` strictly represents lambda values, which are already in Weak Head Normal Form (WHNF). Furthermore, the JIT-compiled closure code expects its arguments, and passing `null` resulted in a segmentation fault when the closure attempted to use the missing argument.

This PR updates `heap_force` to immediately return the current object for all tags other than `TAG_THUNK`, correctly treating `TAG_CLOSURE`, `TAG_CON`, and `TAG_LIT` as WHNF.