### PR TITLE
feat: preserve Haskell error message strings

### DIFF
--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -613,6 +613,22 @@ translate expr =
             emitNode $ NCon consId [charIdx, acc]
           ) suffixIdx (reverse bytes)
 
+    -- Intercept error calls to preserve message string
+    Var v | isErrorVar v -> do
+      hIdx <- emitNode $ NVar 0x4500000000000002
+      let findMsg [] = Nothing
+          findMsg (a:as) = case extractErrorMessage a of
+                             Just bs -> Just bs
+                             Nothing -> findMsg as
+      case findMsg (reverse args) of
+        Just bytes -> do
+          msgIdx <- emitNode $ NLit (LEString (BS.pack bytes))
+          emitNode $ NApp hIdx msgIdx
+        Nothing ->
+          foldM (\fIdx aArg -> do
+            aIdx <- translate aArg
+            emitNode $ NApp fIdx aIdx) hIdx args
+
     -- Desugar unpackFoldrCString# "lit"# f z → f (C# c1) (f (C# c2) (... (f (C# cn) z)))
     -- GHC's build/foldr fusion rewrites foldr/build pairs into unpackFoldrCString#,
     -- whose unfolding uses plusAddr#/indexCharOffAddr# (Addr# pointer arithmetic).
@@ -1521,6 +1537,19 @@ splitUnaryMultiReturnPrimOp :: PrimOp -> Maybe (Text, Text)
 splitUnaryMultiReturnPrimOp = \case
   DoubleDecode_Int64Op -> Just (T.pack "DecodeDoubleMantissa", T.pack "DecodeDoubleExponent")
   _                    -> Nothing
+
+-- | Extract error message from an expression.
+-- Handles both direct LitString and unpackCString# applications,
+-- and recursively peels off PushCallStack wrappers.
+extractErrorMessage :: CoreExpr -> Maybe [Word8]
+extractErrorMessage expr =
+  case collectArgs (stripTicksAndCasts expr) of
+    (Var v, [arg]) | isUnpackCStringVar v -> extractAddrLitBytes arg
+    (Var v, args) | occNameString (nameOccName (idName v)) == "PushCallStack"
+                  , (msg:_) <- filter isValueArg args -> extractErrorMessage msg
+    _ -> case stripTicksAndCasts expr of
+           Lit (LitString bs) -> Just (BS.unpack bs)
+           _ -> Nothing
 
 -- | Extract Addr# literal bytes from an expression.
 -- Handles both direct Lit and Var with an unfolding to Lit

--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -2,8 +2,7 @@ use crate::emit::expr::ensure_heap_ptr;
 use crate::emit::*;
 use crate::pipeline::CodegenPipeline;
 use cranelift_codegen::ir::{
-    self, condcodes::IntCC, types, AbiParam, BlockArg, InstBuilder, MemFlags, Signature, TrapCode,
-    Value,
+    self, condcodes::IntCC, types, AbiParam, BlockArg, InstBuilder, MemFlags, Signature, Value,
 };
 use cranelift_frontend::FunctionBuilder;
 use cranelift_module::{Linkage, Module};
@@ -83,8 +82,8 @@ pub fn emit_case(
             .ins()
             .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
-        // No alts? Trap.
-        builder.ins().trap(TrapCode::unwrap_user(2));
+        // No alts? Call runtime_case_trap to handle pending errors gracefully.
+        emit_case_trap(pipeline, builder, scrut_ptr, &[], merge_block)?;
     }
 
     // Seal merge block
@@ -230,7 +229,7 @@ fn emit_data_dispatch(
             .ins()
             .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
-        emit_case_trap(pipeline, builder, scrut_ptr, data_alts)?;
+        emit_case_trap(pipeline, builder, scrut_ptr, data_alts, merge_block)?;
     }
 
     Ok(())
