### PR TITLE
feat: tail-call optimization for JIT-compiled lambdas

### DIFF
--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -354,7 +354,9 @@ impl CompiledEffectMachine {
             std::mem::transmute(code_ptr);
         let mut result = func(&mut self.vmctx, closure, arg);
         // TCO: resolve pending tail calls
-        self.resolve_tail_calls(&mut result);
+        unsafe {
+            self.resolve_tail_calls(&mut result);
+        }
 
         if trace >= crate::debug::TraceLevel::Calls {
             let name = crate::debug::lookup_lambda(code_ptr)

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -72,7 +72,9 @@ impl CompiledEffectMachine {
 
     /// Execute the compiled function and parse the result.
     pub fn step(&mut self) -> Yield {
-        let result: *mut u8 = unsafe { (self.func_ptr)(&mut self.vmctx) };
+        let mut result: *mut u8 = unsafe { (self.func_ptr)(&mut self.vmctx) };
+        // TCO: resolve pending tail calls
+        unsafe { self.resolve_tail_calls(&mut result); }
         self.parse_result(result)
     }
 
@@ -350,7 +352,9 @@ impl CompiledEffectMachine {
 
         let func: unsafe extern "C" fn(*mut VMContext, *mut u8, *mut u8) -> *mut u8 =
             std::mem::transmute(code_ptr);
-        let result = func(&mut self.vmctx, closure, arg);
+        let mut result = func(&mut self.vmctx, closure, arg);
+        // TCO: resolve pending tail calls
+        self.resolve_tail_calls(&mut result);
 
         if trace >= crate::debug::TraceLevel::Calls {
             let name = crate::debug::lookup_lambda(code_ptr)
@@ -367,6 +371,24 @@ impl CompiledEffectMachine {
         }
 
         result
+    }
+
+    /// Resolve pending tail calls stored in VMContext by the JIT.
+    ///
+    /// # Safety
+    /// VMContext must have valid tail_callee/tail_arg if non-null.
+    unsafe fn resolve_tail_calls(&mut self, result: &mut *mut u8) {
+        while result.is_null() && !self.vmctx.tail_callee.is_null() {
+            let callee = self.vmctx.tail_callee;
+            let arg = self.vmctx.tail_arg;
+            self.vmctx.tail_callee = std::ptr::null_mut();
+            self.vmctx.tail_arg = std::ptr::null_mut();
+            crate::host_fns::reset_call_depth();
+            let code_ptr = *(callee.add(layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
+            let func: unsafe extern "C" fn(*mut VMContext, *mut u8, *mut u8) -> *mut u8 =
+                std::mem::transmute(code_ptr);
+            *result = func(&mut self.vmctx, callee, arg);
+        }
     }
 
     /// Allocate a Con HeapObject on the nursery with the given tag and fields.

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -480,9 +480,70 @@ fn collapse_frame(
                 .ins()
                 .call_indirect(call_sig, code_ptr, &[vmctx, fun_ptr, arg_ptr]);
             let ret_val = builder.inst_results(inst)[0];
+
+            // TCO null check: if callee returned null, it might be a tail call
+            let ret_is_null = builder.ins().icmp_imm(IntCC::Equal, ret_val, 0);
+            let null_check_block = builder.create_block();
+            let ret_ok_block = builder.create_block();
+
+            builder.ins().brif(
+                ret_is_null,
+                null_check_block,
+                &[],
+                ret_ok_block,
+                &[],
+            );
+
+            // ret_ok_block: normal return, jump to merge
+            builder.switch_to_block(ret_ok_block);
+            builder.seal_block(ret_ok_block);
             builder.ins().jump(merge_block, &[BlockArg::Value(ret_val)]);
 
-            // merge_block: result is either poison or call result
+            // null_check_block: check if VMContext has a pending tail call
+            builder.switch_to_block(null_check_block);
+            builder.seal_block(null_check_block);
+
+            let tail_callee = builder.ins().load(
+                types::I64, MemFlags::trusted(), vmctx, VMCTX_TAIL_CALLEE_OFFSET,
+            );
+            let has_tail_call = builder.ins().icmp_imm(IntCC::NotEqual, tail_callee, 0);
+
+            let resolve_block = builder.create_block();
+            let null_propagate_block = builder.create_block();
+
+            builder.ins().brif(
+                has_tail_call,
+                resolve_block,
+                &[],
+                null_propagate_block,
+                &[],
+            );
+
+            // null_propagate_block: no tail call pending, propagate null (error)
+            builder.switch_to_block(null_propagate_block);
+            builder.seal_block(null_propagate_block);
+            let null_val = builder.ins().iconst(types::I64, 0);
+            builder.ins().jump(merge_block, &[BlockArg::Value(null_val)]);
+
+            // resolve_block: call trampoline_resolve to execute the pending tail call
+            builder.switch_to_block(resolve_block);
+            builder.seal_block(resolve_block);
+
+            let resolve_fn = pipeline.module
+                .declare_function("trampoline_resolve", Linkage::Import, &{
+                    let mut sig = Signature::new(pipeline.isa.default_call_conv());
+                    sig.params.push(AbiParam::new(types::I64)); // vmctx
+                    sig.returns.push(AbiParam::new(types::I64)); // result
+                    sig
+                })
+                .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+            let resolve_ref = pipeline.module.declare_func_in_func(resolve_fn, builder.func);
+            let resolve_inst = builder.ins().call(resolve_ref, &[vmctx]);
+            let resolved_val = builder.inst_results(resolve_inst)[0];
+            builder.declare_value_needs_stack_map(resolved_val);
+            builder.ins().jump(merge_block, &[BlockArg::Value(resolved_val)]);
+
+            // merge_block: result from any path
             builder.switch_to_block(merge_block);
             builder.seal_block(merge_block);
             let merged_val = builder.block_params(merge_block)[0];
@@ -674,6 +735,7 @@ fn emit_lam(
 
     let mut inner_emit = EmitContext::new(ctx.prefix.clone());
     inner_emit.lambda_counter = ctx.lambda_counter;
+    inner_emit.in_tail_position = true; // lambda body is in tail position
 
     inner_emit.trace_scope(&format!("insert lam binder {:?}", binder));
     inner_emit.env.insert(binder, SsaVal::HeapPtr(arg_param));
@@ -1174,12 +1236,15 @@ impl EmitContext {
                                     } else {
                                         // Push work in LIFO order: cleanup, eval body, bind, eval rhs
                                         // After rhs eval → bind → eval body → cleanup
+                                        let saved_tail = self.in_tail_position;
                                         work.push(EmitWork::LetCleanupMark(LetCleanup::Single(
                                             binder,
                                         )));
                                         work.push(EmitWork::Eval(body));
+                                        work.push(EmitWork::SetTailPosition(saved_tail)); // restore before body eval
                                         work.push(EmitWork::Bind(binder));
                                         work.push(EmitWork::Eval(rhs));
+                                        work.push(EmitWork::SetTailPosition(false)); // RHS is NOT tail position
                                         break; // exit inner loop, process work stack
                                     }
                                 } else {
@@ -1203,10 +1268,17 @@ impl EmitContext {
                             }
                             // All non-Let nodes: delegate to stack-safe hylomorphism
                             _ => {
-                                let result = emit_subtree(
-                                    self, pipeline, builder, vmctx, gc_sig, oom_func, tree, idx,
-                                )?;
-                                vals.push(result);
+                                if self.in_tail_position && matches!(tree.nodes[idx], CoreFrame::App { .. }) {
+                                    let result = self.emit_tail_app(
+                                        pipeline, builder, vmctx, gc_sig, oom_func, tree, idx,
+                                    )?;
+                                    vals.push(result);
+                                } else {
+                                    let result = emit_subtree(
+                                        self, pipeline, builder, vmctx, gc_sig, oom_func, tree, idx,
+                                    )?;
+                                    vals.push(result);
+                                }
                                 break;
                             }
                         }
@@ -1250,11 +1322,131 @@ impl EmitContext {
                         }
                     }
                 },
+                EmitWork::SetTailPosition(val) => {
+                    self.in_tail_position = val;
+                }
             }
         }
 
         vals.pop()
             .ok_or_else(|| EmitError::InternalError("emit_node: empty value stack".into()))
+    }
+
+    /// Emit a tail-position App: store callee+arg to VMContext, return null.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_tail_app(
+        &mut self,
+        pipeline: &mut CodegenPipeline,
+        builder: &mut FunctionBuilder,
+        vmctx: Value,
+        gc_sig: ir::SigRef,
+        oom_func: ir::FuncRef,
+        tree: &CoreExpr,
+        idx: usize,
+    ) -> Result<SsaVal, EmitError> {
+        let (fun_idx, arg_idx) = match &tree.nodes[idx] {
+            CoreFrame::App { fun, arg } => (*fun, *arg),
+            _ => unreachable!(),
+        };
+
+        // Evaluate fun and arg in NON-tail position
+        let saved_tail = self.in_tail_position;
+        self.in_tail_position = false;
+        let fun_val = emit_subtree(self, pipeline, builder, vmctx, gc_sig, oom_func, tree, fun_idx)?;
+        let arg_val = emit_subtree(self, pipeline, builder, vmctx, gc_sig, oom_func, tree, arg_idx)?;
+        self.in_tail_position = saved_tail;
+
+        let raw_fun_ptr = fun_val.value();
+        let arg_ptr = ensure_heap_ptr(builder, vmctx, gc_sig, oom_func, arg_val);
+
+        // Force thunked function (same as regular App path)
+        let fun_tag = builder.ins().load(types::I8, MemFlags::trusted(), raw_fun_ptr, 0);
+        let is_thunk = builder.ins().icmp_imm(
+            IntCC::Equal,
+            fun_tag,
+            tidepool_heap::layout::TAG_THUNK as i64,
+        );
+
+        let force_fun_block = builder.create_block();
+        let fun_ready_block = builder.create_block();
+        builder.append_block_param(fun_ready_block, types::I64);
+
+        builder.ins().brif(
+            is_thunk,
+            force_fun_block,
+            &[],
+            fun_ready_block,
+            &[BlockArg::Value(raw_fun_ptr)],
+        );
+
+        builder.switch_to_block(force_fun_block);
+        builder.seal_block(force_fun_block);
+
+        let force_fn = pipeline.module
+            .declare_function("heap_force", Linkage::Import, &{
+                let mut sig = Signature::new(pipeline.isa.default_call_conv());
+                sig.params.push(AbiParam::new(types::I64));
+                sig.params.push(AbiParam::new(types::I64));
+                sig.returns.push(AbiParam::new(types::I64));
+                sig
+            })
+            .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+        let force_ref = pipeline.module.declare_func_in_func(force_fn, builder.func);
+        let force_call = builder.ins().call(force_ref, &[vmctx, raw_fun_ptr]);
+        let forced_fun = builder.inst_results(force_call)[0];
+        builder.declare_value_needs_stack_map(forced_fun);
+        builder.ins().jump(fun_ready_block, &[BlockArg::Value(forced_fun)]);
+
+        builder.switch_to_block(fun_ready_block);
+        builder.seal_block(fun_ready_block);
+        let fun_ptr = builder.block_params(fun_ready_block)[0];
+        builder.declare_value_needs_stack_map(fun_ptr);
+
+        // Debug validation (same as regular App)
+        let check_fn = pipeline.module
+            .declare_function("debug_app_check", Linkage::Import, &{
+                let mut sig = Signature::new(pipeline.isa.default_call_conv());
+                sig.params.push(AbiParam::new(types::I64));
+                sig.returns.push(AbiParam::new(types::I64));
+                sig
+            })
+            .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
+        let check_ref = pipeline.module.declare_func_in_func(check_fn, builder.func);
+        let check_inst = builder.ins().call(check_ref, &[fun_ptr]);
+        let check_result = builder.inst_results(check_inst)[0];
+
+        // If debug_app_check returned non-zero (poison/error), return it directly
+        let store_block = builder.create_block();
+        let poison_block = builder.create_block();
+
+        let is_zero = builder.ins().icmp_imm(IntCC::Equal, check_result, 0);
+        builder.ins().brif(is_zero, store_block, &[], poison_block, &[]);
+
+        // poison_block: return poison (error already set by debug_app_check)
+        builder.switch_to_block(poison_block);
+        builder.seal_block(poison_block);
+        builder.ins().return_(&[check_result]);
+
+        // store_block: store callee+arg to VMContext, return null
+        builder.switch_to_block(store_block);
+        builder.seal_block(store_block);
+
+        // Store fun_ptr (closure) to VMContext.tail_callee (offset 24)
+        builder.ins().store(MemFlags::trusted(), fun_ptr, vmctx, VMCTX_TAIL_CALLEE_OFFSET);
+        // Store arg_ptr to VMContext.tail_arg (offset 32)
+        builder.ins().store(MemFlags::trusted(), arg_ptr, vmctx, VMCTX_TAIL_ARG_OFFSET);
+
+        // Return null to signal tail call
+        let null_val = builder.ins().iconst(types::I64, 0);
+        builder.ins().return_(&[null_val]);
+
+        // Dead block for subsequent code
+        let dead_block = builder.create_block();
+        builder.switch_to_block(dead_block);
+        builder.seal_block(dead_block);
+
+        let dummy = builder.ins().iconst(types::I64, 0);
+        Ok(SsaVal::HeapPtr(dummy))
     }
 
     /// Execute LetRec phases 1-3a inline, then push deferred-simple evals
@@ -1292,7 +1484,10 @@ impl EmitContext {
             });
 
             // Push finish + simple evals in reverse order (LIFO)
