### PR TITLE
feat(gc): panic on forwarding table lookup failure during compaction

### DIFF
--- a/tidepool-heap/src/gc/compact.rs
+++ b/tidepool-heap/src/gc/compact.rs
@@ -72,11 +72,10 @@ fn rewrite_value(val: &Value, table: &ForwardingTable) -> Value {
             Value::Closure(rewrite_env(env, table), *binder, expr.clone())
         }
         Value::ThunkRef(id) => Value::ThunkRef(table.lookup(*id).unwrap_or_else(|_| {
-            eprintln!(
-                "GC compact: ThunkRef({}) not in forwarding table — GC trace bug, keeping original",
+            panic!(
+                "GC compact: ThunkRef({}) not in forwarding table — GC trace bug",
                 id.0
             );
-            *id
         })),
         Value::JoinCont(binders, expr, env) => {
             Value::JoinCont(binders.clone(), expr.clone(), rewrite_env(env, table))


### PR DESCRIPTION
This PR escalates a GC forwarding failure from `eprintln!` to `panic!` in `tidepool-heap/src/gc/compact.rs`.

A missed forwarding-table lookup during GC compaction indicates a fundamental violation of GC invariants—a reachable object was not traced. Continuing with a stale `ThunkId` would result in a dangling reference, leading to silent and hard-to-diagnose corruption. Making this fail loudly with a `panic!` ensures that such bugs are caught immediately.

Verified with `cargo check -p tidepool-heap` and `cargo test -p tidepool-heap`.