### PR TITLE
feat: add SIGSEGV/SIGILL crash context and diagnostics

### DIFF
--- a/tidepool-codegen/src/debug.rs
+++ b/tidepool-codegen/src/debug.rs
@@ -43,6 +43,24 @@ impl LambdaRegistry {
         self.entries.get(&code_ptr).map(|s| s.as_str())
     }
 
+    /// Look up a lambda name by an address within its body.
+    /// Finds the entry point <= addr that is closest to addr.
+    pub fn lookup_by_address(&self, addr: usize) -> Option<&str> {
+        let mut best: Option<(usize, &str)> = None;
+        for (&ptr, name) in &self.entries {
+            if ptr <= addr {
+                if let Some((best_ptr, _)) = best {
+                    if ptr > best_ptr {
+                        best = Some((ptr, name.as_str()));
+                    }
+                } else {
+                    best = Some((ptr, name.as_str()));
+                }
+            }
+        }
+        best.map(|(_, name)| name)
+    }
+
     /// Number of registered lambdas.
     pub fn len(&self) -> usize {
         self.entries.len()
@@ -73,6 +91,15 @@ pub fn lookup_lambda(code_ptr: usize) -> Option<String> {
     guard
         .as_ref()
         .and_then(|r| r.lookup(code_ptr))
+        .map(|s| s.to_string())
+}
+
+/// Look up a lambda name by an address within its body in the global registry.
+pub fn lookup_lambda_by_address(addr: usize) -> Option<String> {
+    let guard = LAMBDA_REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+    guard
+        .as_ref()
+        .and_then(|r| r.lookup_by_address(addr))
         .map(|s| s.to_string())
 }
 

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -76,6 +76,32 @@ thread_local! {
 
     /// Captured JIT diagnostics.
     static DIAGNOSTICS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+
+    static EXEC_CONTEXT: RefCell<String> = const { RefCell::new(String::new()) };
+    pub(crate) static SIGNAL_SAFE_CTX: Cell<[u8; 128]> = const { Cell::new([0u8; 128]) };
+    pub(crate) static SIGNAL_SAFE_CTX_LEN: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Set the current execution context for JIT code.
+/// This is used to provide more info when a signal (SIGSEGV/SIGILL) occurs.
+pub fn set_exec_context(ctx: &str) {
+    EXEC_CONTEXT.with(|c| {
+        let mut s = c.borrow_mut();
+        s.clear();
+        s.push_str(ctx);
+    });
+    SIGNAL_SAFE_CTX.with(|c| {
+        let mut buf = [0u8; 128];
+        let len = ctx.len().min(128);
+        buf[..len].copy_from_slice(&ctx.as_bytes()[..len]);
+        c.set(buf);
+    });
+    SIGNAL_SAFE_CTX_LEN.with(|c| c.set(ctx.len().min(128)));
+}
+
+/// Get the current execution context.
+pub fn get_exec_context() -> String {
+    EXEC_CONTEXT.with(|c| c.borrow().clone())
 }
 
 /// Push a diagnostic message to the thread-local buffer.

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -125,6 +125,7 @@ impl JitEffectMachine {
 
         let mut machine = CompiledEffectMachine::new(func_ptr, vmctx, tags);
         crate::host_fns::reset_call_depth();
+        crate::host_fns::set_exec_context("stepping main function");
         let mut yield_result =
             match unsafe { crate::signal_safety::with_signal_protection(|| machine.step()) } {
                 Ok(y) => y,
@@ -178,6 +179,7 @@ impl JitEffectMachine {
                     .map_err(JitError::Signal)?
                     .map_err(JitError::HeapBridge)?;
                     crate::host_fns::reset_call_depth();
+                    crate::host_fns::set_exec_context(&format!("resuming after effect tag={}", tag));
                     yield_result = match unsafe {
                         crate::signal_safety::with_signal_protection(|| {
                             machine.resume(continuation, resp_ptr)
@@ -215,6 +217,7 @@ impl JitEffectMachine {
         let mut vmctx = self.nursery.make_vmctx(crate::host_fns::gc_trigger);
 
         crate::host_fns::reset_call_depth();
+        crate::host_fns::set_exec_context("running pure computation");
         let result_ptr: *mut u8 = match unsafe {
             crate::signal_safety::with_signal_protection(|| func_ptr(&mut vmctx))
         } {
@@ -258,9 +261,26 @@ impl JitEffectMachine {
 /// signal error. A runtime error like BadFunPtrTag is set by debug_app_check
 /// before the JIT continues and crashes — prefer it over the raw signal number.
 fn runtime_error_or_signal(sig: i32) -> crate::yield_type::YieldError {
+    let fault_addr = crate::signal_safety::FAULTING_ADDR.with(|c| c.get());
     if let Some(err) = crate::host_fns::take_runtime_error() {
+        if fault_addr != 0 {
+            if let Some(name) = crate::debug::lookup_lambda_by_address(fault_addr) {
+                crate::host_fns::push_diagnostic(format!(
+                    "Faulting JIT function: {} (addr=0x{:x})",
+                    name, fault_addr
+                ));
+            }
+        }
         crate::yield_type::YieldError::from(err)
     } else {
+        if fault_addr != 0 {
+            if let Some(name) = crate::debug::lookup_lambda_by_address(fault_addr) {
+                crate::host_fns::push_diagnostic(format!(
+                    "Signal {} in JIT function: {} (addr=0x{:x})",
+                    sig, name, fault_addr
+                ));
+            }
+        }
         crate::yield_type::YieldError::Signal(sig)
     }
 }

--- a/tidepool-codegen/src/signal_safety.rs
+++ b/tidepool-codegen/src/signal_safety.rs
@@ -51,7 +51,7 @@ mod inner {
             _ => b"UNKNOWN",
         };
 
-        let mut buf = [0u8; 256];
+        let mut buf = [0u8; 512];
         let mut pos = 0;
 
         // "[tidepool-crash] sig="
@@ -120,6 +120,22 @@ mod inner {
         }
         buf[pos..pos + ts_len].copy_from_slice(&ts_buf[..ts_len]);
         pos += ts_len;
+
+        // " ctx="
+        let ctx_prefix = b" ctx=";
+        buf[pos..pos + ctx_prefix.len()].copy_from_slice(ctx_prefix);
+        pos += ctx_prefix.len();
+
+        crate::host_fns::SIGNAL_SAFE_CTX_LEN.with(|c| {
+            let len = c.get();
+            crate::host_fns::SIGNAL_SAFE_CTX.with(|buf_cell| {
+                let s_buf = buf_cell.get();
+                if len > 0 {
+                    buf[pos..pos + len].copy_from_slice(&s_buf[..len]);
+                    pos += len;
+                }
+            });
+        });
 
         buf[pos] = b'\n';
         pos += 1;
@@ -198,6 +214,7 @@ mod inner {
     // the thread-local read async-signal-safe in practice.
     thread_local! {
         static JMP_BUF: Cell<*mut SigJmpBuf> = const { Cell::new(ptr::null_mut()) };
+        pub(crate) static FAULTING_ADDR: Cell<usize> = const { Cell::new(0) };
     }
 
     /// Trampoline called from C after sigsetjmp returns 0.
@@ -246,6 +263,7 @@ mod inner {
 
         // Store the jump buffer so the signal handler can find it.
         JMP_BUF.with(|cell| cell.set(&mut buf as *mut SigJmpBuf));
+        FAULTING_ADDR.with(|c| c.set(0));
 
         // Double-box: outer Box for the fat pointer, inner Box<dyn FnOnce()>.
         let boxed: Box<Box<dyn FnOnce()>> = Box::new(wrapper);
@@ -268,6 +286,13 @@ mod inner {
     extern "C" fn handler(sig: libc::c_int, _info: *mut libc::siginfo_t, _ctx: *mut libc::c_void) {
         // Synchronous signals (SIGILL, SIGSEGV, SIGBUS) are delivered to the
         // faulting thread, so the thread-local read returns this thread's buf.
+        let si_addr = if !_info.is_null() {
+            unsafe { (*_info).si_addr() as usize }
+        } else {
+            0
+        };
+        FAULTING_ADDR.with(|c| c.set(si_addr));
+
         let buf = JMP_BUF.with(|cell| cell.get());
         if !buf.is_null() {
             // In JIT context — jump back to sigsetjmp

--- a/tidepool-codegen/src/yield_type.rs
+++ b/tidepool-codegen/src/yield_type.rs
@@ -110,6 +110,7 @@ impl std::fmt::Display for YieldError {
             YieldError::BlackHole => write!(f, "blackhole detected (infinite loop: thunk forced itself)"),
             YieldError::BadThunkState(state) => write!(f, "thunk has invalid evaluation state: {}", state),
             YieldError::Signal(sig) => {
+                let ctx = crate::host_fns::get_exec_context();
                 #[cfg(unix)]
                 {
                     let name = match *sig {
@@ -121,12 +122,30 @@ impl std::fmt::Display for YieldError {
                         }
                         libc::SIGBUS => "SIGBUS (bus error)",
                         libc::SIGTRAP => "SIGTRAP (trap — likely Cranelift trap instruction)",
-                        _ => return write!(f, "JIT signal: signal {} (unknown)", sig),
+                        _ => {
+                            if !ctx.is_empty() {
+                                return write!(
+                                    f,
+                                    "JIT signal: signal {} (unknown, context: {})",
+                                    sig, ctx
+                                );
+                            } else {
+                                return write!(f, "JIT signal: signal {} (unknown)", sig);
+                            }
+                        }
                     };
-                    write!(f, "JIT signal: {}", name)
+                    if !ctx.is_empty() {
+                        write!(f, "JIT signal: {} (context: {})", name, ctx)
+                    } else {
+                        write!(f, "JIT signal: {}", name)
+                    }
                 }
                 #[cfg(not(unix))]
-                write!(f, "JIT signal: signal {}", sig)
+                if !ctx.is_empty() {
+                    write!(f, "JIT signal: signal {} (context: {})", sig, ctx)
+                } else {
+                    write!(f, "JIT signal: signal {}", sig)
+                }
             }
         }
     }

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -1634,9 +1634,24 @@ impl TidepoolMcpServerImpl {
             }
             Ok(None) => {
                 tracing::error!("eval thread crashed");
+                let mut crash_info = String::new();
+                if let Ok(content) = std::fs::read_to_string(".tidepool/crash.log") {
+                    let lines: Vec<_> = content.lines().rev().take(5).collect();
+                    if !lines.is_empty() {
+                        crash_info.push_str("\n\n## Recent Crash Log Entries\n```\n");
+                        for line in lines.into_iter().rev() {
+                            crash_info.push_str(line);
+                            crash_info.push('\n');
+                        }
+                        crash_info.push_str("```\n");
+                    }
+                }
                 let error_msg = format_error_with_source(
                     "Crash",
-                    "Eval thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.",
+                    &format!(
+                        "Eval thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.{}",
+                        crash_info
+                    ),
                     &source,
                 );
                 Ok(CallToolResult::error(vec![Content::text(error_msg)]))
@@ -1730,9 +1745,24 @@ impl TidepoolMcpServerImpl {
             }
             Ok(None) => {
                 tracing::error!("eval thread crashed");
+                let mut crash_info = String::new();
+                if let Ok(content) = std::fs::read_to_string(".tidepool/crash.log") {
+                    let lines: Vec<_> = content.lines().rev().take(5).collect();
+                    if !lines.is_empty() {
+                        crash_info.push_str("\n\n## Recent Crash Log Entries\n```\n");
+                        for line in lines.into_iter().rev() {
+                            crash_info.push_str(line);
+                            crash_info.push('\n');
+                        }
+                        crash_info.push_str("```\n");
+                    }
+                }
                 let error_msg = format_error_with_source(
                     "Crash",
-                    "Eval thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.",
+                    &format!(
+                        "Eval thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.{}",
+                        crash_info
+                    ),
                     &source,
                 );
                 Ok(CallToolResult::error(vec![Content::text(error_msg)]))


### PR DESCRIPTION
This PR enhances the diagnostics for JIT crashes (SIGSEGV, SIGILL) by providing execution context and lambda registry info.

Key changes:
- Added thread-local `EXEC_CONTEXT` and an async-signal-safe `SIGNAL_SAFE_CTX` buffer in `host_fns.rs`.
- Updated the signal handler in `signal_safety.rs` to capture the faulting address and include the execution context in the `crash.log`.
- Enhanced `LambdaRegistry` in `debug.rs` with `lookup_lambda_by_address` to identify which JIT function contained the faulting address.
- Updated `JitEffectMachine` to set the execution context before `step()`, `resume()`, and `run_pure()`.
- Enhanced `YieldError::Signal` display to include the execution context.
- Updated MCP error reporting to include the last few lines of `crash.log` and JIT diagnostics when the eval thread crashes.

Verification:
- All 71 tests in `tidepool-codegen` pass.
- MCP tests pass.
- `cargo check --workspace` passes.