### PR TITLE
feat: name magic constants (0x45, 0x1000, lit tags in heap_bridge)

### DIFF
--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -223,7 +223,7 @@ fn collapse_frame(
             Some(v) => Ok(v),
             None => {
                 let tag = (vid.0 >> 56) as u8;
-                if tag == 0x45 {
+                if tag == tidepool_repr::ERROR_SENTINEL_TAG {
                     // Lazy poison: emit a constant pointer to a pre-allocated
                     // poison closure. The error flag is NOT set now — only when
                     // the closure is actually called (forced). This is critical
@@ -1120,7 +1120,7 @@ pub fn compile_expr(
 }
 
 impl EmitContext {
-    /// Check if a binding's RHS references an error sentinel (tag 0x45).
+    /// Check if a binding's RHS references an error sentinel (tag ERROR_SENTINEL_TAG).
     /// GHC Core hoists `error "..."` into let bindings that are only forced on
     /// impossible branches. Since our JIT is strict, we must not evaluate these
     /// eagerly. Returns true if the RHS free vars contain an error sentinel.
@@ -1133,7 +1133,7 @@ impl EmitContext {
         let mut idx = rhs_idx;
         loop {
             match &tree.nodes[idx] {
-                CoreFrame::Var(v) => return (v.0 >> 56) as u8 == 0x45,
+                CoreFrame::Var(v) => return (v.0 >> 56) as u8 == tidepool_repr::ERROR_SENTINEL_TAG,
                 CoreFrame::App { fun, .. } => idx = *fun,
                 _ => return false,
             }
@@ -1145,7 +1145,7 @@ impl EmitContext {
         let mut idx = rhs_idx;
         loop {
             match &tree.nodes[idx] {
-                CoreFrame::Var(v) if (v.0 >> 56) as u8 == 0x45 => return v.0 & 0xFF,
+                CoreFrame::Var(v) if (v.0 >> 56) as u8 == tidepool_repr::ERROR_SENTINEL_TAG => return v.0 & 0xFF,
                 CoreFrame::App { fun, .. } => idx = *fun,
                 _ => return 2, // fallback: UserError
             }

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -1,4 +1,8 @@
 use crate::context::VMContext;
+use crate::emit::{
+    LIT_TAG_ADDR, LIT_TAG_ARRAY, LIT_TAG_BYTEARRAY, LIT_TAG_CHAR, LIT_TAG_DOUBLE, LIT_TAG_FLOAT,
+    LIT_TAG_INT, LIT_TAG_SMALLARRAY, LIT_TAG_STRING, LIT_TAG_WORD,
+};
 use std::fmt;
 use tidepool_eval::value::Value;
 use tidepool_heap::layout;
@@ -89,14 +93,14 @@ unsafe fn heap_to_value_inner(
             let raw_value = *(ptr.add(layout::LIT_VALUE_OFFSET) as *const i64);
 
             match lit_tag {
-                0 => Ok(Value::Lit(Literal::LitInt(raw_value))),
-                1 => Ok(Value::Lit(Literal::LitWord(raw_value as u64))),
-                2 => Ok(Value::Lit(Literal::LitChar(
+                x if x == LIT_TAG_INT => Ok(Value::Lit(Literal::LitInt(raw_value))),
+                x if x == LIT_TAG_WORD => Ok(Value::Lit(Literal::LitWord(raw_value as u64))),
+                x if x == LIT_TAG_CHAR => Ok(Value::Lit(Literal::LitChar(
                     char::from_u32(raw_value as u32).unwrap_or('\0'),
                 ))),
-                3 => Ok(Value::Lit(Literal::LitFloat(raw_value as u64))),
-                4 => Ok(Value::Lit(Literal::LitDouble(raw_value as u64))),
-                5 => {
+                x if x == LIT_TAG_FLOAT => Ok(Value::Lit(Literal::LitFloat(raw_value as u64))),
+                x if x == LIT_TAG_DOUBLE => Ok(Value::Lit(Literal::LitDouble(raw_value as u64))),
+                x if x == LIT_TAG_STRING => {
                     // LitString: value is pointer to [len: u64][bytes...]
                     // Use read_unaligned because JIT data sections may not be 8-byte aligned
                     let data_ptr = raw_value as *const u8;
@@ -111,12 +115,12 @@ unsafe fn heap_to_value_inner(
                     let bytes = std::slice::from_raw_parts(bytes_ptr, len).to_vec();
                     Ok(Value::Lit(Literal::LitString(bytes)))
                 }
-                6 => {
+                x if x == LIT_TAG_ADDR => {
                     // Addr# — intermediate value, shouldn't normally be a final result.
                     // Wrap as empty LitString as graceful fallback.
                     Ok(Value::Lit(Literal::LitString(vec![])))
                 }
-                7 => {
+                x if x == LIT_TAG_BYTEARRAY => {
                     // ByteArray# — raw pointer to [len: u64][bytes...]
                     let ba_ptr = raw_value as *const u8;
                     if ba_ptr.is_null() {
@@ -134,7 +138,7 @@ unsafe fn heap_to_value_inner(
                         std::sync::Mutex::new(bytes),
                     )))
                 }
-                8 | 9 => {
+                x if x == LIT_TAG_SMALLARRAY || x == LIT_TAG_ARRAY => {
                     // SmallArray# (8) / Array# (9) — boxed pointer arrays
                     // Layout: [u64 length][ptr0][ptr1]...[ptrN-1]
                     let arr_ptr = raw_value as *const u8;
@@ -226,27 +230,27 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
             match lit {
                 Literal::LitInt(n) => {
                     layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = 0;
+                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_INT as u8;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *n;
                 }
                 Literal::LitWord(n) => {
                     layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = 1;
+                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_WORD as u8;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *n as i64;
                 }
                 Literal::LitChar(c) => {
                     layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = 2;
+                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_CHAR as u8;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *c as i64;
                 }
                 Literal::LitFloat(bits) => {
                     layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = 3;
+                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_FLOAT as u8;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *bits as i64;
                 }
                 Literal::LitDouble(bits) => {
                     layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = 4;
+                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_DOUBLE as u8;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *bits as i64;
                 }
                 Literal::LitString(bytes) => {
@@ -263,7 +267,7 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
 
                     // Only write the header once we're sure all allocations succeeded
                     layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = 5;
+                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_STRING as u8;
                     *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = data_ptr as i64;
                 }
             }
@@ -311,7 +315,7 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
                 return Err(BridgeError::NurseryExhausted);
             }
             layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-            *ptr.add(layout::LIT_TAG_OFFSET) = 7; // LIT_TAG_BYTEARRAY
+            *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_BYTEARRAY as u8;
             *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = data_ptr as i64;
             Ok(ptr)
         }

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -746,7 +746,7 @@ pub fn reset_call_depth() {
 
 /// Check pointer validity; if bad, set runtime error and return true.
 fn check_ptr_invalid(ptr: *const u8, fn_name: &str) -> bool {
-    if (ptr as u64) < MIN_VALID_ADDR {
+    if (ptr as i64) < MIN_VALID_ADDR as i64 {
         let msg = format!("[BUG] {}: bad pointer {:#x}", fn_name, ptr as u64);
         eprintln!("{}", msg);
         push_diagnostic(msg);

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -8,6 +8,9 @@ use tidepool_heap::layout;
 
 type GcHook = fn(&[StackRoot]);
 
+/// Addresses below this are considered invalid (null page guard).
+const MIN_VALID_ADDR: u64 = 0x1000;
+
 /// Runtime errors raised by JIT code via host functions.
 #[derive(Debug, Clone)]
 pub enum RuntimeError {
@@ -743,7 +746,7 @@ pub fn reset_call_depth() {
 
 /// Check pointer validity; if bad, set runtime error and return true.
 fn check_ptr_invalid(ptr: *const u8, fn_name: &str) -> bool {
-    if (ptr as u64) < 0x1000 {
+    if (ptr as u64) < MIN_VALID_ADDR {
         let msg = format!("[BUG] {}: bad pointer {:#x}", fn_name, ptr as u64);
         eprintln!("{}", msg);
         push_diagnostic(msg);

--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -138,7 +138,7 @@ fn eval_at(
     match &expr.nodes[idx] {
         CoreFrame::Var(v) => {
             let tag = (v.0 >> 56) as u8;
-            if tag == 0x45 {
+            if tag == tidepool_repr::ERROR_SENTINEL_TAG {
                 // 'E' = error tag: synthetic error VarIds from Translate.hs
                 let kind = v.0 & 0xFF;
                 return Err(match kind {

--- a/tidepool-repr/src/types.rs
+++ b/tidepool-repr/src/types.rs
@@ -1,3 +1,6 @@
+/// Tag byte stored in high bits of VarId to mark error-sentinel bindings.
+pub const ERROR_SENTINEL_TAG: u8 = 0x45;
+
 /// Variable identifier. Wraps a numeric ID.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VarId(pub u64);


### PR DESCRIPTION
This PR replaces magic constants with named constants and addresses review feedback:
- `0x45` (error sentinel tag) -> `ERROR_SENTINEL_TAG` in `tidepool-repr`
- `0x1000` (pointer validity threshold) -> `MIN_VALID_ADDR` in `host_fns.rs`
- Raw integer literal tags in `heap_bridge.rs` -> named constants from `crate::emit`
- Fixed pointer guards in `host_fns.rs` to use signed checks, correctly catching negative `i64` addresses.

Verification:
- `cargo check --workspace` passed.
- `cargo test -p tidepool-codegen -p tidepool-eval -p tidepool-repr` passed.
- All proptests in `proptest_cbor` passed on rerun.