### PR TITLE
fix: resolve JIT SIGSEGV by handling thunks properly in App/PrimOps and fixing heap_force

### DIFF
--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -117,18 +117,20 @@ fn emit_data_dispatch(
     default_alt: Option<&Alt<usize>>,
     merge_block: ir::Block,
 ) -> Result<(), EmitError> {
-    // 1. Force if needed (tag < 2: Closure or Thunk)
+    // 1. Force if needed (tag == TAG_THUNK)
     let tag = builder
         .ins()
         .load(types::I8, MemFlags::trusted(), initial_scrut_ptr, 0);
-    let needs_force = builder.ins().icmp_imm(IntCC::UnsignedLessThan, tag, 2);
+    let is_thunk = builder
+        .ins()
+        .icmp_imm(IntCC::Equal, tag, layout::TAG_THUNK as i64);
 
     let force_block = builder.create_block();
     let dispatch_block = builder.create_block();
     builder.append_block_param(dispatch_block, types::I64);
 
     builder.ins().brif(
-        needs_force,
+        is_thunk,
         force_block,
         &[],
         dispatch_block,

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -369,11 +369,74 @@ fn collapse_frame(
         }
         EmitFrame::App { fun, arg } => {
             ctx.declare_env(builder);
-            let fun_ptr = fun.value();
+            let initial_fun_ptr = fun.value();
             let arg_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, arg);
 
+            // Null check before loading tag
+            let zero = builder.ins().iconst(types::I64, 0);
+            let is_null = builder.ins().icmp(IntCC::Equal, initial_fun_ptr, zero);
+            let not_null_block = builder.create_block();
+            let check_block = builder.create_block();
+            builder.append_block_param(check_block, types::I64);
+
+            builder.ins().brif(
+                is_null,
+                check_block,
+                &[ir::BlockArg::Value(initial_fun_ptr)],
+                not_null_block,
+                &[],
+            );
+
+            // It's not null, read tag
+            builder.switch_to_block(not_null_block);
+            builder.seal_block(not_null_block);
+            let tag = builder
+                .ins()
+                .load(types::I8, MemFlags::trusted(), initial_fun_ptr, 0);
+
+            // Force if it's a thunk (TAG_THUNK == 1)
+            let is_thunk = builder
+                .ins()
+                .icmp_imm(IntCC::Equal, tag, layout::TAG_THUNK as i64);
+
+            let force_block = builder.create_block();
+
+            builder.ins().brif(
+                is_thunk,
+                force_block,
+                &[],
+                check_block,
+                &[ir::BlockArg::Value(initial_fun_ptr)],
+            );
+
+            // Force block: call host_fns::heap_force
+            builder.switch_to_block(force_block);
+            builder.seal_block(force_block);
+            let force_fn = pipeline
+                .module
+                .declare_function("heap_force", Linkage::Import, &{
+                    let mut sig = Signature::new(pipeline.isa.default_call_conv());
+                    sig.params.push(AbiParam::new(types::I64)); // vmctx
+                    sig.params.push(AbiParam::new(types::I64)); // thunk
+                    sig.returns.push(AbiParam::new(types::I64)); // result
+                    sig
+                })
+                .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+            let force_ref = pipeline.module.declare_func_in_func(force_fn, builder.func);
+            let call = builder.ins().call(force_ref, &[vmctx, initial_fun_ptr]);
+            let force_result = builder.inst_results(call)[0];
+            builder.declare_value_needs_stack_map(force_result);
+            builder
+                .ins()
+                .jump(check_block, &[ir::BlockArg::Value(force_result)]);
+
+            // check_block: validate and call
+            builder.switch_to_block(check_block);
+            builder.seal_block(check_block);
+            let fun_ptr = builder.block_params(check_block)[0];
+            builder.declare_value_needs_stack_map(fun_ptr);
+
             // Debug: call host fn to validate fun_ptr tag before call_indirect.
-            // Returns 0 (null) if ok, or a poison pointer if call should be skipped.
             let check_fn = pipeline
                 .module
                 .declare_function("debug_app_check", Linkage::Import, &{
@@ -387,13 +450,12 @@ fn collapse_frame(
             let check_inst = builder.ins().call(check_ref, &[fun_ptr]);
             let check_result = builder.inst_results(check_inst)[0];
 
-            // If debug_app_check returned non-zero (poison), short-circuit
             let call_block = builder.create_block();
             let merge_block = builder.create_block();
             builder.append_block_param(merge_block, types::I64);
 
             let is_zero = builder.ins().icmp_imm(IntCC::Equal, check_result, 0);
-            builder.ins().brif(is_zero, call_block, &[], merge_block, &[BlockArg::Value(check_result)]);
+            builder.ins().brif(is_zero, call_block, &[], merge_block, &[ir::BlockArg::Value(check_result)]);
 
             // call_block: normal function call
             builder.switch_to_block(call_block);
@@ -417,14 +479,15 @@ fn collapse_frame(
                 .ins()
                 .call_indirect(call_sig, code_ptr, &[vmctx, fun_ptr, arg_ptr]);
             let ret_val = builder.inst_results(inst)[0];
-            builder.ins().jump(merge_block, &[BlockArg::Value(ret_val)]);
+            builder.ins().jump(merge_block, &[ir::BlockArg::Value(ret_val)]);
 
-            // merge_block: result is either poison or call result
+            // merge_block
             builder.switch_to_block(merge_block);
             builder.seal_block(merge_block);
-            let merged_val = builder.block_params(merge_block)[0];
-            builder.declare_value_needs_stack_map(merged_val);
-            Ok(SsaVal::HeapPtr(merged_val))
+            let final_ret = builder.block_params(merge_block)[0];
+            builder.declare_value_needs_stack_map(final_ret);
+
+            Ok(SsaVal::HeapPtr(final_ret))
         }
         EmitFrame::Lam { binder, body_idx } => emit_lam(
             ctx, pipeline, builder, vmctx, gc_sig, oom_func, tree, binder, body_idx,

--- a/tidepool-codegen/src/emit/primop.rs
+++ b/tidepool-codegen/src/emit/primop.rs
@@ -45,38 +45,38 @@ pub fn emit_primop(
         // Int arithmetic (binary)
         PrimOpKind::IntAdd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntSub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntMul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntNegate => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().ineg(a), LIT_TAG_INT))
         }
         PrimOpKind::IntQuot => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             emit_div_zero_check(builder, b);
             Ok(SsaVal::Raw(builder.ins().sdiv(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntRem => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             emit_div_zero_check(builder, b);
             Ok(SsaVal::Raw(builder.ins().srem(a, b), LIT_TAG_INT))
         }
@@ -84,58 +84,61 @@ pub fn emit_primop(
         // Int bitwise
         PrimOpKind::IntAnd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().band(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntOr => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().bor(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntXor => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().bxor(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntNot => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().bnot(a), LIT_TAG_INT))
         }
 
         // Int shifts
         PrimOpKind::IntShl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().ishl(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntShra => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().sshr(a, b), LIT_TAG_INT))
         }
         PrimOpKind::IntShrl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().ushr(a, b), LIT_TAG_INT))
         }
 
         // Int comparison \u2192 returns i64 (0=False, 1=True)
         PrimOpKind::IntEq => {
-            emit_int_compare(pipeline, builder, op, IntCC::Equal, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, IntCC::Equal, args, LIT_TAG_INT)
         }
         PrimOpKind::IntNe => {
-            emit_int_compare(pipeline, builder, op, IntCC::NotEqual, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, IntCC::NotEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::IntLt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::SignedLessThan,
             args,
@@ -144,6 +147,9 @@ pub fn emit_primop(
         PrimOpKind::IntLe => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::SignedLessThanOrEqual,
             args,
@@ -152,6 +158,9 @@ pub fn emit_primop(
         PrimOpKind::IntGt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::SignedGreaterThan,
             args,
@@ -160,6 +169,9 @@ pub fn emit_primop(
         PrimOpKind::IntGe => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::SignedGreaterThanOrEqual,
             args,
@@ -169,34 +181,34 @@ pub fn emit_primop(
         // Word arithmetic
         PrimOpKind::WordAdd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordSub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordMul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_WORD))
         }
 
         PrimOpKind::WordQuot => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             emit_div_zero_check(builder, b);
             Ok(SsaVal::Raw(builder.ins().udiv(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordRem => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             emit_div_zero_check(builder, b);
             Ok(SsaVal::Raw(builder.ins().urem(a, b), LIT_TAG_WORD))
         }
@@ -204,52 +216,55 @@ pub fn emit_primop(
         // Word bitwise
         PrimOpKind::WordAnd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().band(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordOr => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().bor(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordXor => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().bxor(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordNot => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().bnot(a), LIT_TAG_WORD))
         }
 
         // Word shifts
         PrimOpKind::WordShl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().ishl(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::WordShrl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().ushr(a, b), LIT_TAG_WORD))
         }
 
         // Word comparison (unsigned)
         PrimOpKind::WordEq => {
-            emit_int_compare(pipeline, builder, op, IntCC::Equal, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, IntCC::Equal, args, LIT_TAG_INT)
         }
         PrimOpKind::WordNe => {
-            emit_int_compare(pipeline, builder, op, IntCC::NotEqual, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, IntCC::NotEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::WordLt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedLessThan,
             args,
@@ -258,6 +273,9 @@ pub fn emit_primop(
         PrimOpKind::WordLe => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedLessThanOrEqual,
             args,
@@ -266,6 +284,9 @@ pub fn emit_primop(
         PrimOpKind::WordGt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedGreaterThan,
             args,
@@ -274,6 +295,9 @@ pub fn emit_primop(
         PrimOpKind::WordGe => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedGreaterThanOrEqual,
             args,
@@ -283,42 +307,45 @@ pub fn emit_primop(
         // Double arithmetic
         PrimOpKind::DoubleAdd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
-            let b = unbox_double(pipeline, builder, args[1]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().fadd(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleSub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
-            let b = unbox_double(pipeline, builder, args[1]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().fsub(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleMul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
-            let b = unbox_double(pipeline, builder, args[1]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().fmul(a, b), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleDiv => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
-            let b = unbox_double(pipeline, builder, args[1]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().fdiv(a, b), LIT_TAG_DOUBLE))
         }
 
         // Double comparison
         PrimOpKind::DoubleEq => {
-            emit_float_compare(pipeline, builder, op, FloatCC::Equal, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, FloatCC::Equal, args, LIT_TAG_INT)
         }
         PrimOpKind::DoubleNe => {
-            emit_float_compare(pipeline, builder, op, FloatCC::NotEqual, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, FloatCC::NotEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::DoubleLt => {
-            emit_float_compare(pipeline, builder, op, FloatCC::LessThan, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, FloatCC::LessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::DoubleLe => emit_float_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             FloatCC::LessThanOrEqual,
             args,
@@ -327,6 +354,9 @@ pub fn emit_primop(
         PrimOpKind::DoubleGt => emit_float_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             FloatCC::GreaterThan,
             args,
@@ -335,6 +365,9 @@ pub fn emit_primop(
         PrimOpKind::DoubleGe => emit_float_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             FloatCC::GreaterThanOrEqual,
             args,
@@ -343,14 +376,17 @@ pub fn emit_primop(
 
         // Char comparison
         PrimOpKind::CharEq => {
-            emit_int_compare(pipeline, builder, op, IntCC::Equal, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, IntCC::Equal, args, LIT_TAG_INT)
         }
         PrimOpKind::CharNe => {
-            emit_int_compare(pipeline, builder, op, IntCC::NotEqual, args, LIT_TAG_INT)
+            emit_int_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, IntCC::NotEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::CharLt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedLessThan,
             args,
@@ -359,6 +395,9 @@ pub fn emit_primop(
         PrimOpKind::CharLe => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedLessThanOrEqual,
             args,
@@ -367,6 +406,9 @@ pub fn emit_primop(
         PrimOpKind::CharGt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedGreaterThan,
             args,
@@ -375,6 +417,9 @@ pub fn emit_primop(
         PrimOpKind::CharGe => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedGreaterThanOrEqual,
             args,
@@ -384,17 +429,17 @@ pub fn emit_primop(
         // Conversions
         PrimOpKind::Chr => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_CHAR))
         }
         PrimOpKind::Ord => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_INT))
         }
         PrimOpKind::Int2Word | PrimOpKind::Word2Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let tag = if matches!(op, PrimOpKind::Int2Word) {
                 LIT_TAG_WORD
             } else {
@@ -404,7 +449,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Int2Double => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fcvt_from_sint(types::F64, v),
                 LIT_TAG_DOUBLE,
@@ -412,7 +457,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Double2Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_double(pipeline, builder, args[0]);
+            let v = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fcvt_to_sint_sat(types::I64, v),
                 LIT_TAG_INT,
@@ -420,7 +465,7 @@ pub fn emit_primop(
         }
         PrimOpKind::DecodeDoubleMantissa => {
             check_arity(op, 1, args.len())?;
-            let d = unbox_double(pipeline, builder, args[0]);
+            let d = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let bits = builder.ins().bitcast(types::I64, MemFlags::new(), d);
             let result = emit_runtime_call(
                 pipeline,
@@ -434,7 +479,7 @@ pub fn emit_primop(
         }
         PrimOpKind::DecodeDoubleExponent => {
             check_arity(op, 1, args.len())?;
-            let d = unbox_double(pipeline, builder, args[0]);
+            let d = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let bits = builder.ins().bitcast(types::I64, MemFlags::new(), d);
             let result = emit_runtime_call(
                 pipeline,
@@ -448,7 +493,7 @@ pub fn emit_primop(
         }
         PrimOpKind::ShowDoubleAddr => {
             check_arity(op, 1, args.len())?;
-            let d = unbox_double(pipeline, builder, args[0]);
+            let d = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let bits = builder.ins().bitcast(types::I64, MemFlags::new(), d);
             let result = emit_runtime_call(
                 pipeline,
@@ -462,7 +507,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Int2Float => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fcvt_from_sint(types::F32, v),
                 LIT_TAG_FLOAT,
@@ -470,7 +515,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Float2Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_float(pipeline, builder, args[0]);
+            let v = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fcvt_to_sint_sat(types::I64, v),
                 LIT_TAG_INT,
@@ -478,7 +523,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Double2Float => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_double(pipeline, builder, args[0]);
+            let v = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fdemote(types::F32, v),
                 LIT_TAG_FLOAT,
@@ -486,7 +531,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Float2Double => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_float(pipeline, builder, args[0]);
+            let v = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(
                 builder.ins().fpromote(types::F64, v),
                 LIT_TAG_DOUBLE,
@@ -496,7 +541,7 @@ pub fn emit_primop(
         // Narrowing
         PrimOpKind::Narrow8Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let narrow = builder.ins().ireduce(types::I8, v);
             Ok(SsaVal::Raw(
                 builder.ins().sextend(types::I64, narrow),
@@ -505,7 +550,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow16Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let narrow = builder.ins().ireduce(types::I16, v);
             Ok(SsaVal::Raw(
                 builder.ins().sextend(types::I64, narrow),
@@ -514,7 +559,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow32Int => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let narrow = builder.ins().ireduce(types::I32, v);
             Ok(SsaVal::Raw(
                 builder.ins().sextend(types::I64, narrow),
@@ -523,7 +568,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow8Word => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let narrow = builder.ins().ireduce(types::I8, v);
             Ok(SsaVal::Raw(
                 builder.ins().uextend(types::I64, narrow),
@@ -532,7 +577,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow16Word => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let narrow = builder.ins().ireduce(types::I16, v);
             Ok(SsaVal::Raw(
                 builder.ins().uextend(types::I64, narrow),
@@ -541,7 +586,7 @@ pub fn emit_primop(
         }
         PrimOpKind::Narrow32Word => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let narrow = builder.ins().ireduce(types::I32, v);
             Ok(SsaVal::Raw(
                 builder.ins().uextend(types::I64, narrow),
@@ -552,7 +597,51 @@ pub fn emit_primop(
         // Special ops
         PrimOpKind::DataToTag => {
             check_arity(op, 1, args.len())?;
-            let obj = args[0].value();
+            let initial_ptr = args[0].value();
+
+            // Force if needed
+            let tag = builder
+                .ins()
+                .load(types::I8, MemFlags::trusted(), initial_ptr, 0);
+            let needs_force = builder.ins().icmp_imm(IntCC::UnsignedLessThan, tag, 2);
+
+            let force_block = builder.create_block();
+            let ready_block = builder.create_block();
+            builder.append_block_param(ready_block, types::I64);
+
+            builder.ins().brif(
+                needs_force,
+                force_block,
+                &[],
+                ready_block,
+                &[ir::BlockArg::Value(initial_ptr)],
+            );
+
+            // Force block
+            builder.switch_to_block(force_block);
+            builder.seal_block(force_block);
+            let force_fn = pipeline
+                .module
+                .declare_function("heap_force", Linkage::Import, &{
+                    let mut sig = Signature::new(pipeline.isa.default_call_conv());
+                    sig.params.push(AbiParam::new(types::I64)); // vmctx
+                    sig.params.push(AbiParam::new(types::I64)); // thunk
+                    sig.returns.push(AbiParam::new(types::I64)); // result
+                    sig
+                })
+                .unwrap();
+            let force_ref = pipeline.module.declare_func_in_func(force_fn, builder.func);
+            let call = builder.ins().call(force_ref, &[vmctx, initial_ptr]);
+            let forced = builder.inst_results(call)[0];
+            builder.declare_value_needs_stack_map(forced);
+            builder.ins().jump(ready_block, &[ir::BlockArg::Value(forced)]);
+
+            // Ready block
+            builder.switch_to_block(ready_block);
+            builder.seal_block(ready_block);
+            let obj = builder.block_params(ready_block)[0];
+            builder.declare_value_needs_stack_map(obj);
+
             let tag = builder
                 .ins()
                 .load(types::I64, MemFlags::trusted(), obj, CON_TAG_OFFSET);
@@ -560,18 +649,18 @@ pub fn emit_primop(
         }
         PrimOpKind::DoubleNegate => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().fneg(a), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleFabs => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().fabs(a), LIT_TAG_DOUBLE))
         }
         // Double math unary: sqrt, exp, log, trig, etc. All via libm runtime calls.
         PrimOpKind::DoubleSqrt => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().sqrt(a), LIT_TAG_DOUBLE))
         }
         PrimOpKind::DoubleExp
@@ -591,7 +680,7 @@ pub fn emit_primop(
         | PrimOpKind::DoubleAcosh
         | PrimOpKind::DoubleAtanh => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let fn_name = match op {
                 PrimOpKind::DoubleExp => "runtime_double_exp",
                 PrimOpKind::DoubleExpM1 => "runtime_double_expm1",
@@ -627,8 +716,8 @@ pub fn emit_primop(
         }
         PrimOpKind::DoublePower => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_double(pipeline, builder, args[0]);
-            let b = unbox_double(pipeline, builder, args[1]);
+            let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let bits_a = builder.ins().bitcast(types::I64, MemFlags::new(), a);
             let bits_b = builder.ins().bitcast(types::I64, MemFlags::new(), b);
             let result = emit_runtime_call(
@@ -644,7 +733,7 @@ pub fn emit_primop(
         }
         PrimOpKind::FloatNegate => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_float(pipeline, builder, args[0]);
+            let a = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().fneg(a), LIT_TAG_FLOAT))
         }
 
@@ -658,8 +747,8 @@ pub fn emit_primop(
 
         PrimOpKind::IndexCharOffAddr => {
             check_arity(op, 2, args.len())?;
-            let addr = unbox_addr(pipeline, builder, args[0]);
-            let idx = unbox_int(pipeline, builder, args[1]);
+            let addr = unbox_addr(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let idx = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let effective = builder.ins().iadd(addr, idx);
             let byte_val = builder.ins().load(types::I8, MemFlags::new(), effective, 0);
             let char_val = builder.ins().uextend(types::I64, byte_val);
@@ -668,8 +757,8 @@ pub fn emit_primop(
 
         PrimOpKind::PlusAddr => {
             check_arity(op, 2, args.len())?;
-            let addr = unbox_addr(pipeline, builder, args[0]);
-            let offset = unbox_int(pipeline, builder, args[1]);
+            let addr = unbox_addr(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let offset = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(addr, offset), LIT_TAG_ADDR))
         }
 
@@ -681,37 +770,37 @@ pub fn emit_primop(
         // Int64 arithmetic
         PrimOpKind::Int64Add => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_INT))
         }
         PrimOpKind::Int64Sub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_INT))
         }
         PrimOpKind::Int64Mul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_INT))
         }
         PrimOpKind::Int64Negate => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().ineg(a), LIT_TAG_INT))
         }
         PrimOpKind::Int64Shl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().ishl(a, b), LIT_TAG_INT))
         }
         PrimOpKind::Int64Shra => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().sshr(a, b), LIT_TAG_INT))
         }
 
@@ -719,6 +808,9 @@ pub fn emit_primop(
         PrimOpKind::Int64Lt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::SignedLessThan,
             args,
@@ -727,6 +819,9 @@ pub fn emit_primop(
         PrimOpKind::Int64Le => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::SignedLessThanOrEqual,
             args,
@@ -735,6 +830,9 @@ pub fn emit_primop(
         PrimOpKind::Int64Gt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::SignedGreaterThan,
             args,
@@ -743,6 +841,9 @@ pub fn emit_primop(
         PrimOpKind::Int64Ge => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::SignedGreaterThanOrEqual,
             args,
@@ -752,44 +853,44 @@ pub fn emit_primop(
         // Word64 arithmetic/bitwise
         PrimOpKind::Word64And => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().band(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::Word64Shl => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().ishl(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::Word64Or => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().bor(a, b), LIT_TAG_WORD))
         }
 
         // Conversions between sized int/word types (no-ops on 64-bit)
         PrimOpKind::Word64ToInt64 | PrimOpKind::Int64ToInt | PrimOpKind::Int64ToWord64 => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_INT))
         }
         PrimOpKind::IntToInt64 => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_INT))
         }
         PrimOpKind::Word8ToWord => {
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(v, LIT_TAG_WORD))
         }
         PrimOpKind::WordToWord8 => {
             // wordToWord8# :: Word# -> Word8#
             // Narrow to 8 bits
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let mask = builder.ins().iconst(types::I64, 0xFF);
             let narrow = builder.ins().band(v, mask);
             Ok(SsaVal::Raw(narrow, LIT_TAG_WORD))
@@ -798,15 +899,15 @@ pub fn emit_primop(
         // Word8 arithmetic/comparison
         PrimOpKind::Word8Add => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let sum = builder.ins().iadd(a, b);
             Ok(SsaVal::Raw(builder.ins().band_imm(sum, 0xFF), LIT_TAG_WORD))
         }
         PrimOpKind::Word8Sub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let diff = builder.ins().isub(a, b);
             Ok(SsaVal::Raw(
                 builder.ins().band_imm(diff, 0xFF),
@@ -816,6 +917,9 @@ pub fn emit_primop(
         PrimOpKind::Word8Lt => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedLessThan,
             args,
@@ -824,6 +928,9 @@ pub fn emit_primop(
         PrimOpKind::Word8Le => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedLessThanOrEqual,
             args,
@@ -832,6 +939,9 @@ pub fn emit_primop(
         PrimOpKind::Word8Ge => emit_int_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             IntCC::UnsignedGreaterThanOrEqual,
             args,
@@ -846,14 +956,14 @@ pub fn emit_primop(
         // We emit just the value or carry depending on which variant.
         PrimOpKind::AddIntCVal => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_INT))
         }
         PrimOpKind::AddIntCCarry => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let sum = builder.ins().iadd(a, b);
             // Signed overflow: (a > 0 && b > 0 && sum < 0) || (a < 0 && b < 0 && sum >= 0)
             // Simplified: overflow if sign(a) == sign(b) && sign(sum) != sign(a)
@@ -870,14 +980,14 @@ pub fn emit_primop(
         // subWordC# :: Word# -> Word# -> (# Word#, Int# #)
         PrimOpKind::SubWordCVal => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().isub(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::SubWordCCarry => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             // Borrow if a < b (unsigned)
             let borrow = builder.ins().icmp(IntCC::UnsignedLessThan, a, b);
             Ok(SsaVal::Raw(
@@ -889,14 +999,14 @@ pub fn emit_primop(
         // addWordC# :: Word# -> Word# -> (# Word#, Int# #)
         PrimOpKind::AddWordCVal => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().iadd(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::AddWordCCarry => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let sum = builder.ins().iadd(a, b);
             // Carry if sum < a (unsigned)
             let carry = builder.ins().icmp(IntCC::UnsignedLessThan, sum, a);
@@ -910,20 +1020,20 @@ pub fn emit_primop(
         // Signed widening multiply: (hi, lo, overflow)
         PrimOpKind::TimesInt2Hi => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().smulhi(a, b), LIT_TAG_INT))
         }
         PrimOpKind::TimesInt2Lo => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_INT))
         }
         PrimOpKind::TimesInt2Overflow => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             // Overflow if smulhi(a,b) != (imul(a,b) >>s 63)
             // i.e., the high word differs from sign-extending the low word
             let hi = builder.ins().smulhi(a, b);
@@ -940,29 +1050,29 @@ pub fn emit_primop(
         // High and low words of 128-bit multiply
         PrimOpKind::TimesWord2Hi => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().umulhi(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::TimesWord2Lo => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().imul(a, b), LIT_TAG_WORD))
         }
 
         // quotRemWord# :: Word# -> Word# -> (# Word#, Word# #)
         PrimOpKind::QuotRemWordVal => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             emit_div_zero_check(builder, b);
             Ok(SsaVal::Raw(builder.ins().udiv(a, b), LIT_TAG_WORD))
         }
         PrimOpKind::QuotRemWordRem => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
-            let b = unbox_int(pipeline, builder, args[1]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             emit_div_zero_check(builder, b);
             Ok(SsaVal::Raw(builder.ins().urem(a, b), LIT_TAG_WORD))
         }
@@ -975,7 +1085,7 @@ pub fn emit_primop(
         PrimOpKind::NewByteArray => {
             // newByteArray# :: Int# -> State# s -> (# State# s, MutableByteArray# s #)
             // State# token may or may not be passed (1 or 2 args)
-            let size = unbox_int(pipeline, builder, args[0]);
+            let size = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let ba_ptr = emit_runtime_call(
                 pipeline,
                 builder,
@@ -996,7 +1106,7 @@ pub fn emit_primop(
 
         PrimOpKind::SizeofByteArray | PrimOpKind::SizeofMutableByteArray => {
             // sizeofByteArray# :: ByteArray# -> Int#
-            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             // Read u64 length from offset 0
             let len = builder.ins().load(types::I64, MemFlags::new(), ba_ptr, 0);
             Ok(SsaVal::Raw(len, LIT_TAG_INT))
@@ -1004,8 +1114,8 @@ pub fn emit_primop(
 
         PrimOpKind::ReadWord8Array | PrimOpKind::IndexWord8Array => {
             // readWord8Array# :: MutableByteArray# s -> Int# -> State# s -> (# State# s, Word# #)
-            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
-            let idx = unbox_int(pipeline, builder, args[1]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let idx = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             // Data starts at offset 8
             let base = builder.ins().iadd_imm(ba_ptr, 8);
             let effective = builder.ins().iadd(base, idx);
@@ -1016,9 +1126,9 @@ pub fn emit_primop(
 
         PrimOpKind::WriteWord8Array => {
             // writeWord8Array# :: MutableByteArray# s -> Int# -> Word# -> State# s -> State# s
-            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
-            let idx = unbox_int(pipeline, builder, args[1]);
-            let val = unbox_int(pipeline, builder, args[2]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let idx = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let val = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
             let base = builder.ins().iadd_imm(ba_ptr, 8);
             let effective = builder.ins().iadd(base, idx);
             let byte = builder.ins().ireduce(types::I8, val);
@@ -1032,8 +1142,8 @@ pub fn emit_primop(
 
         PrimOpKind::IndexWordArray | PrimOpKind::ReadWordArray => {
             // indexWordArray# :: ByteArray# -> Int# -> Word#
-            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
-            let idx = unbox_int(pipeline, builder, args[1]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let idx = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let base = builder.ins().iadd_imm(ba_ptr, 8);
             // Word-sized (8 bytes) indexing
             let byte_offset = builder.ins().imul_imm(idx, 8);
@@ -1046,9 +1156,9 @@ pub fn emit_primop(
 
         PrimOpKind::WriteWordArray => {
             // writeWordArray# :: MutableByteArray# s -> Int# -> Word# -> State# s -> State# s
-            let ba_ptr = unbox_bytearray(pipeline, builder, args[0]);
-            let idx = unbox_int(pipeline, builder, args[1]);
-            let val = unbox_int(pipeline, builder, args[2]);
+            let ba_ptr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let idx = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let val = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
             let base = builder.ins().iadd_imm(ba_ptr, 8);
             let byte_offset = builder.ins().imul_imm(idx, 8);
             let effective = builder.ins().iadd(base, byte_offset);
@@ -1061,10 +1171,10 @@ pub fn emit_primop(
 
         PrimOpKind::CopyAddrToByteArray => {
             // copyAddrToByteArray# :: Addr# -> MutableByteArray# s -> Int# -> Int# -> State# s -> State# s
-            let src = unbox_addr(pipeline, builder, args[0]);
-            let dest_ba = unbox_bytearray(pipeline, builder, args[1]);
-            let dest_off = unbox_int(pipeline, builder, args[2]);
-            let len = unbox_int(pipeline, builder, args[3]);
+            let src = unbox_addr(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let dest_ba = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let dest_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1086,10 +1196,10 @@ pub fn emit_primop(
 
         PrimOpKind::SetByteArray => {
             // setByteArray# :: MutableByteArray# s -> Int# -> Int# -> Int# -> State# s -> State# s
-            let ba = unbox_bytearray(pipeline, builder, args[0]);
-            let off = unbox_int(pipeline, builder, args[1]);
-            let len = unbox_int(pipeline, builder, args[2]);
-            let val = unbox_int(pipeline, builder, args[3]);
+            let ba = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let val = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1111,8 +1221,8 @@ pub fn emit_primop(
 
         PrimOpKind::ShrinkMutableByteArray => {
             // shrinkMutableByteArray# :: MutableByteArray# s -> Int# -> State# s -> State# s
-            let ba = unbox_bytearray(pipeline, builder, args[0]);
-            let new_size = unbox_int(pipeline, builder, args[1]);
+            let ba = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let new_size = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1130,8 +1240,8 @@ pub fn emit_primop(
             // resizeMutableByteArray# :: MutableByteArray# s -> Int# -> State# s
             //   -> (# State# s, MutableByteArray# s #)
             // Returns the (possibly reallocated) byte array pointer.
-            let ba = unbox_bytearray(pipeline, builder, args[0]);
-            let new_size = unbox_int(pipeline, builder, args[1]);
+            let ba = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let new_size = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1146,11 +1256,11 @@ pub fn emit_primop(
         PrimOpKind::CopyByteArray => {
             // copyByteArray# :: ByteArray# -> Int# -> MutableByteArray# s -> Int# -> Int# -> State# s -> State# s
             // src, src_off, dest, dest_off, len
-            let src = unbox_bytearray(pipeline, builder, args[0]);
-            let src_off = unbox_int(pipeline, builder, args[1]);
-            let dest = unbox_bytearray(pipeline, builder, args[2]);
-            let dest_off = unbox_int(pipeline, builder, args[3]);
-            let len = unbox_int(pipeline, builder, args[4]);
+            let src = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let src_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let dest = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let dest_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[4]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1172,11 +1282,11 @@ pub fn emit_primop(
         }
         PrimOpKind::CopyMutableByteArray => {
             // copyMutableByteArray# \u2014 same args as CopyByteArray
-            let src = unbox_bytearray(pipeline, builder, args[0]);
-            let src_off = unbox_int(pipeline, builder, args[1]);
-            let dest = unbox_bytearray(pipeline, builder, args[2]);
-            let dest_off = unbox_int(pipeline, builder, args[3]);
-            let len = unbox_int(pipeline, builder, args[4]);
+            let src = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let src_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let dest = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let dest_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[4]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1205,11 +1315,11 @@ pub fn emit_primop(
                     args.len(),
                 ));
             }
-            let a = unbox_bytearray(pipeline, builder, args[0]);
-            let a_off = unbox_int(pipeline, builder, args[1]);
-            let b = unbox_bytearray(pipeline, builder, args[2]);
-            let b_off = unbox_int(pipeline, builder, args[3]);
-            let len = unbox_int(pipeline, builder, args[4]);
+            let a = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let a_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let b = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let b_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[4]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1228,8 +1338,8 @@ pub fn emit_primop(
         }
         PrimOpKind::IndexWord8OffAddr => {
             // indexWord8OffAddr# :: Addr# -> Int# -> Word#
-            let addr = unbox_addr(pipeline, builder, args[0]);
-            let off = unbox_int(pipeline, builder, args[1]);
+            let addr = unbox_addr(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let ptr = builder.ins().iadd(addr, off);
             let byte = builder.ins().load(types::I8, MemFlags::trusted(), ptr, 0);
             let word = builder.ins().uextend(types::I64, byte);
@@ -1238,7 +1348,7 @@ pub fn emit_primop(
         PrimOpKind::Clz8 => {
             // clz8# :: Word# -> Word#
             check_arity(op, 1, args.len())?;
-            let v = unbox_int(pipeline, builder, args[0]);
+            let v = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let narrow = builder.ins().ireduce(types::I8, v);
             let clz8 = builder.ins().clz(narrow);
             let result = builder.ins().uextend(types::I64, clz8);
@@ -1262,7 +1372,7 @@ pub fn emit_primop(
         }
         PrimOpKind::FfiStrlen => {
             // strlen :: Addr# -> Int#
-            let addr = unbox_addr(pipeline, builder, args[0]);
+            let addr = unbox_addr(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1275,11 +1385,11 @@ pub fn emit_primop(
         }
         PrimOpKind::FfiTextMeasureOff => {
             // _hs_text_measure_off :: ByteArray# -> CSize -> CSize -> CSize -> CSsize
-            let ba = unbox_bytearray(pipeline, builder, args[0]);
+            let ba = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let data_ptr = builder.ins().iadd_imm(ba, 8); // skip length prefix
-            let off = unbox_int(pipeline, builder, args[1]);
-            let len = unbox_int(pipeline, builder, args[2]);
-            let cnt = unbox_int(pipeline, builder, args[3]);
+            let off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let cnt = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1297,11 +1407,11 @@ pub fn emit_primop(
         }
         PrimOpKind::FfiTextMemchr => {
             // _hs_text_memchr :: ByteArray# -> CSize -> CSize -> Word8 -> CSsize
-            let ba = unbox_bytearray(pipeline, builder, args[0]);
+            let ba = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let data_ptr = builder.ins().iadd_imm(ba, 8); // skip length prefix
-            let off = unbox_int(pipeline, builder, args[1]);
-            let len = unbox_int(pipeline, builder, args[2]);
-            let needle = unbox_int(pipeline, builder, args[3]);
+            let off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let needle = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1319,12 +1429,12 @@ pub fn emit_primop(
         }
         PrimOpKind::FfiTextReverse => {
             // _hs_text_reverse :: MutableByteArray# -> ByteArray# -> CSize -> CSize -> ()
-            let dest_ba = unbox_bytearray(pipeline, builder, args[0]);
+            let dest_ba = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let dest_ptr = builder.ins().iadd_imm(dest_ba, 8); // skip length prefix
-            let src_ba = unbox_bytearray(pipeline, builder, args[1]);
+            let src_ba = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let src_ptr = builder.ins().iadd_imm(src_ba, 8); // skip length prefix
-            let off = unbox_int(pipeline, builder, args[2]);
-            let len = unbox_int(pipeline, builder, args[3]);
+            let off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1347,40 +1457,43 @@ pub fn emit_primop(
         // Float arithmetic + comparison
         PrimOpKind::FloatAdd => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_float(pipeline, builder, args[0]);
-            let b = unbox_float(pipeline, builder, args[1]);
+            let a = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().fadd(a, b), LIT_TAG_FLOAT))
         }
         PrimOpKind::FloatSub => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_float(pipeline, builder, args[0]);
-            let b = unbox_float(pipeline, builder, args[1]);
+            let a = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().fsub(a, b), LIT_TAG_FLOAT))
         }
         PrimOpKind::FloatMul => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_float(pipeline, builder, args[0]);
-            let b = unbox_float(pipeline, builder, args[1]);
+            let a = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().fmul(a, b), LIT_TAG_FLOAT))
         }
         PrimOpKind::FloatDiv => {
             check_arity(op, 2, args.len())?;
-            let a = unbox_float(pipeline, builder, args[0]);
-            let b = unbox_float(pipeline, builder, args[1]);
+            let a = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let b = unbox_float(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             Ok(SsaVal::Raw(builder.ins().fdiv(a, b), LIT_TAG_FLOAT))
         }
         PrimOpKind::FloatEq => {
-            emit_float_compare(pipeline, builder, op, FloatCC::Equal, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, FloatCC::Equal, args, LIT_TAG_INT)
         }
         PrimOpKind::FloatNe => {
-            emit_float_compare(pipeline, builder, op, FloatCC::NotEqual, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, FloatCC::NotEqual, args, LIT_TAG_INT)
         }
         PrimOpKind::FloatLt => {
-            emit_float_compare(pipeline, builder, op, FloatCC::LessThan, args, LIT_TAG_INT)
+            emit_float_compare(pipeline, builder, vmctx, gc_sig, oom_func, op, FloatCC::LessThan, args, LIT_TAG_INT)
         }
         PrimOpKind::FloatLe => emit_float_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             FloatCC::LessThanOrEqual,
             args,
@@ -1389,6 +1502,9 @@ pub fn emit_primop(
         PrimOpKind::FloatGt => emit_float_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             FloatCC::GreaterThan,
             args,
@@ -1397,6 +1513,9 @@ pub fn emit_primop(
         PrimOpKind::FloatGe => emit_float_compare(
             pipeline,
             builder,
+            vmctx,
+            gc_sig,
+            oom_func,
             op,
             FloatCC::GreaterThanOrEqual,
             args,
@@ -1414,7 +1533,7 @@ pub fn emit_primop(
         // ---------------------------------------------------------------
         PrimOpKind::NewSmallArray | PrimOpKind::NewArray => {
             // newSmallArray# :: Int# -> a -> State# -> (# State#, SmallMutableArray# s a #)
-            let size = unbox_int(pipeline, builder, args[0]);
+            let size = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let init_ptr = args[1].value();
             let arr_ptr = emit_runtime_call(
                 pipeline,
@@ -1448,8 +1567,8 @@ pub fn emit_primop(
                     args
                 )));
             }
-            let arr_ptr = unbox_bytearray(pipeline, builder, args[0]);
-            let idx = unbox_int(pipeline, builder, args[1]);
+            let arr_ptr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let idx = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let base = builder.ins().iadd_imm(arr_ptr, 8);
             let byte_offset = builder.ins().imul_imm(idx, 8);
             let effective = builder.ins().iadd(base, byte_offset);
@@ -1462,8 +1581,8 @@ pub fn emit_primop(
 
         PrimOpKind::WriteSmallArray | PrimOpKind::WriteArray => {
             // writeSmallArray# :: SmallMutableArray# s a -> Int# -> a -> State# -> State#
-            let arr_ptr = unbox_bytearray(pipeline, builder, args[0]);
-            let idx = unbox_int(pipeline, builder, args[1]);
+            let arr_ptr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let idx = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let val = args[2].value();
             let base = builder.ins().iadd_imm(arr_ptr, 8);
             let byte_offset = builder.ins().imul_imm(idx, 8);
@@ -1480,7 +1599,7 @@ pub fn emit_primop(
         | PrimOpKind::SizeofArray
         | PrimOpKind::SizeofMutableArray => {
             // sizeofSmallArray# :: SmallArray# a -> Int#
-            let arr_ptr = unbox_bytearray(pipeline, builder, args[0]);
+            let arr_ptr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let len = builder.ins().load(types::I64, MemFlags::new(), arr_ptr, 0);
             Ok(SsaVal::Raw(len, LIT_TAG_INT))
         }
@@ -1498,11 +1617,11 @@ pub fn emit_primop(
         | PrimOpKind::CopyArray
         | PrimOpKind::CopyMutableArray => {
             // copySmallArray# :: src -> src_off -> dest -> dest_off -> len -> State# -> State#
-            let src = unbox_bytearray(pipeline, builder, args[0]);
-            let src_off = unbox_int(pipeline, builder, args[1]);
-            let dest = unbox_bytearray(pipeline, builder, args[2]);
-            let dest_off = unbox_int(pipeline, builder, args[3]);
-            let len = unbox_int(pipeline, builder, args[4]);
+            let src = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let src_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let dest = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
+            let dest_off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[3]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[4]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1525,9 +1644,9 @@ pub fn emit_primop(
 
         PrimOpKind::CloneSmallArray | PrimOpKind::CloneSmallMutableArray => {
             // cloneSmallArray# :: SmallArray# a -> Int# -> Int# -> SmallArray# a
-            let arr = unbox_bytearray(pipeline, builder, args[0]);
-            let off = unbox_int(pipeline, builder, args[1]);
-            let len = unbox_int(pipeline, builder, args[2]);
+            let arr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1551,9 +1670,9 @@ pub fn emit_primop(
         }
 
         PrimOpKind::CloneArray | PrimOpKind::CloneMutableArray => {
-            let arr = unbox_bytearray(pipeline, builder, args[0]);
-            let off = unbox_int(pipeline, builder, args[1]);
-            let len = unbox_int(pipeline, builder, args[2]);
+            let arr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let off = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
+            let len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[2]);
             let result = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1577,8 +1696,8 @@ pub fn emit_primop(
         }
 
         PrimOpKind::ShrinkSmallMutableArray => {
-            let arr = unbox_bytearray(pipeline, builder, args[0]);
-            let new_len = unbox_int(pipeline, builder, args[1]);
+            let arr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let new_len = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let _ = emit_runtime_call(
                 pipeline,
                 builder,
@@ -1598,8 +1717,8 @@ pub fn emit_primop(
             //   -> (# State# s, Int#, a #)
             // Returns (0#, old) if CAS succeeded, (1#, old) if failed.
             // We simplify: return the old value (caller checks).
-            let arr = unbox_bytearray(pipeline, builder, args[0]);
-            let idx = unbox_int(pipeline, builder, args[1]);
+            let arr = unbox_bytearray(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+            let idx = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
             let expected = args[2].value();
             let new_val = args[3].value();
             let old = emit_runtime_call(
@@ -1625,48 +1744,48 @@ pub fn emit_primop(
         // ---------------------------------------------------------------
         PrimOpKind::PopCnt | PrimOpKind::PopCnt64 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().popcnt(a), LIT_TAG_WORD))
         }
         PrimOpKind::PopCnt8 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let masked = builder.ins().band_imm(a, 0xFF);
             Ok(SsaVal::Raw(builder.ins().popcnt(masked), LIT_TAG_WORD))
         }
         PrimOpKind::PopCnt16 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let masked = builder.ins().band_imm(a, 0xFFFF);
             Ok(SsaVal::Raw(builder.ins().popcnt(masked), LIT_TAG_WORD))
         }
         PrimOpKind::PopCnt32 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let masked = builder.ins().band_imm(a, 0xFFFF_FFFF);
             Ok(SsaVal::Raw(builder.ins().popcnt(masked), LIT_TAG_WORD))
         }
         PrimOpKind::Ctz | PrimOpKind::Ctz64 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             Ok(SsaVal::Raw(builder.ins().ctz(a), LIT_TAG_WORD))
         }
         PrimOpKind::Ctz8 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             // Set bit 8 so ctz stops there if all lower 8 bits are zero
             let with_sentinel = builder.ins().bor_imm(a, 0x100);
             Ok(SsaVal::Raw(builder.ins().ctz(with_sentinel), LIT_TAG_WORD))
         }
         PrimOpKind::Ctz16 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let with_sentinel = builder.ins().bor_imm(a, 0x10000);
             Ok(SsaVal::Raw(builder.ins().ctz(with_sentinel), LIT_TAG_WORD))
         }
         PrimOpKind::Ctz32 => {
             check_arity(op, 1, args.len())?;
-            let a = unbox_int(pipeline, builder, args[0]);
+            let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
             let with_sentinel = builder.ins().bor_imm(a, 0x1_0000_0000);
             Ok(SsaVal::Raw(builder.ins().ctz(with_sentinel), LIT_TAG_WORD))
         }
@@ -1684,14 +1803,17 @@ fn check_arity(op: &PrimOpKind, expected: usize, got: usize) -> Result<(), EmitE
 fn emit_int_compare(
     pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    oom_func: ir::FuncRef,
     op: &PrimOpKind,
     cc: IntCC,
     args: &[SsaVal],
     tag: i64,
 ) -> Result<SsaVal, EmitError> {
     check_arity(op, 2, args.len())?;
-    let a = unbox_int(pipeline, builder, args[0]);
-    let b = unbox_int(pipeline, builder, args[1]);
+    let a = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+    let b = unbox_int(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
     let cmp = builder.ins().icmp(cc, a, b);
     Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp), tag))
 }
@@ -1699,66 +1821,112 @@ fn emit_int_compare(
 fn emit_float_compare(
     pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    oom_func: ir::FuncRef,
     op: &PrimOpKind,
     cc: FloatCC,
     args: &[SsaVal],
     tag: i64,
 ) -> Result<SsaVal, EmitError> {
     check_arity(op, 2, args.len())?;
-    let a = unbox_double(pipeline, builder, args[0]);
-    let b = unbox_double(pipeline, builder, args[1]);
+    let a = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[0]);
+    let b = unbox_double(pipeline, builder, vmctx, gc_sig, oom_func, args[1]);
     let cmp = builder.ins().fcmp(cc, a, b);
     Ok(SsaVal::Raw(builder.ins().uextend(types::I64, cmp), tag))
 }
 
+/// Helper to force thunks and unbox CON wrappers recursively until a LIT is reached.
+fn emit_force_and_unbox_loop(
+    pipeline: &mut CodegenPipeline,
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    initial_ptr: Value,
+) -> Value {
+    let loop_header = builder.create_block();
+    builder.append_block_param(loop_header, types::I64);
+    builder.ins().jump(loop_header, &[ir::BlockArg::Value(initial_ptr)]);
+
+    builder.switch_to_block(loop_header);
+    let curr_ptr = builder.block_params(loop_header)[0];
+    builder.declare_value_needs_stack_map(curr_ptr);
+
+    let zero = builder.ins().iconst(types::I64, 0);
+    let is_null = builder.ins().icmp(IntCC::Equal, curr_ptr, zero);
+    let check_tag_block = builder.create_block();
+    let done_block = builder.create_block();
+    builder.append_block_param(done_block, types::I64);
+
+    builder.ins().brif(is_null, done_block, &[ir::BlockArg::Value(curr_ptr)], check_tag_block, &[]);
+
+    builder.switch_to_block(check_tag_block);
+    builder.seal_block(check_tag_block);
+    let tag = builder.ins().load(types::I8, MemFlags::trusted(), curr_ptr, 0);
+
+    let force_block = builder.create_block();
+    let not_thunk_block = builder.create_block();
+
+    let is_thunk = builder.ins().icmp_imm(IntCC::Equal, tag, layout::TAG_THUNK as i64);
+    builder.ins().brif(is_thunk, force_block, &[], not_thunk_block, &[]);
+
+    builder.switch_to_block(force_block);
+    builder.seal_block(force_block);
+    let force_fn = pipeline
+        .module
+        .declare_function("heap_force", Linkage::Import, &{
+            let mut sig = Signature::new(pipeline.isa.default_call_conv());
+            sig.params.push(AbiParam::new(types::I64)); // vmctx
+            sig.params.push(AbiParam::new(types::I64)); // thunk
+            sig.returns.push(AbiParam::new(types::I64)); // result
+            sig
+        })
+        .unwrap();
+    let force_ref = pipeline.module.declare_func_in_func(force_fn, builder.func);
+    let call = builder.ins().call(force_ref, &[vmctx, curr_ptr]);
+    let forced = builder.inst_results(call)[0];
+    builder.declare_value_needs_stack_map(forced);
+    builder.ins().jump(loop_header, &[ir::BlockArg::Value(forced)]);
+
+    builder.switch_to_block(not_thunk_block);
+    builder.seal_block(not_thunk_block);
+
+    let con_block = builder.create_block();
+    let is_con = builder.ins().icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
+    builder.ins().brif(is_con, con_block, &[], done_block, &[ir::BlockArg::Value(curr_ptr)]);
+
+    builder.switch_to_block(con_block);
+    builder.seal_block(con_block);
+    let field0 = builder.ins().load(
+        types::I64,
+        MemFlags::trusted(),
+        curr_ptr,
+        layout::CON_FIELDS_OFFSET as i32,
+    );
+    builder.declare_value_needs_stack_map(field0);
+    builder.ins().jump(loop_header, &[ir::BlockArg::Value(field0)]);
+
+    builder.seal_block(loop_header);
+
+    builder.switch_to_block(done_block);
+    builder.seal_block(done_block);
+    let result = builder.block_params(done_block)[0];
+    builder.declare_value_needs_stack_map(result);
+    result
+}
+
 /// Unbox an Addr# value recursively.
 fn unbox_addr(
-    _pipeline: &mut CodegenPipeline,
+    pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
+    vmctx: Value,
+    _gc_sig: ir::SigRef,
+    _oom_func: ir::FuncRef,
     val: SsaVal,
 ) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
-            let start_block = builder.create_block();
-            let next_block = builder.create_block();
-            builder.append_block_param(start_block, types::I64);
-            builder.append_block_param(next_block, types::I64);
-
-            builder.ins().jump(start_block, &[BlockArg::Value(v)]);
-
-            builder.switch_to_block(start_block);
-            let curr_v = builder.block_params(start_block)[0];
-            let tag = builder
-                .ins()
-                .load(types::I8, MemFlags::trusted(), curr_v, 0);
-            let is_con = builder
-                .ins()
-                .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
-
-            let con_block = builder.create_block();
-            builder.ins().brif(
-                is_con,
-                con_block,
-                &[],
-                next_block,
-                &[BlockArg::Value(curr_v)],
-            );
-
-            builder.switch_to_block(con_block);
-            builder.seal_block(con_block);
-            let field0 = builder.ins().load(
-                types::I64,
-                MemFlags::trusted(),
-                curr_v,
-                layout::CON_FIELDS_OFFSET as i32,
-            );
-            builder.ins().jump(start_block, &[BlockArg::Value(field0)]);
-
-            builder.switch_to_block(next_block);
-            builder.seal_block(start_block);
-            builder.seal_block(next_block);
-            let v_final = builder.block_params(next_block)[0];
+            let v_final = emit_force_and_unbox_loop(pipeline, builder, vmctx, v);
 
             let raw_val =
                 builder
@@ -1785,52 +1953,17 @@ fn unbox_addr(
 
 /// Extract the raw ByteArray pointer from a Lit(BYTEARRAY) heap object recursively.
 fn unbox_bytearray(
-    _pipeline: &mut CodegenPipeline,
+    pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
+    vmctx: Value,
+    _gc_sig: ir::SigRef,
+    _oom_func: ir::FuncRef,
     val: SsaVal,
 ) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
-            let start_block = builder.create_block();
-            let next_block = builder.create_block();
-            builder.append_block_param(start_block, types::I64);
-            builder.append_block_param(next_block, types::I64);
-
-            builder.ins().jump(start_block, &[BlockArg::Value(v)]);
-
-            builder.switch_to_block(start_block);
-            let curr_v = builder.block_params(start_block)[0];
-            let tag = builder
-                .ins()
-                .load(types::I8, MemFlags::trusted(), curr_v, 0);
-            let is_con = builder
-                .ins()
-                .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
-
-            let con_block = builder.create_block();
-            builder.ins().brif(
-                is_con,
-                con_block,
-                &[],
-                next_block,
-                &[BlockArg::Value(curr_v)],
-            );
-
-            builder.switch_to_block(con_block);
-            builder.seal_block(con_block);
-            let field0 = builder.ins().load(
-                types::I64,
-                MemFlags::trusted(),
-                curr_v,
-                layout::CON_FIELDS_OFFSET as i32,
-            );
-            builder.ins().jump(start_block, &[BlockArg::Value(field0)]);
-
-            builder.switch_to_block(next_block);
-            builder.seal_block(start_block);
-            builder.seal_block(next_block);
-            let v_final = builder.block_params(next_block)[0];
+            let v_final = emit_force_and_unbox_loop(pipeline, builder, vmctx, v);
 
             let raw_val =
                 builder
@@ -1853,53 +1986,17 @@ fn unbox_bytearray(
 }
 
 pub fn unbox_int(
-    _pipeline: &mut CodegenPipeline,
+    pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
+    vmctx: Value,
+    _gc_sig: ir::SigRef,
+    _oom_func: ir::FuncRef,
     val: SsaVal,
 ) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
-            let start_block = builder.create_block();
-            let next_block = builder.create_block();
-            builder.append_block_param(start_block, types::I64);
-            builder.append_block_param(next_block, types::I64);
-
-            builder.ins().jump(start_block, &[BlockArg::Value(v)]);
-
-            builder.switch_to_block(start_block);
-            let curr_v = builder.block_params(start_block)[0];
-            let tag = builder
-                .ins()
-                .load(types::I8, MemFlags::trusted(), curr_v, 0);
-            let is_con = builder
-                .ins()
-                .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
-
-            let con_block = builder.create_block();
-            builder.ins().brif(
-                is_con,
-                con_block,
-                &[],
-                next_block,
-                &[BlockArg::Value(curr_v)],
-            );
-
-            builder.switch_to_block(con_block);
-            builder.seal_block(con_block);
-            let field0 = builder.ins().load(
-                types::I64,
-                MemFlags::trusted(),
-                curr_v,
-                layout::CON_FIELDS_OFFSET as i32,
-            );
-            builder.ins().jump(start_block, &[BlockArg::Value(field0)]);
-
-            builder.switch_to_block(next_block);
-            builder.seal_block(start_block);
-            builder.seal_block(next_block);
-            let v_final = builder.block_params(next_block)[0];
-
+            let v_final = emit_force_and_unbox_loop(pipeline, builder, vmctx, v);
             builder
                 .ins()
                 .load(types::I64, MemFlags::trusted(), v_final, LIT_VALUE_OFFSET)
@@ -1908,53 +2005,17 @@ pub fn unbox_int(
 }
 
 pub fn unbox_double(
-    _pipeline: &mut CodegenPipeline,
+    pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
+    vmctx: Value,
+    _gc_sig: ir::SigRef,
+    _oom_func: ir::FuncRef,
     val: SsaVal,
 ) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
-            let start_block = builder.create_block();
-            let next_block = builder.create_block();
-            builder.append_block_param(start_block, types::I64);
-            builder.append_block_param(next_block, types::I64);
-
-            builder.ins().jump(start_block, &[BlockArg::Value(v)]);
-
-            builder.switch_to_block(start_block);
-            let curr_v = builder.block_params(start_block)[0];
-            let tag = builder
-                .ins()
-                .load(types::I8, MemFlags::trusted(), curr_v, 0);
-            let is_con = builder
-                .ins()
-                .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
-
-            let con_block = builder.create_block();
-            builder.ins().brif(
-                is_con,
-                con_block,
-                &[],
-                next_block,
-                &[BlockArg::Value(curr_v)],
-            );
-
-            builder.switch_to_block(con_block);
-            builder.seal_block(con_block);
-            let field0 = builder.ins().load(
-                types::I64,
-                MemFlags::trusted(),
-                curr_v,
-                layout::CON_FIELDS_OFFSET as i32,
-            );
-            builder.ins().jump(start_block, &[BlockArg::Value(field0)]);
-
-            builder.switch_to_block(next_block);
-            builder.seal_block(start_block);
-            builder.seal_block(next_block);
-            let v_final = builder.block_params(next_block)[0];
-
+            let v_final = emit_force_and_unbox_loop(pipeline, builder, vmctx, v);
             builder
                 .ins()
                 .load(types::F64, MemFlags::trusted(), v_final, LIT_VALUE_OFFSET)
@@ -1963,53 +2024,17 @@ pub fn unbox_double(
 }
 
 pub fn unbox_float(
-    _pipeline: &mut CodegenPipeline,
+    pipeline: &mut CodegenPipeline,
     builder: &mut FunctionBuilder,
+    vmctx: Value,
+    _gc_sig: ir::SigRef,
+    _oom_func: ir::FuncRef,
     val: SsaVal,
 ) -> Value {
     match val {
         SsaVal::Raw(v, _) => v,
         SsaVal::HeapPtr(v) => {
-            let start_block = builder.create_block();
-            let next_block = builder.create_block();
-            builder.append_block_param(start_block, types::I64);
-            builder.append_block_param(next_block, types::I64);
-
-            builder.ins().jump(start_block, &[BlockArg::Value(v)]);
-
-            builder.switch_to_block(start_block);
-            let curr_v = builder.block_params(start_block)[0];
-            let tag = builder
-                .ins()
-                .load(types::I8, MemFlags::trusted(), curr_v, 0);
-            let is_con = builder
-                .ins()
-                .icmp_imm(IntCC::Equal, tag, layout::TAG_CON as i64);
-
-            let con_block = builder.create_block();
-            builder.ins().brif(
-                is_con,
-                con_block,
-                &[],
-                next_block,
-                &[BlockArg::Value(curr_v)],
-            );
-
-            builder.switch_to_block(con_block);
-            builder.seal_block(con_block);
-            let field0 = builder.ins().load(
-                types::I64,
-                MemFlags::trusted(),
-                curr_v,
-                layout::CON_FIELDS_OFFSET as i32,
-            );
-            builder.ins().jump(start_block, &[BlockArg::Value(field0)]);
-
-            builder.switch_to_block(next_block);
-            builder.seal_block(start_block);
-            builder.seal_block(next_block);
-            let v_final = builder.block_params(next_block)[0];
-
+            let v_final = emit_force_and_unbox_loop(pipeline, builder, vmctx, v);
             builder
                 .ins()
                 .load(types::F32, MemFlags::trusted(), v_final, LIT_VALUE_OFFSET)

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -270,8 +270,8 @@ pub extern "C" fn heap_force(vmctx: *mut VMContext, obj: *mut u8) -> *mut u8 {
         loop {
             let tag = layout::read_tag(current);
 
-            if tag >= 2 {
-                return current; // Con or Lit — already WHNF
+            if tag >= 2 || tag == layout::TAG_CLOSURE {
+                return current; // Con, Lit, or Closure — already WHNF
             }
 
             if tag == layout::TAG_THUNK {
@@ -321,31 +321,7 @@ pub extern "C" fn heap_force(vmctx: *mut VMContext, obj: *mut u8) -> *mut u8 {
                 }
             }
 
-            if tag != layout::TAG_CLOSURE {
-                return current; // Unknown — not handled here
-            }
-
-            // Closure: read code_ptr
-            let code_ptr_val = *(current.add(layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
-
-            if code_ptr_val == 0 {
-                RUNTIME_ERROR.with(|cell| {
-                    *cell.borrow_mut() = Some(RuntimeError::NullFunPtr);
-                });
-                return error_poison_ptr();
-            }
-
-            // Force the closure. In a data-case scrutinee position, GHC Core
-            // guarantees the result must be a data constructor, so any closure
-            // here is a thunk (suspended computation) regardless of capture count.
-            // SAFETY: code_ptr is a JIT-compiled function pointer. The JIT guarantees
-            // it points to a function with this exact signature (closure calling convention).
-            let f: extern "C" fn(*mut VMContext, *mut u8, *mut u8) -> *mut u8 =
-                std::mem::transmute(code_ptr_val);
-            let result = f(vmctx, current, std::ptr::null_mut());
-
-            // Closure result may be a thunk — loop to force it
-            current = result;
+            return current; // Unknown — not handled here
         }
     }
 }

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -1776,6 +1776,7 @@ mod tests {
     /// Compile and run a Haskell snippet through the JIT with the full handler stack.
     /// Returns the result as serde_json::Value, or panics on error.
     fn jit_eval(code: &[&str]) -> serde_json::Value {
+        tidepool_codegen::signal_safety::install();
         let source = jit_test_source(code);
         let include = prelude_include();
         let include_paths: Vec<&std::path::Path> = vec![include.as_path()];


### PR DESCRIPTION
Fixes a SIGSEGV in `test_jit_git_show_roundtrip` (and others) caused by incorrect handling of thunks during JIT execution:
- Fixed `heap_force` so it no longer erroneously forces closures by applying them to `NULL` (closures are already in WHNF).
- Updated `EmitFrame::App` and `EmitFrame::Case` to explicitly force only `TAG_THUNK` objects, preventing them from inadvertently attempting to force a closure or reading garbage.
- Corrected the `unbox_*` helpers in `primop.rs` to forcefully evaluate thunks recursively (and peel `newtype` constructors) before extracting literal values.
- Also added JIT signal handlers to `jit_eval` to improve test diagnostics.

All JIT tests now pass cleanly.