### PR TITLE
feat: Implement Thunk Creation for Non-Trivial Con Fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,107 @@ Compile freer-simple effect stacks into Cranelift-backed state machines drivable
 
 ---
 
+## Rules
+
+All rules from the exomonad project apply here. Additionally:
+
+### Locked Decisions
+
+The Key Decisions Reference section below is the source of truth for all architectural decisions. Every entry is final. Do not deviate from locked decisions. Do not re-derive them. If you need a decision that isn't there, escalate to the human.
+
+### Plans
+
+`plans/README.md` tracks the current active plan. Read it before starting new work.
+
+---
+
+## Orchestration Model
+
+This project is built by a tree of agents managed by ExoMonad. Understanding the execution model is mandatory for every TL agent.
+
+### Roles
+
+- **Human (root):** Owns `main`. Makes architectural decisions. Approves phase gates.
+- **TL (Claude Opus):** Owns a subtree branch (e.g., `main.core-repr`). Decomposes work into leaf specs, spawns agents, merges their PRs. Never writes implementation code.
+- **Leaf (Gemini):** Spawned via `spawn_leaf_subtree`. Owns a leaf branch (e.g., `main.core-repr.scaffold`). Implements one task spec. Files PR. Iterates against Copilot review until clean. Calls `notify_parent` when done.
+- **Worker (Gemini):** Spawned via `spawn_workers`. Works in the parent's directory. Does NOT create branches, commit, or file PRs. Writes code, runs verify, calls `notify_parent`. The parent reviews and commits.
+
+### Fire-and-Forget Execution
+
+The TL's workflow is: **decompose -> spec -> spawn -> move on**. The TL does not wait, poll, review intermediate output, or manually re-spec.
+
+**Convergence is leaf + Copilot, not TL:**
+
+1. TL writes spec, spawns leaf, returns immediately
+2. Leaf works -> commits -> files PR
+3. GitHub poller detects Copilot review comments -> injects into leaf's pane
+4. Leaf reads Copilot feedback, fixes, pushes
+5. Copilot re-reviews; loop repeats until clean
+6. Leaf calls `notify_parent` with `success` -> TL gets `[CHILD COMPLETE]`
+7. TL reviews the merged diff (parallel merges may interact), then merges
+
+**`notify_parent` means DONE** — not "I filed a PR." The leaf owns its quality.
+
+### Spawn Tool Selection
+
+All spawn tools take the same structured `AgentSpec` (name, task, read_first, context, steps, verify, done_criteria, boundary). Branch names auto-derived from `spec.name`.
+
+| Tool | Default? | Use when | Litmus test |
+|------|----------|----------|-------------|
+| `spawn_leaf_subtree` | **Yes** | Any well-specified implementation task | Will the agent add mod declarations, deps, or re-exports? Multiple agents in parallel? → leaf. |
+| `spawn_workers` | No | Single agent doing scaffolding you'll commit yourself, OR multiple agents with provably zero file overlap | Can you list every file each agent touches, and the lists don't intersect at all? Not even lib.rs or Cargo.toml? If you have to think about it → use leaf. |
+| `spawn_subtree` | No | Task needs further decomposition or architectural judgment | 10-30x more expensive. Almost never needed. |
+
+**`spawn_leaf_subtree` is the default.** The worktree isolation and Copilot review loop make it the safe choice. The overhead (branch + PR) is handled automatically by tooling. The quality improvement from Copilot review is significant and free.
+
+**`spawn_workers` is the exception.** Workers share your directory. Use only for single-agent scaffolding gates where you review and commit directly. If any agent needs to touch Cargo.toml, lib.rs, or mod declarations alongside other agents — use leaf subtrees.
+
+### Spec Quality (You Only Get One Shot)
+
+Since the TL doesn't iterate on specs, the v1 spec must be production-quality. All `AgentSpec` fields map directly to prompt sections:
+
+| Field | Purpose |
+|-------|---------|
+| `boundary` | DO NOT rules — known failure modes (rendered FIRST in prompt) |
+| `read_first` | Exact files to read before coding |
+| `steps` | Numbered concrete actions with code snippets |
+| `verify` | Exact shell commands to run |
+| `done_criteria` | Measurable checklist for completion |
+| `context` | Freeform: code snippets, type signatures, examples |
+
+**Anti-patterns / boundary section is mandatory and comes first.** Known Gemini failure modes:
+
+| Failure Mode | Rule |
+|---|---|
+| Adds unnecessary dependencies | "ZERO external deps. Do NOT add serde/tokio/etc." |
+| Invents escape hatches | "No `todo!()`, `Raw(String)`, `Other(Box<dyn Any>)`" |
+| Writes thinking-out-loud comments | "Doc comments only. No stream-of-consciousness." |
+| Renames types/variants | "Use EXACT type signatures below." |
+| Makes architectural decisions | "Do not change module structure." |
+| Overengineers | "This is N lines in M files, not a new module." |
+
+Specs are self-contained. The leaf has no context from previous attempts. Include complete code snippets and full file paths.
+
+### Escalation, Not Iteration
+
+If a leaf fails after 3+ Copilot rounds, it calls `notify_parent` with `failure`. The TL then: re-decomposes (smaller leaves), tries a different approach, or escalates to the human. The TL never manually fixes a leaf's code.
+
+### Branch Hierarchy
+
+```
+main                              [human]
+├── main.core-repr                [TL - Claude]
+│   ├── main.core-repr.scaffold   [leaf - Gemini]
+│   ├── main.core-repr.serial     [leaf - Gemini]
+│   └── main.core-repr.pretty     [leaf - Gemini]
+├── main.core-eval                [TL - Claude]
+│   └── ...
+```
+
+PRs target parent branch (not main). Merged via recursive fold up the tree.
+
+---
+
 ## Project Structure
 
 ```

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -442,7 +442,7 @@ fn emit_subtree(
 }
 
 /// Determine if a Con field expression is trivial (should be evaluated eagerly).
-/// Trivial: Var that's already in the environment, or Lit.
+/// Trivial: Var that's already in the environment or an error sentinel (tag 0x45), or Lit.
 /// Non-trivial: App, Case, Con-with-children, PrimOp, etc. → thunkify.
 fn is_trivial_con_field(tree: &CoreExpr, idx: usize, env: &std::collections::HashMap<VarId, SsaVal>) -> bool {
     match &tree.nodes[idx] {
@@ -552,6 +552,11 @@ fn emit_lam(
 
     let mut inner_emit = EmitContext::new(ctx.prefix.clone());
     inner_emit.lambda_counter = ctx.lambda_counter;
+    inner_emit.depth = ctx.depth + 1;
+
+    if inner_emit.depth > 200 {
+        return Err(EmitError::DepthLimitExceeded);
+    }
 
     inner_emit.trace_scope(&format!("insert lam binder {:?}", binder));
     inner_emit.env.insert(binder, SsaVal::HeapPtr(arg_param));
@@ -747,6 +752,11 @@ fn emit_thunk(
     // 4. Set up inner emit context, load captures from thunk_self
     let mut inner_emit = EmitContext::new(ctx.prefix.clone());
     inner_emit.lambda_counter = ctx.lambda_counter;
+    inner_emit.depth = ctx.depth + 1;
+
+    if inner_emit.depth > 200 {
+        return Err(EmitError::DepthLimitExceeded);
+    }
 
     for (i, (var_id, _)) in captures.iter().enumerate() {
         let offset = THUNK_CAPTURED_START + 8 * i as i32;
@@ -1279,6 +1289,12 @@ impl EmitContext {
 
                         let mut inner_emit = EmitContext::new(self.prefix.clone());
                         inner_emit.lambda_counter = self.lambda_counter;
+                        inner_emit.depth = self.depth + 1;
+
+                        if inner_emit.depth > 200 {
+                            return Err(EmitError::DepthLimitExceeded);
+                        }
+
                         inner_emit
                             .env
                             .insert(lam_binder, SsaVal::HeapPtr(inner_arg));

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -32,7 +32,7 @@ enum EmitFrame<A> {
     // Simple recursive — children are A (stack-safe)
     Con {
         tag: DataConId,
-        fields: Vec<A>,
+        field_indices: Vec<usize>, // Raw tree indices — NOT mapped by hylomorphism
     },
     App {
         fun: A,
@@ -80,9 +80,9 @@ impl MappableFrame for EmitFrameToken {
             EmitFrame::Var(v) => EmitFrame::Var(v),
             EmitFrame::Lit(l) => EmitFrame::Lit(l),
             EmitFrame::LitString(b) => EmitFrame::LitString(b),
-            EmitFrame::Con { tag, fields } => EmitFrame::Con {
+            EmitFrame::Con { tag, field_indices } => EmitFrame::Con {
                 tag,
-                fields: fields.into_iter().map(&mut f).collect(),
+                field_indices, // Not mapped — raw indices preserved
             },
             EmitFrame::App { fun, arg } => EmitFrame::App {
                 fun: f(fun),
@@ -134,7 +134,7 @@ fn expand_node(tree: &CoreExpr, idx: usize) -> Result<EmitFrame<usize>, EmitErro
         CoreFrame::Lit(lit) => Ok(EmitFrame::Lit(lit.clone())),
         CoreFrame::Con { tag, fields } => Ok(EmitFrame::Con {
             tag: *tag,
-            fields: fields.clone(),
+            field_indices: fields.clone(),
         }),
         CoreFrame::App { fun, arg } => Ok(EmitFrame::App {
             fun: *fun,
@@ -237,13 +237,26 @@ fn collapse_frame(
                 Ok(SsaVal::HeapPtr(result))
             }
         },
-        EmitFrame::Con { tag, fields } => {
-            let field_vals: Vec<Value> = fields
-                .iter()
-                .map(|v| ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, *v))
-                .collect();
+        EmitFrame::Con { tag, field_indices } => {
+            let num_fields = field_indices.len();
+            let mut field_vals: Vec<Value> = Vec::with_capacity(num_fields);
 
-            let num_fields = field_vals.len();
+            for &idx in &field_indices {
+                if is_trivial_con_field(tree, idx, &ctx.env) {
+                    // Trivial field: evaluate eagerly via emit_node (same as before)
+                    let val = ctx.emit_node(
+                        pipeline, builder, vmctx, gc_sig, oom_func, tree, idx,
+                    )?;
+                    field_vals.push(ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, val));
+                } else {
+                    // Non-trivial field: compile as thunk
+                    let thunk_val = emit_thunk(
+                        ctx, pipeline, builder, vmctx, gc_sig, oom_func, tree, idx,
+                    )?;
+                    field_vals.push(thunk_val);
+                }
+            }
+
             let size = 24 + 8 * num_fields as u64;
             let ptr = emit_alloc_fast_path(builder, vmctx, size, gc_sig, oom_func);
 
@@ -426,6 +439,17 @@ fn emit_subtree(
         |idx| expand_node(tree, idx),
         |frame| collapse_frame(ctx, pipeline, builder, vmctx, gc_sig, oom_func, tree, frame),
     )
+}
+
+/// Determine if a Con field expression is trivial (should be evaluated eagerly).
+/// Trivial: Var that's already in the environment, or Lit.
+/// Non-trivial: App, Case, Con-with-children, PrimOp, etc. → thunkify.
+fn is_trivial_con_field(tree: &CoreExpr, idx: usize, env: &std::collections::HashMap<VarId, SsaVal>) -> bool {
+    match &tree.nodes[idx] {
+        CoreFrame::Var(v) => env.contains_key(v) || (v.0 >> 56) as u8 == 0x45, // bound var or error sentinel
+        CoreFrame::Lit(_) => true,
+        _ => false,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -623,6 +647,199 @@ fn emit_lam(
 
     builder.declare_value_needs_stack_map(closure_ptr);
     Ok(SsaVal::HeapPtr(closure_ptr))
+}
+
+/// Compile a non-trivial Con field as a thunk — a zero-arg closure that
+/// evaluates the expression on first force. Mirrors `emit_lam` but with
+/// a 2-param calling convention (vmctx, thunk_ptr) → result.
+#[allow(clippy::too_many_arguments)]
+fn emit_thunk(
+    ctx: &mut EmitContext,
+    pipeline: &mut CodegenPipeline,
+    builder: &mut FunctionBuilder,
+    vmctx: Value,
+    gc_sig: ir::SigRef,
+    oom_func: ir::FuncRef,
+    tree: &CoreExpr,
+    body_idx: usize,
+) -> Result<Value, EmitError> {
+    // 1. Extract subtree and find free variables
+    let body_tree = tree.extract_subtree(body_idx);
+    let fvs = tidepool_repr::free_vars::free_vars(&body_tree);
+
+    let dropped: Vec<VarId> = fvs
+        .iter()
+        .filter(|v| !ctx.env.contains_key(v))
+        .copied()
+        .collect();
+    if !dropped.is_empty() {
+        ctx.trace_scope(&format!(
+            "thunk capture: dropped {} free vars not in scope: {:?}",
+            dropped.len(),
+            dropped
+        ));
+    }
+    let mut sorted_fvs: Vec<VarId> = fvs
+        .into_iter()
+        .filter(|v| ctx.env.contains_key(v))
+        .collect();
+    sorted_fvs.sort_by_key(|v| v.0);
+
+    let captures: Vec<(VarId, SsaVal)> = sorted_fvs
+        .iter()
+        .map(|v| {
+            let val = ctx.env.get(v).ok_or_else(|| {
+                EmitError::MissingCaptureVar(
+                    *v,
+                    format!("Thunk capture: not in env (env has {} vars)", ctx.env.len()),
+                )
+            })?;
+            Ok::<_, EmitError>((*v, *val))
+        })
+        .collect::<Result<Vec<_>, EmitError>>()?;
+
+    // 2. Create thunk entry function: fn(vmctx, thunk_ptr) -> whnf_ptr
+    let thunk_name = ctx.next_lambda_name(); // reuse lambda naming
+    let mut thunk_sig = Signature::new(pipeline.isa.default_call_conv());
+    thunk_sig.params.push(AbiParam::new(types::I64)); // vmctx
+    thunk_sig.params.push(AbiParam::new(types::I64)); // thunk_ptr (self, for captures)
+    thunk_sig.returns.push(AbiParam::new(types::I64)); // result
+
+    let thunk_func_id = pipeline
+        .module
+        .declare_function(&thunk_name, Linkage::Local, &thunk_sig)
+        .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+    pipeline.register_lambda(thunk_func_id, thunk_name.clone());
+
+    // 3. Build inner function
+    let mut inner_ctx = Context::new();
+    inner_ctx.func.signature = thunk_sig;
+    inner_ctx.func.name = UserFuncName::default();
+
+    let mut inner_fb_ctx = FunctionBuilderContext::new();
+    let mut inner_builder = FunctionBuilder::new(&mut inner_ctx.func, &mut inner_fb_ctx);
+    let inner_block = inner_builder.create_block();
+    inner_builder.append_block_params_for_function_params(inner_block);
+    inner_builder.switch_to_block(inner_block);
+    inner_builder.seal_block(inner_block);
+
+    let inner_vmctx = inner_builder.block_params(inner_block)[0];
+    let thunk_self = inner_builder.block_params(inner_block)[1];
+    inner_builder.declare_value_needs_stack_map(thunk_self);
+
+    // GC sig + oom func for inner function
+    let mut inner_gc_sig = Signature::new(pipeline.isa.default_call_conv());
+    inner_gc_sig.params.push(AbiParam::new(types::I64));
+    let inner_gc_sig_ref = inner_builder.import_signature(inner_gc_sig);
+
+    let inner_oom_func = {
+        let mut sig = Signature::new(pipeline.isa.default_call_conv());
+        sig.returns.push(AbiParam::new(types::I64));
+        let func_id = pipeline
+            .module
+            .declare_function("runtime_oom", Linkage::Import, &sig)
+            .map_err(|e| EmitError::CraneliftError(format!("declare runtime_oom: {e}")))?;
+        pipeline
+            .module
+            .declare_func_in_func(func_id, inner_builder.func)
+    };
+
+    // 4. Set up inner emit context, load captures from thunk_self
+    let mut inner_emit = EmitContext::new(ctx.prefix.clone());
+    inner_emit.lambda_counter = ctx.lambda_counter;
+
+    for (i, (var_id, _)) in captures.iter().enumerate() {
+        let offset = THUNK_CAPTURED_START + 8 * i as i32;
+        let val = inner_builder
+            .ins()
+            .load(types::I64, MemFlags::trusted(), thunk_self, offset);
+        inner_builder.declare_value_needs_stack_map(val);
+        inner_emit.trace_scope(&format!("insert thunk capture {:?}", var_id));
+        inner_emit.env.insert(*var_id, SsaVal::HeapPtr(val));
+    }
+
+    // 5. Compile thunked expression body
+    let body_root = body_tree.nodes.len() - 1;
+    let body_result = inner_emit.emit_node(
+        pipeline,
+        &mut inner_builder,
+        inner_vmctx,
+        inner_gc_sig_ref,
+        inner_oom_func,
+        &body_tree,
+        body_root,
+    )?;
+    let ret_val = ensure_heap_ptr(
+        &mut inner_builder,
+        inner_vmctx,
+        inner_gc_sig_ref,
+        inner_oom_func,
+        body_result,
+    );
+
+    inner_builder.ins().return_(&[ret_val]);
+    inner_builder.finalize();
+
+    ctx.lambda_counter = inner_emit.lambda_counter;
+
+    // Debug: dump Cranelift IR when TIDEPOOL_DUMP_CLIF=1
+    if std::env::var("TIDEPOOL_DUMP_CLIF").is_ok() {
+        eprintln!("=== CLIF THUNK {} ({} captures) ===", thunk_name, captures.len());
+        for (i, (var_id, ssaval)) in captures.iter().enumerate() {
+            let kind = match ssaval {
+                SsaVal::HeapPtr(_) => "HeapPtr",
+                SsaVal::Raw(_, tag) => &format!("Raw(tag={})", tag),
+            };
+            eprintln!("  capture[{}]: VarId({:#x}) = {}", i, var_id.0, kind);
+        }
+        eprintln!("{}", inner_ctx.func.display());
+        eprintln!("=== END CLIF THUNK {} ===", thunk_name);
+    }
+
+    pipeline.define_function(thunk_func_id, &mut inner_ctx)?;
+
+    // 6. Allocate thunk heap object in outer function
+    let func_ref = pipeline
+        .module
+        .declare_func_in_func(thunk_func_id, builder.func);
+    let code_ptr = builder.ins().func_addr(types::I64, func_ref);
+
+    let num_captures = captures.len();
+    let thunk_size = 24 + 8 * num_captures as u64; // header(8) + state(8) + code_ptr(8) + captures
+    let thunk_ptr = emit_alloc_fast_path(builder, vmctx, thunk_size, gc_sig, oom_func);
+
+    // Write header: tag = TAG_THUNK, size
+    let tag_val = builder.ins().iconst(types::I8, layout::TAG_THUNK as i64);
+    builder
+        .ins()
+        .store(MemFlags::trusted(), tag_val, thunk_ptr, 0);
+    let size_val = builder.ins().iconst(types::I16, thunk_size as i64);
+    builder
+        .ins()
+        .store(MemFlags::trusted(), size_val, thunk_ptr, 1);
+
+    // Write state = Unevaluated (0) at offset 8
+    let state_val = builder.ins().iconst(types::I8, layout::THUNK_UNEVALUATED as i64);
+    builder
+        .ins()
+        .store(MemFlags::trusted(), state_val, thunk_ptr, THUNK_STATE_OFFSET);
+
+    // Write code pointer at offset 16
+    builder
+        .ins()
+        .store(MemFlags::trusted(), code_ptr, thunk_ptr, THUNK_CODE_PTR_OFFSET);
+
+    // Write captures at offset 24+
+    for (i, (_, ssaval)) in captures.iter().enumerate() {
+        let cap_val = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, *ssaval);
+        let offset = THUNK_CAPTURED_START + 8 * i as i32;
+        builder
+            .ins()
+            .store(MemFlags::trusted(), cap_val, thunk_ptr, offset);
+    }
+
+    builder.declare_value_needs_stack_map(thunk_ptr);
+    Ok(thunk_ptr) // Return as Value (Cranelift), not SsaVal — caller wraps in Con
 }
 
 // ---------------------------------------------------------------------------
@@ -1166,11 +1383,16 @@ impl EmitContext {
                                 deferred_cons.push((*ptr, field_indices.clone()));
                             } else {
                                 for (i, &f_idx) in field_indices.iter().enumerate() {
-                                    let val = self.emit_node(
-                                        pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
-                                    )?;
-                                    let field_val =
-                                        ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, val);
+                                    let field_val = if is_trivial_con_field(tree, f_idx, &self.env) {
+                                        let val = self.emit_node(
+                                            pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
+                                        )?;
+                                        ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, val)
+                                    } else {
+                                        emit_thunk(
+                                            self, pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
+                                        )?
+                                    };
                                     builder.ins().store(
                                         MemFlags::trusted(),
                                         field_val,
@@ -1314,11 +1536,16 @@ impl EmitContext {
                             remaining_deps.remove(binder);
                             if remaining_deps.is_empty() && !field_indices.is_empty() {
                                 for (i, &f_idx) in field_indices.iter().enumerate() {
-                                    let val = self.emit_node(
-                                        pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
-                                    )?;
-                                    let field_val =
-                                        ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, val);
+                                    let field_val = if is_trivial_con_field(tree, f_idx, &self.env) {
+                                        let val = self.emit_node(
+                                            pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
+                                        )?;
+                                        ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, val)
+                                    } else {
+                                        emit_thunk(
+                                            self, pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
+                                        )?
+                                    };
                                     builder.ins().store(
                                         MemFlags::trusted(),
                                         field_val,
@@ -1354,10 +1581,16 @@ impl EmitContext {
                     // incrementally during Phase 3c.
                     for (ptr, field_indices, _) in &deferred_con_deps {
                         for (i, &f_idx) in field_indices.iter().enumerate() {
-                            let val = self.emit_node(
-                                pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
-                            )?;
-                            let field_val = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, val);
+                            let field_val = if is_trivial_con_field(tree, f_idx, &self.env) {
+                                let val = self.emit_node(
+                                    pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
+                                )?;
+                                ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, val)
+                            } else {
+                                emit_thunk(
+                                    self, pipeline, builder, vmctx, gc_sig, oom_func, tree, f_idx,
+                                )?
+                            };
                             builder.ins().store(
                                 MemFlags::trusted(),
                                 field_val,

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -56,6 +56,7 @@ pub struct EmitContext {
     pub join_blocks: HashMap<JoinId, JoinInfo>,
     pub lambda_counter: u32,
     pub prefix: String,
+    pub depth: usize,
 }
 
 /// Placeholder for join point info (used by case/join leaf later).
@@ -76,6 +77,8 @@ pub enum EmitError {
     MissingCaptureVar(VarId, String),
     /// Internal invariant violation (should never happen).
     InternalError(String),
+    /// Recursion depth limit exceeded during compilation
+    DepthLimitExceeded,
 }
 
 impl std::fmt::Display for EmitError {
@@ -96,6 +99,7 @@ impl std::fmt::Display for EmitError {
                 write!(f, "missing capture variable VarId({:#x}): {}", v.0, ctx)
             }
             EmitError::InternalError(msg) => write!(f, "internal error: {}", msg),
+            EmitError::DepthLimitExceeded => write!(f, "recursion depth limit exceeded during compilation"),
         }
     }
 }
@@ -115,6 +119,7 @@ impl EmitContext {
             join_blocks: HashMap::new(),
             lambda_counter: 0,
             prefix,
+            depth: 0,
         }
     }
 

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -15,6 +15,10 @@ pub const CLOSURE_CAPTURED_START: i32 = 24;
 pub const CON_TAG_OFFSET: i32 = 8;
 pub const CON_NUM_FIELDS_OFFSET: i32 = 16;
 pub const CON_FIELDS_START: i32 = 24;
+// -- Thunk layout constants (i32 offsets for Cranelift) --
+pub const THUNK_STATE_OFFSET: i32 = 8;
+pub const THUNK_CODE_PTR_OFFSET: i32 = 16;
+pub const THUNK_CAPTURED_START: i32 = 24;
 pub const LIT_TAG_OFFSET: i32 = 8;
 pub const LIT_VALUE_OFFSET: i32 = 16;
 pub const LIT_TOTAL_SIZE: u64 = 24;

--- a/tidepool-codegen/tests/emit_expr.rs
+++ b/tidepool-codegen/tests/emit_expr.rs
@@ -2773,7 +2773,7 @@ fn test_emit_primop_conversions_extra() {
     }
 }
 
-/// Test that a Con with a non-trivial field (App) creates a thunk
+/// Test that a Con with a non-trivial field (LetNonRec) creates a thunk
 /// that is correctly forced when the field is used via Case.
 #[test]
 fn test_con_thunk_field_forced_by_case() {

--- a/tidepool-codegen/tests/emit_expr.rs
+++ b/tidepool-codegen/tests/emit_expr.rs
@@ -2772,3 +2772,97 @@ fn test_emit_primop_conversions_extra() {
         assert_eq!(read_lit_int(res_f2i.result_ptr), 3);
     }
 }
+
+/// Test that a Con with a non-trivial field (App) creates a thunk
+/// that is correctly forced when the field is used via Case.
+#[test]
+fn test_con_thunk_field_forced_by_case() {
+    // Build:
+    // let y = 43 in
+    // let thunk_body = Con(1, [y]) in
+    // let c = Con(0, [thunk_body]) in
+    // case (case c of { Con(0) [f] -> f }) of { Con(1) [x] -> x }
+    //
+    // 1. thunk_body is non-trivial (Let node), so it's thunked when used as a field.
+    // 2. Inner case extracts the thunk.
+    // 3. Outer case forces the thunk, which evaluates to Con(1, [43]).
+    // 4. Outer case matches Con(1, [x]) and returns x (Literal 43).
+    let y_id = VarId(10);
+    let f_id = VarId(11);
+    let x_id = VarId(12);
+    let b1_id = VarId(13);
+    let b2_id = VarId(14);
+
+    let tree = RecursiveTree {
+        nodes: vec![
+            CoreFrame::Lit(Literal::LitInt(43)), // 0
+            CoreFrame::Var(y_id),                // 1
+            CoreFrame::Con {                     // 2: Con(1, [y])
+                tag: DataConId(1),
+                fields: vec![1],
+            },
+            CoreFrame::LetNonRec {               // 3: let y = 43 in Con(1, [y])
+                binder: y_id,
+                rhs: 0,
+                body: 2,
+            },
+            CoreFrame::Con {                     // 4: Con(0, [3]) -- 3 is Let, so non-trivial
+                tag: DataConId(0),
+                fields: vec![3],
+            },
+            CoreFrame::Var(f_id),                // 5
+            CoreFrame::Case {                    // 6: Inner case, extracts Thunk
+                scrutinee: 4,
+                binder: b1_id,
+                alts: vec![Alt {
+                    con: AltCon::DataAlt(DataConId(0)),
+                    binders: vec![f_id],
+                    body: 5,
+                }],
+            },
+            CoreFrame::Var(x_id),                // 7
+            CoreFrame::Case {                    // 8: Outer case, forces Thunk, matches Con(1)
+                scrutinee: 6,
+                binder: b2_id,
+                alts: vec![Alt {
+                    con: AltCon::DataAlt(DataConId(1)),
+                    binders: vec![x_id],
+                    body: 7,
+                }],
+            },
+        ],
+    };
+
+    let result = compile_and_run(&tree);
+    unsafe {
+        assert_eq!(read_lit_int(result.result_ptr), 43);
+    }
+}
+
+
+#[test]
+fn test_con_trivial_fields_stay_eager() {
+    // Con(0, [Lit(10), Lit(20)]) — all Lit fields are trivial, no thunks
+    let tree = RecursiveTree {
+        nodes: vec![
+            CoreFrame::Lit(Literal::LitInt(10)), // 0
+            CoreFrame::Lit(Literal::LitInt(20)), // 1
+            CoreFrame::Con {
+                tag: DataConId(5),
+                fields: vec![0, 1],
+            }, // 2 (root)
+        ],
+    };
+    let result = compile_and_run(&tree);
+    unsafe {
+        assert_eq!(layout::read_tag(result.result_ptr), layout::TAG_CON);
+        assert_eq!(read_con_tag(result.result_ptr), 5);
+        // Fields should be direct values (Lit), not thunks
+        let f0 = read_con_field(result.result_ptr, 0);
+        let f1 = read_con_field(result.result_ptr, 1);
+        assert_eq!(layout::read_tag(f0), layout::TAG_LIT);
+        assert_eq!(layout::read_tag(f1), layout::TAG_LIT);
+        assert_eq!(read_lit_int(f0), 10);
+        assert_eq!(read_lit_int(f1), 20);
+    }
+}


### PR DESCRIPTION
This PR implements thunk creation for non-trivial `Con` fields during JIT codegen, per the task specification.

### Changes:
- Added thunk layout constants to `tidepool-codegen/src/emit/mod.rs`.
- Updated `EmitFrame::Con` to use raw tree indices to preserve stack safety for trivial fields while avoiding hylomorphism traversal for thunks.
- Implemented `is_trivial_con_field` to eagerly evaluate `Var` and `Lit` fields.
- Implemented `emit_thunk` to compile non-trivial fields into zero-arg closure functions that evaluate the expression on first force.
- Updated `collapse_frame` and `LetRec` emission phases to utilize the new logic.
- Added testing in `tidepool-codegen/tests/emit_expr.rs`.

### PR Review Fixes Applied
- Added an explicit `depth` counter to `EmitContext` (incremented in `emit_lam`, `emit_thunk`, and `LetRec`'s inner function compilation) with a limit of 200 to prevent stack overflows and severe compile-time blowups. Returns `EmitError::DepthLimitExceeded`.
- Updated doc comments in `tidepool-codegen/src/emit/expr.rs` and `tidepool-codegen/tests/emit_expr.rs` to accurately reflect implementation details.
- Addressed downstream test failure expectations: `effect_machine.rs` and `heap_bridge.rs` must force the newly created thunks before interpreting `Con` fields. Modifying these downstream crates is out-of-bounds for this PR, so `cargo test --workspace` failures are expected until the parent coordinates updates.