+            let saved_tail = self.in_tail_position;
             work.push(EmitWork::LetRecFinish { body, state_idx });
+            // Restore tail position before LetRecFinish (which pushes Eval(body))
+            work.push(EmitWork::SetTailPosition(saved_tail));
             for (binder, rhs_idx) in simple_bindings.iter().rev() {
                 if Self::rhs_is_error_call(tree, *rhs_idx) {
                     let poison_addr = self.emit_error_poison(tree, *rhs_idx);
@@ -1307,6 +1502,8 @@ impl EmitContext {
                     work.push(EmitWork::Eval(*rhs_idx));
                 }
             }
+            // Set false before first RHS eval
+            work.push(EmitWork::SetTailPosition(false));
             return Ok(());
         }
 
@@ -1543,6 +1740,7 @@ impl EmitContext {
 
             let mut inner_emit = EmitContext::new(self.prefix.clone());
             inner_emit.lambda_counter = self.lambda_counter;
+            inner_emit.in_tail_position = true; // lambda body is in tail position
             inner_emit
                 .env
                 .insert(lam_binder, SsaVal::HeapPtr(inner_arg));
@@ -1752,7 +1950,10 @@ impl EmitContext {
         });
 
         // Push work items in LIFO order: finish, then simple evals (reversed)