@@ -243,6 +242,7 @@ fn emit_case_trap(
     builder: &mut FunctionBuilder,
     scrut_ptr: Value,
     data_alts: &[&Alt<usize>],
+    merge_block: ir::Block,
 ) -> Result<(), EmitError> {
     // Collect expected tags
     let tags: Vec<u64> = data_alts
@@ -282,10 +282,11 @@ fn emit_case_trap(
         .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
     let trap_ref = pipeline.module.declare_func_in_func(trap_fn, builder.func);
     let num_alts_val = builder.ins().iconst(types::I64, num_alts as i64);
-    builder
+    let call = builder
         .ins()
         .call(trap_ref, &[scrut_ptr, num_alts_val, tags_addr]);
-    builder.ins().trap(TrapCode::unwrap_user(2));
+    let result = builder.inst_results(call)[0];
+    builder.ins().jump(merge_block, &[BlockArg::Value(result)]);
     Ok(())
 }
 
@@ -398,7 +399,9 @@ fn emit_lit_dispatch(
             .ins()
             .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
-        builder.ins().trap(TrapCode::unwrap_user(2));
+        // No alts matched.
+        // We pass empty data_alts since these are lit alts.
+        emit_case_trap(pipeline, builder, scrut_value, &[], merge_block)?;
     }
 
     Ok(())

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -1094,6 +1094,31 @@ impl EmitContext {
         }
     }
 
+    /// Extract the error message from an error call (walks App chain to find LitString).
+    fn extract_error_message(tree: &CoreExpr, rhs_idx: usize) -> Option<Vec<u8>> {
+        let mut idx = rhs_idx;
+        loop {
+            match &tree.nodes[idx] {
+                CoreFrame::App { fun, arg } => {
+                    // Check if arg is a LitString (the message)
+                    if let CoreFrame::Lit(Literal::LitString(bytes)) = &tree.nodes[*arg] {
+                        return Some(bytes.clone());
+                    }
+                    idx = *fun; // continue walking the App chain
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    fn emit_error_poison(&self, tree: &CoreExpr, rhs_idx: usize) -> i64 {
+        let kind = Self::extract_error_kind(tree, rhs_idx);
+        match Self::extract_error_message(tree, rhs_idx) {
+            Some(msg) => crate::host_fns::error_poison_ptr_lazy_msg(kind, &msg) as i64,
+            None => crate::host_fns::error_poison_ptr_lazy(kind) as i64,
+        }
+    }
+
     /// Trampoline-based emit_node: converts recursive Let-chain evaluation to
     /// an explicit work stack. This prevents Rust stack overflow during JIT
     /// compilation of deeply nested GHC Core ASTs.
@@ -1134,9 +1159,7 @@ impl EmitContext {
                                 if body_fvs.contains(&binder) {
                                     if Self::rhs_is_error_call(tree, rhs) {
                                         // Bind to lazy poison closure — error only triggers on call.
-                                        let kind = Self::extract_error_kind(tree, rhs);
-                                        let poison_addr =
-                                            crate::host_fns::error_poison_ptr_lazy(kind) as i64;
+                                        let poison_addr = self.emit_error_poison(tree, rhs);
                                         let poison_val =
                                             builder.ins().iconst(types::I64, poison_addr);
                                         self.trace_scope(&format!(
@@ -1272,8 +1295,7 @@ impl EmitContext {
             work.push(EmitWork::LetRecFinish { body, state_idx });
             for (binder, rhs_idx) in simple_bindings.iter().rev() {
                 if Self::rhs_is_error_call(tree, *rhs_idx) {
-                    let kind = Self::extract_error_kind(tree, *rhs_idx);
-                    let poison_addr = crate::host_fns::error_poison_ptr_lazy(kind) as i64;
+                    let poison_addr = self.emit_error_poison(tree, *rhs_idx);
                     let poison_val = builder.ins().iconst(types::I64, poison_addr);
                     self.trace_scope(&format!("defer error LetRec(simple) {:?}", binder));
                     self.env.insert(*binder, SsaVal::HeapPtr(poison_val));
@@ -1430,8 +1452,7 @@ impl EmitContext {
         let mut deferred_simple = Vec::with_capacity(simple_bindings.len());
         for (binder, rhs_idx) in &simple_bindings {
             if Self::rhs_is_error_call(tree, *rhs_idx) {
-                let kind = Self::extract_error_kind(tree, *rhs_idx);
-                let poison_addr = crate::host_fns::error_poison_ptr_lazy(kind) as i64;
+                let poison_addr = self.emit_error_poison(tree, *rhs_idx);
                 let poison_val = builder.ins().iconst(types::I64, poison_addr);
                 self.trace_scope(&format!("defer error LetRec(trivial) {:?}", binder));
                 self.env.insert(*binder, SsaVal::HeapPtr(poison_val));
@@ -1735,8 +1756,7 @@ impl EmitContext {
 
         for (binder, rhs_idx) in deferred_simple.iter().rev() {
             if Self::rhs_is_error_call(tree, *rhs_idx) {
-                let kind = Self::extract_error_kind(tree, *rhs_idx);
-                let poison_addr = crate::host_fns::error_poison_ptr_lazy(kind) as i64;
+                let poison_addr = self.emit_error_poison(tree, *rhs_idx);
                 let poison_val = builder.ins().iconst(types::I64, poison_addr);
                 self.trace_scope(&format!("defer error LetRec(deferred) {:?}", binder));
                 self.env.insert(*binder, SsaVal::HeapPtr(poison_val));

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -23,6 +23,7 @@ pub enum RuntimeError {
     StackOverflow,
     BlackHole,
     BadThunkState(u8),
+    UserErrorMsg(String), // NEW: error with preserved message
 }
 
 impl std::fmt::Display for RuntimeError {
@@ -31,6 +32,7 @@ impl std::fmt::Display for RuntimeError {
             RuntimeError::DivisionByZero => write!(f, "division by zero"),
             RuntimeError::Overflow => write!(f, "arithmetic overflow"),
             RuntimeError::UserError => write!(f, "Haskell error called"),
+            RuntimeError::UserErrorMsg(msg) => write!(f, "Haskell error: {}", msg),
             RuntimeError::Undefined => write!(f, "Haskell undefined forced"),
             RuntimeError::TypeMetadata => write!(f, "forced type metadata (should be dead code)"),
             RuntimeError::UnresolvedVar(id) => {
@@ -405,6 +407,43 @@ pub extern "C" fn runtime_error(kind: u64) -> *mut u8 {
     error_poison_ptr()
 }
 
+/// Called by JIT code for runtime errors with a specific message.
+pub extern "C" fn runtime_error_with_msg(kind: u64, msg_ptr: *const u8, msg_len: u64) -> *mut u8 {
+    let msg = if !msg_ptr.is_null() && msg_len > 0 {
+        let slice = unsafe { std::slice::from_raw_parts(msg_ptr, msg_len as usize) };
+        String::from_utf8_lossy(slice).to_string()
+    } else {
+        String::new()
+    };
+    let err_name = match kind {
+        0 => "DivisionByZero",
+        1 => "Overflow",
+        2 => "UserError",
+        3 => "Undefined",
+        4 => "TypeMetadata",
+        _ => "Unknown",
+    };
+    let diag = format!(
+        "[JIT] runtime_error called: kind={} ({}) msg={:?}",
+        kind, err_name, msg
+    );
+    eprintln!("{}", diag);
+    push_diagnostic(diag);
+    let err = match kind {
+        2 if !msg.is_empty() => RuntimeError::UserErrorMsg(msg),
+        0 => RuntimeError::DivisionByZero,
+        1 => RuntimeError::Overflow,
+        2 => RuntimeError::UserError,
+        3 => RuntimeError::Undefined,
+        4 => RuntimeError::TypeMetadata,
+        _ => RuntimeError::UserError,
+    };
+    RUNTIME_ERROR.with(|cell| {
+        *cell.borrow_mut() = Some(err);
+    });
+    error_poison_ptr()
+}
+
 pub extern "C" fn runtime_oom() -> *mut u8 {
     RUNTIME_ERROR.with(|cell| {
         *cell.borrow_mut() = Some(RuntimeError::HeapOverflow);
@@ -525,10 +564,66 @@ pub fn error_poison_ptr_lazy(kind: u64) -> *mut u8 {
 unsafe extern "C" fn poison_trampoline_lazy(
     _vmctx: *mut VMContext,
     closure: *mut u8,
+    arg: *mut u8,
+) -> *mut u8 {
+    let kind = *(closure.add(tidepool_heap::layout::CLOSURE_CAPTURED_OFFSET) as *const u64);
+
+    // If the argument is a LitString, use it as the error message.
+    if !arg.is_null() && tidepool_heap::layout::read_tag(arg) == tidepool_heap::layout::TAG_LIT {
+        let lit_tag = *arg.add(tidepool_heap::layout::LIT_TAG_OFFSET);
+        if lit_tag == 5 {
+            // LIT_TAG_STRING
+            let raw_ptr = *(arg.add(tidepool_heap::layout::LIT_VALUE_OFFSET) as *const *const u8);
+            if !raw_ptr.is_null() {
+                let len = *(raw_ptr as *const u64);
+                let bytes_ptr = raw_ptr.add(8);
+                return runtime_error_with_msg(kind, bytes_ptr, len);
+            }
+        }
+    }
+
+    runtime_error(kind)
+}
+
+/// Create a pre-allocated "lazy poison" Closure for a given error kind and message.
+pub fn error_poison_ptr_lazy_msg(kind: u64, msg: &[u8]) -> *mut u8 {
+    // Leak the message bytes so they live forever
+    let msg_bytes = msg.to_vec().into_boxed_slice();
+    let msg_ptr = msg_bytes.as_ptr();
+    let msg_len = msg_bytes.len();
+    std::mem::forget(msg_bytes);
+
+    // Allocate closure with 3 captures: kind, msg_ptr, msg_len
+    // Closure: header(8) + code_ptr(8) + num_captured(2+pad=8) + 3*8 = 48
+    let size = tidepool_heap::layout::CLOSURE_CAPTURED_OFFSET + 3 * 8;
+    let layout = std::alloc::Layout::from_size_align(size, 8).unwrap();
+    let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+    if ptr.is_null() {
+        std::alloc::handle_alloc_error(layout);
+    }
+    unsafe {
+        tidepool_heap::layout::write_header(ptr, tidepool_heap::layout::TAG_CLOSURE, size as u16);
+        *(ptr.add(tidepool_heap::layout::CLOSURE_CODE_PTR_OFFSET) as *mut usize) =
+            poison_trampoline_lazy_msg as *const () as usize;
+        *(ptr.add(tidepool_heap::layout::CLOSURE_NUM_CAPTURED_OFFSET) as *mut u16) = 3;
+        *(ptr.add(tidepool_heap::layout::CLOSURE_CAPTURED_OFFSET) as *mut u64) = kind;
+        *(ptr.add(tidepool_heap::layout::CLOSURE_CAPTURED_OFFSET + 8) as *mut usize) =
+            msg_ptr as usize;
+        *(ptr.add(tidepool_heap::layout::CLOSURE_CAPTURED_OFFSET + 16) as *mut u64) = msg_len as u64;
+    }
+    ptr
+}
+
+unsafe extern "C" fn poison_trampoline_lazy_msg(
+    _vmctx: *mut VMContext,
+    closure: *mut u8,
     _arg: *mut u8,
 ) -> *mut u8 {
     let kind = *(closure.add(tidepool_heap::layout::CLOSURE_CAPTURED_OFFSET) as *const u64);
-    runtime_error(kind)
+    let msg_ptr =
+        *(closure.add(tidepool_heap::layout::CLOSURE_CAPTURED_OFFSET + 8) as *const *const u8);
+    let msg_len = *(closure.add(tidepool_heap::layout::CLOSURE_CAPTURED_OFFSET + 16) as *const u64);
+    runtime_error_with_msg(kind, msg_ptr, msg_len)
 }
 
 /// Check and take any pending runtime error from JIT code.
@@ -1109,6 +1204,10 @@ pub fn host_fn_symbols() -> Vec<(&'static str, *const u8)> {
         ("heap_force", heap_force as *const u8),
         ("unresolved_var_trap", unresolved_var_trap as *const u8),
         ("runtime_error", runtime_error as *const u8),
+        (
+            "runtime_error_with_msg",
+            runtime_error_with_msg as *const u8,
+        ),
         ("debug_app_check", debug_app_check as *const u8),
         (
             "runtime_new_byte_array",
@@ -1806,8 +1905,22 @@ pub extern "C" fn runtime_case_trap(scrut_ptr: i64, num_alts: i64, alt_tags: i64
         return error_poison_ptr();
     }
 
-    use std::io::Write;
     let ptr = scrut_ptr as *const u8;
+
+    // Check if the scrutinee is a lazy poison closure. If so, trigger it to set the error flag.
+    if !ptr.is_null() && unsafe { tidepool_heap::layout::read_tag(ptr) } == tidepool_heap::layout::TAG_CLOSURE {
+        let code_ptr = unsafe { *(ptr.add(tidepool_heap::layout::CLOSURE_CODE_PTR_OFFSET) as *const usize) };
+        if code_ptr == poison_trampoline_lazy as *const () as usize || code_ptr == poison_trampoline_lazy_msg as *const () as usize {
+            // Trigger the error by calling the trampoline
+            unsafe {
+                let func: unsafe extern "C" fn(*mut VMContext, *mut u8, *mut u8) -> *mut u8 = std::mem::transmute(code_ptr);
+                func(std::ptr::null_mut(), ptr as *mut u8, std::ptr::null_mut());
+            }
+            return error_poison_ptr();
+        }
+    }
+
+    use std::io::Write;
     if (scrut_ptr as u64) < 0x1000 {
         let mut stderr = std::io::stderr().lock();
         let _ = writeln!(

--- a/tidepool-codegen/src/yield_type.rs
+++ b/tidepool-codegen/src/yield_type.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for Yield {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum YieldError {
     /// Result HeapObject had unexpected tag byte.
     UnexpectedTag(u8),
@@ -54,6 +54,8 @@ pub enum YieldError {
     Overflow,
     /// Haskell `error` called in JIT code.
     UserError,
+    /// Haskell `error` called with a specific message.
+    UserErrorMsg(String),
     /// Haskell `undefined` forced in JIT code.
     Undefined,
     /// GHC type metadata forced (should be dead code).
@@ -92,6 +94,7 @@ impl std::fmt::Display for YieldError {
             YieldError::DivisionByZero => write!(f, "division by zero"),
             YieldError::Overflow => write!(f, "arithmetic overflow"),
             YieldError::UserError => write!(f, "Haskell error called"),
+            YieldError::UserErrorMsg(msg) => write!(f, "Haskell error: {}", msg),
             YieldError::Undefined => write!(f, "Haskell undefined forced"),
             YieldError::TypeMetadata => write!(f, "forced type metadata (should be dead code)"),
             YieldError::UnresolvedVar(id) => {
@@ -141,6 +144,7 @@ impl From<crate::host_fns::RuntimeError> for YieldError {
             RuntimeError::DivisionByZero => YieldError::DivisionByZero,
             RuntimeError::Overflow => YieldError::Overflow,
             RuntimeError::UserError => YieldError::UserError,
+            RuntimeError::UserErrorMsg(msg) => YieldError::UserErrorMsg(msg),
             RuntimeError::Undefined => YieldError::Undefined,
             RuntimeError::TypeMetadata => YieldError::TypeMetadata,
             RuntimeError::UnresolvedVar(id) => YieldError::UnresolvedVar(id),

--- a/tidepool-runtime/tests/test_error_msg.rs
+++ b/tidepool-runtime/tests/test_error_msg.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+use tidepool_codegen::yield_type::YieldError;
+
+fn prelude_path() -> std::path::PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().unwrap().join("haskell").join("lib")
+}
+
+#[test]
+fn test_error_message() {
+    let src = r#"{-# LANGUAGE NoImplicitPrelude, OverloadedStrings #-}
+module Test where
+import Tidepool.Prelude
+
+{-# NOINLINE f #-}
+f :: Int -> Int
+f x = if x == 0 then error "head: empty list" else x
+
+result :: Int
+result = f 0
+"#;
+    let pp = prelude_path();
+    let include = [pp.as_path()];
+    let res = tidepool_runtime::compile_and_run_pure(&src, "result", &include);
+    
+    match res {
+        Err(e) => {
+            let msg = format!("{}", e);
+            assert!(msg.contains("head: empty list"), "Error message should contain 'head: empty list', got: {}", msg);
+        }
+        Ok(_) => panic!("Expected error, got success"),
+    }
+}
+
+#[test]
+fn test_pat_error_message() {
+    let src = r#"{-# LANGUAGE NoImplicitPrelude, OverloadedStrings #-}
+module Test where
+import Tidepool.Prelude
+
+f :: Int -> Int
+f 0 = 1
+-- f 1 is missing, should trigger patError
+
+result :: Int
+result = f 1
+"#;
+    let pp = prelude_path();
+    let include = [pp.as_path()];
+    let res = tidepool_runtime::compile_and_run_pure(&src, "result", &include);
+    
+    match res {
+        Err(e) => {
+            let msg = format!("{}", e);
+            // patError usually contains the location and function name
+            assert!(msg.contains("function f"), "Error message should contain 'function f', got: {}", msg);
+        }
+        Ok(_) => panic!("Expected error, got success"),
+    }
+}


### PR DESCRIPTION
This PR threads the error message from GHC Core through to the JIT runtime, so that `error "msg"` returns `YieldError::UserErrorMsg("msg")` instead of a generic message.

Changes:
- **`haskell/src/Tidepool/Translate.hs`**: Intercepts `error` and `patError` calls, recursively unwrapping `PushCallStack` to find the `LitString` message. It then wraps the `0x45` error sentinel in an `App` with the `LitString`.
- **`tidepool-codegen/src/emit/expr.rs`**: Added `extract_error_message` and `emit_error_poison` to statically detect string literals in `LetRec`/`LetNonRec` error branches and pre-allocate 3-capture lazy poison closures. Also fixed an existing indentation bug in the simple bindings phase.
- **`tidepool-codegen/src/host_fns.rs`**: Implemented `runtime_error_with_msg` and `error_poison_ptr_lazy_msg`. Modified the existing 1-capture `poison_trampoline_lazy` to inspect its argument: if it's a `LitString` (as generated by the new `App` wrapper), it dynamically extracts the string and logs/preserves it.
- **`tidepool-codegen/src/yield_type.rs`**: Added `YieldError::UserErrorMsg(String)` to correctly propagate the error string up to the `run` caller.
- **`tidepool-codegen/src/emit/case.rs`**: **Fixed a pre-existing cascading `SIGILL` bug.** `emit_case_trap` now accepts the `merge_block` and performs a `jump` with the poison pointer (if an error is in-flight) instead of unconditionally issuing a `builder.ins().trap(...)` which was causing a hard process crash when testing unresolved variables.
- **`tidepool-runtime/tests/test_error_msg.rs`**: Added integration tests to verify that standard `error "..."` and missing-pattern `patError`s correctly propagate their strings through the entire pipeline.