+        let saved_tail = self.in_tail_position;
         work.push(EmitWork::LetRecFinish { body, state_idx });
+        // Restore tail position before LetRecFinish (which pushes Eval(body))
+        work.push(EmitWork::SetTailPosition(saved_tail));
 
         for (binder, rhs_idx) in deferred_simple.iter().rev() {
             if Self::rhs_is_error_call(tree, *rhs_idx) {
@@ -1796,6 +1997,8 @@ impl EmitContext {
                 }
             }
         }
+        // Set false before first RHS eval
+        work.push(EmitWork::SetTailPosition(false));
 
         Ok(())
     }
@@ -1939,6 +2142,8 @@ enum EmitWork {
     LetRecFinish { body: usize, state_idx: usize },
     /// Pop cleanup on return
     LetCleanupMark(LetCleanup),
+    /// Set the in_tail_position flag on the EmitContext.
+    SetTailPosition(bool),
 }
 
 /// Deferred state for LetRec phases 3c/3a'/3d, stored in EmitContext

--- a/tidepool-codegen/src/gc/frame_walker.rs
+++ b/tidepool-codegen/src/gc/frame_walker.rs
@@ -36,12 +36,9 @@ pub unsafe fn walk_frames(start_fp: usize, stack_maps: &StackMapRegistry) -> Vec
 
         // Check if this return address is in JIT code
         if !stack_maps.contains_address(return_addr) {
-            if !roots.is_empty() {
-                // We were in JIT territory and now we left it. Stop.
-                break;
-            }
-            // We haven't hit JIT territory yet. Skip this frame
-            // (e.g., gc_trigger → perform_gc before reaching JIT frames).
+            // Not a JIT frame — skip it and keep walking.
+            // This handles both pre-JIT frames (gc_trigger → perform_gc)
+            // and JIT→Host→JIT sandwiches (heap_force, trampoline_resolve).
             let next_fp = *(fp as *const usize);
             if next_fp == 0 || next_fp == fp || next_fp <= fp {
                 break;

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -231,6 +231,31 @@ impl JitEffectMachine {
             }
         };
 
+        // TCO: resolve pending tail calls
+        let result_ptr = unsafe {
+            let mut ptr = result_ptr;
+            while ptr.is_null() && !vmctx.tail_callee.is_null() {
+                let callee = vmctx.tail_callee;
+                let arg = vmctx.tail_arg;
+                vmctx.tail_callee = std::ptr::null_mut();
+                vmctx.tail_arg = std::ptr::null_mut();
+                crate::host_fns::reset_call_depth();
+                let code_ptr = *(callee.add(tidepool_heap::layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
+                let func: unsafe extern "C" fn(*mut crate::context::VMContext, *mut u8, *mut u8) -> *mut u8 =
+                    std::mem::transmute(code_ptr);
+                ptr = match crate::signal_safety::with_signal_protection(|| func(&mut vmctx, callee, arg)) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        crate::host_fns::clear_gc_state();
+                        crate::host_fns::clear_stack_map_registry();
+                        crate::debug::clear_lambda_registry();
+                        return Err(JitError::Yield(runtime_error_or_signal(e.0)));
+                    }
+                };
+            }
+            ptr
+        };
+
         // Check for runtime error FIRST — runtime_error now returns a poison
         // object instead of null, so we can't rely on null-check alone.
         let result = if let Some(err) = crate::host_fns::take_runtime_error() {

--- a/tidepool-codegen/tests/tco.rs
+++ b/tidepool-codegen/tests/tco.rs
@@ -1,0 +1,210 @@
+//! Tail-call optimization tests.
+//!
+//! These tests verify that tail-position function applications in lambda bodies
+//! use the TCO path (VMContext store + null return → trampoline resolution)
+//! instead of `call_indirect`, enabling deep recursion without stack overflow.
+
+use tidepool_codegen::jit_machine::JitEffectMachine;
+use tidepool_eval::value::Value;
+use tidepool_repr::datacon_table::DataConTable;
+use tidepool_repr::frame::CoreFrame;
+use tidepool_repr::types::*;
+use tidepool_repr::{CoreExpr, Literal, TreeBuilder};
+
+fn assert_lit_int(val: &Value, expected: i64) {
+    match val {
+        Value::Lit(Literal::LitInt(n)) => assert_eq!(*n, expected),
+        other => panic!("expected Lit(Int({})), got {:?}", expected, other),
+    }
+}
+
+fn empty_table() -> DataConTable {
+    DataConTable::new()
+}
+
+/// Build: `let go = \n -> case n ==# 0# of { 1# -> Lit(result); _ -> go (n -# 1#) } in go N`
+///
+/// This is a tail-recursive countdown. Without TCO, N=100000 overflows the stack.
+fn build_tail_recursive_countdown(n: i64, result: i64) -> CoreExpr {
+    let go = VarId(1);
+    let param_n = VarId(2);
+    let case_binder = VarId(3);
+
+    let mut bld = TreeBuilder::new();
+
+    // Leaf nodes used in the lambda body:
+    // 0: Var(param_n) — the parameter
+    let var_n = bld.push(CoreFrame::Var(param_n));
+    // 1: Lit(0) — comparison target
+    let lit_0 = bld.push(CoreFrame::Lit(Literal::LitInt(0)));
+    // 2: param_n ==# 0# → produces 1# (true) or 0# (false)
+    let cmp = bld.push(CoreFrame::PrimOp {
+        op: PrimOpKind::IntEq,
+        args: vec![var_n, lit_0],
+    });
+
+    // True branch: return result literal
+    let lit_result = bld.push(CoreFrame::Lit(Literal::LitInt(result)));
+
+    // False branch: go (n -# 1#)
+    let var_n2 = bld.push(CoreFrame::Var(param_n));
+    let lit_1 = bld.push(CoreFrame::Lit(Literal::LitInt(1)));
+    let sub = bld.push(CoreFrame::PrimOp {
+        op: PrimOpKind::IntSub,
+        args: vec![var_n2, lit_1],
+    });
+    let var_go = bld.push(CoreFrame::Var(go));
+    let tail_call = bld.push(CoreFrame::App {
+        fun: var_go,
+        arg: sub,
+    });
+
+    // Case on the comparison result (unboxed Int#)
+    let case_node = bld.push(CoreFrame::Case {
+        scrutinee: cmp,
+        binder: case_binder,
+        alts: vec![
+            Alt {
+                con: AltCon::LitAlt(Literal::LitInt(1)),
+                binders: vec![],
+                body: lit_result,
+            },
+            Alt {
+                con: AltCon::Default,
+                binders: vec![],
+                body: tail_call,
+            },
+        ],
+    });
+
+    // Lambda: \n -> case ...
+    let lam = bld.push(CoreFrame::Lam {
+        binder: param_n,
+        body: case_node,
+    });
+
+    // Application: go N
+    let lit_n = bld.push(CoreFrame::Lit(Literal::LitInt(n)));
+    let var_go2 = bld.push(CoreFrame::Var(go));
+    let app = bld.push(CoreFrame::App {
+        fun: var_go2,
+        arg: lit_n,
+    });
+
+    // LetRec: let go = \n -> ... in go N
+    bld.push(CoreFrame::LetRec {
+        bindings: vec![(go, lam)],
+        body: app,
+    });
+
+    bld.build()
+}
+
+/// Deep self-recursion: `go 100000` should complete without stack overflow.
+#[test]
+fn test_tco_deep_self_recursion() {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            let expr = build_tail_recursive_countdown(100_000, 42);
+            let table = empty_table();
+            let mut machine =
+                JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+            let result = machine.run_pure().unwrap();
+            assert_lit_int(&result, 42);
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+/// Moderate recursion to verify basic correctness with a smaller depth.
+#[test]
+fn test_tco_moderate_recursion() {
+    let expr = build_tail_recursive_countdown(1000, 99);
+    let table = empty_table();
+    let mut machine = JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+    let result = machine.run_pure().unwrap();
+    assert_lit_int(&result, 99);
+}
+
+/// Non-tail call to a function that internally does tail calls.
+/// `let go = \n -> case n ==# 0# of { 1# -> 7; _ -> go (n -# 1#) } in go 50 +# go 50`
+#[test]
+fn test_tco_non_tail_calling_tail_function() {
+    let go = VarId(1);
+    let param_n = VarId(2);
+    let case_binder = VarId(3);
+
+    let mut bld = TreeBuilder::new();
+
+    // Lambda body: case n ==# 0# of { 1# -> 7; _ -> go (n-1) }
+    let var_n = bld.push(CoreFrame::Var(param_n));
+    let lit_0 = bld.push(CoreFrame::Lit(Literal::LitInt(0)));
+    let cmp = bld.push(CoreFrame::PrimOp {
+        op: PrimOpKind::IntEq,
+        args: vec![var_n, lit_0],
+    });
+    let lit_7 = bld.push(CoreFrame::Lit(Literal::LitInt(7)));
+    let var_n2 = bld.push(CoreFrame::Var(param_n));
+    let lit_1 = bld.push(CoreFrame::Lit(Literal::LitInt(1)));
+    let sub = bld.push(CoreFrame::PrimOp {
+        op: PrimOpKind::IntSub,
+        args: vec![var_n2, lit_1],
+    });
+    let var_go = bld.push(CoreFrame::Var(go));
+    let tail_call = bld.push(CoreFrame::App {
+        fun: var_go,
+        arg: sub,
+    });
+    let case_node = bld.push(CoreFrame::Case {
+        scrutinee: cmp,
+        binder: case_binder,
+        alts: vec![
+            Alt {
+                con: AltCon::LitAlt(Literal::LitInt(1)),
+                binders: vec![],
+                body: lit_7,
+            },
+            Alt {
+                con: AltCon::Default,
+                binders: vec![],
+                body: tail_call,
+            },
+        ],
+    });
+    let lam = bld.push(CoreFrame::Lam {
+        binder: param_n,
+        body: case_node,
+    });
+
+    // Body: go 50 +# go 50
+    let lit_50a = bld.push(CoreFrame::Lit(Literal::LitInt(50)));
+    let var_go_a = bld.push(CoreFrame::Var(go));
+    let app_a = bld.push(CoreFrame::App {
+        fun: var_go_a,
+        arg: lit_50a,
+    });
+    let lit_50b = bld.push(CoreFrame::Lit(Literal::LitInt(50)));
+    let var_go_b = bld.push(CoreFrame::Var(go));
+    let app_b = bld.push(CoreFrame::App {
+        fun: var_go_b,
+        arg: lit_50b,
+    });
+    let add = bld.push(CoreFrame::PrimOp {
+        op: PrimOpKind::IntAdd,
+        args: vec![app_a, app_b],
+    });
+
+    bld.push(CoreFrame::LetRec {
+        bindings: vec![(go, lam)],
+        body: add,
+    });
+
+    let expr = bld.build();
+    let table = empty_table();
+    let mut machine = JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+    let result = machine.run_pure().unwrap();
+    // go 50 returns 7, so 7 + 7 = 14
+    assert_lit_int(&result, 14);
+}

--- a/tidepool-codegen/tests/tco.rs
+++ b/tidepool-codegen/tests/tco.rs
@@ -101,21 +101,19 @@ fn build_tail_recursive_countdown(n: i64, result: i64) -> CoreExpr {
 }
 
 /// Deep self-recursion: `go 100000` should complete without stack overflow.
+/// Uses default thread stack size so this would overflow without TCO.
 #[test]
 fn test_tco_deep_self_recursion() {
-    std::thread::Builder::new()
-        .stack_size(32 * 1024 * 1024)
-        .spawn(|| {
-            let expr = build_tail_recursive_countdown(100_000, 42);
-            let table = empty_table();
-            let mut machine =
-                JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
-            let result = machine.run_pure().unwrap();
-            assert_lit_int(&result, 42);
-        })
-        .unwrap()
-        .join()
-        .unwrap();
+    std::thread::spawn(|| {
+        let expr = build_tail_recursive_countdown(100_000, 42);
+        let table = empty_table();
+        let mut machine =
+            JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+        let result = machine.run_pure().unwrap();
+        assert_lit_int(&result, 42);
+    })
+    .join()
+    .unwrap();
 }
 
 /// Moderate recursion to verify basic correctness with a smaller depth.


### PR DESCRIPTION
## Summary

- Tail-position `App` nodes in lambda bodies store callee+arg into VMContext fields and return null instead of `call_indirect`, enabling deep recursion (100K+ iterations) without stack overflow
- Non-tail callers detect null returns and resolve pending tail calls via `trampoline_resolve` host function
- Frame walker updated to skip non-JIT frames, supporting JIT→Host→JIT sandwiches (heap_force, trampoline_resolve)
- Resolution loops added to `effect_machine.rs` (step/call_closure) and `jit_machine.rs` (run_pure)

## Changes

| File | What |
|------|------|
| `emit/expr.rs` (+215) | `SetTailPosition` work item, `emit_tail_app` for tail Apps, null-check + trampoline call for non-tail Apps |
| `effect_machine.rs` (+26) | `resolve_tail_calls` helper called from `step()` and `call_closure()` |
| `jit_machine.rs` (+25) | Inline resolution loop in `run_pure()` with signal protection |
| `gc/frame_walker.rs` (+9/-13) | Skip non-JIT frames instead of breaking on first non-JIT frame |
| `tests/tco.rs` (new) | 3 integration tests: deep 100K recursion, moderate 1K, mixed tail/non-tail |

## Design

Builds on the VMContext infrastructure from ec050b6 (`tail_callee`/`tail_arg` fields, `trampoline_resolve`).

Key correctness arguments:
- No new GC safepoints in JIT tail-call path (null check is just a branch)
- VMContext tail fields don't need GC roots (set immediately before return, consumed immediately by resolver)
- `compile_expr` intentionally does NOT enable tail position — only lambda bodies get TCO, since raw JIT callers (test harnesses) may lack resolution loops

## Test plan

- [x] `cargo test -p tidepool-codegen test_tco` — 3 TCO tests pass
- [x] `cargo test --workspace` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)