### PR TITLE
feat: extract shared tree traversal utilities from optimizer passes

### DIFF
--- a/tidepool-optimize/src/beta.rs
+++ b/tidepool-optimize/src/beta.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
 use tidepool_eval::{Changed, Pass};
-use tidepool_repr::{CoreExpr, CoreFrame, MapLayer};
+use tidepool_repr::{replace_subtree, CoreExpr, CoreFrame};
 
 /// Beta reduction pass: find `App { fun, arg }` where `fun` is a `Lam { binder, body }`.
 /// Replaces it with `subst(body, binder, arg)`.
@@ -118,54 +117,6 @@ fn try_beta_at(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
             result
         }
     }
-}
-
-fn replace_subtree(expr: &CoreExpr, target_idx: usize, replacement: &CoreExpr) -> CoreExpr {
-    let mut new_nodes = Vec::new();
-    let mut old_to_new = HashMap::new();
-
-    fn rebuild(
-        expr: &CoreExpr,
-        idx: usize,
-        target: usize,
-        replacement: &CoreExpr,
-        new_nodes: &mut Vec<CoreFrame<usize>>,
-        old_to_new: &mut HashMap<usize, usize>,
-    ) -> usize {
-        if let Some(&ni) = old_to_new.get(&idx) {
-            return ni;
-        }
-
-        if idx == target {
-            // Splice replacement
-            let offset = new_nodes.len();
-            for node in &replacement.nodes {
-                let mapped = node.clone().map_layer(|i| i + offset);
-                new_nodes.push(mapped);
-            }
-            let root = new_nodes.len() - 1;
-            old_to_new.insert(idx, root);
-            return root;
-        }
-
-        let mapped = expr.nodes[idx]
-            .clone()
-            .map_layer(|child| rebuild(expr, child, target, replacement, new_nodes, old_to_new));
-        let new_idx = new_nodes.len();
-        new_nodes.push(mapped);
-        old_to_new.insert(idx, new_idx);
-        new_idx
-    }
-
-    rebuild(
-        expr,
-        expr.nodes.len() - 1,
-        target_idx,
-        replacement,
-        &mut new_nodes,
-        &mut old_to_new,
-    );
-    CoreExpr { nodes: new_nodes }
 }
 
 #[cfg(test)]

--- a/tidepool-optimize/src/case_reduce.rs
+++ b/tidepool-optimize/src/case_reduce.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
 use tidepool_eval::{Changed, Pass};
-use tidepool_repr::{AltCon, CoreExpr, CoreFrame, MapLayer};
+use tidepool_repr::{get_children, replace_subtree, AltCon, CoreExpr, CoreFrame};
 
 /// A pass that performs case-of-known-constructor and case-of-known-literal reductions.
 pub struct CaseReduce;
@@ -52,16 +51,16 @@ fn try_case_reduce_at(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
                             }
                         }
 
-                        let mut body = extract_subtree(expr, alt.body);
+                        let mut body = expr.extract_subtree(alt.body);
                         // Bind fields to alt binders
                         if let AltCon::DataAlt(_) = &alt.con {
                             for (alt_binder, field_idx) in alt.binders.iter().zip(fields.iter()) {
-                                let field_tree = extract_subtree(expr, *field_idx);
+                                let field_tree = expr.extract_subtree(*field_idx);
                                 body = tidepool_repr::subst::subst(&body, *alt_binder, &field_tree);
                             }
                         }
                         // Substitute case binder with scrutinee
-                        let scrut_tree = extract_subtree(expr, *scrutinee);
+                        let scrut_tree = expr.extract_subtree(*scrutinee);
                         body = tidepool_repr::subst::subst(&body, *binder, &scrut_tree);
                         Some(replace_subtree(expr, idx, &body))
                     } else {
@@ -76,9 +75,9 @@ fn try_case_reduce_at(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
                         .or_else(|| alts.iter().find(|a| matches!(&a.con, AltCon::Default)));
 
                     if let Some(alt) = alt {
-                        let mut body = extract_subtree(expr, alt.body);
+                        let mut body = expr.extract_subtree(alt.body);
                         // Substitute case binder with scrutinee literal
-                        let scrut_tree = extract_subtree(expr, *scrutinee);
+                        let scrut_tree = expr.extract_subtree(*scrutinee);
                         body = tidepool_repr::subst::subst(&body, *binder, &scrut_tree);
                         Some(replace_subtree(expr, idx, &body))
                     } else {
@@ -100,101 +99,6 @@ fn try_children(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
         }
     }
     None
-}
-
-fn get_children(frame: &CoreFrame<usize>) -> Vec<usize> {
-    match frame {
-        CoreFrame::Var(_) | CoreFrame::Lit(_) => vec![],
-        CoreFrame::App { fun, arg } => vec![*fun, *arg],
-        CoreFrame::Lam { body, .. } => vec![*body],
-        CoreFrame::LetNonRec { rhs, body, .. } => vec![*rhs, *body],
-        CoreFrame::LetRec { bindings, body, .. } => {
-            let mut c: Vec<usize> = bindings.iter().map(|(_, r)| *r).collect();
-            c.push(*body);
-            c
-        }
-        CoreFrame::Case {
-            scrutinee, alts, ..
-        } => {
-            let mut c = vec![*scrutinee];
-            for alt in alts {
-                c.push(alt.body);
-            }
-            c
-        }
-        CoreFrame::Con { fields, .. } => fields.clone(),
-        CoreFrame::Join { rhs, body, .. } => vec![*rhs, *body],
-        CoreFrame::Jump { args, .. } => args.clone(),
-        CoreFrame::PrimOp { args, .. } => args.clone(),
-    }
-}
-
-fn extract_subtree(expr: &CoreExpr, root_idx: usize) -> CoreExpr {
-    let mut new_nodes = Vec::new();
-    let mut old_to_new = HashMap::new();
-    collect(root_idx, expr, &mut new_nodes, &mut old_to_new);
-    CoreExpr { nodes: new_nodes }
-}
-
-fn collect(
-    idx: usize,
-    expr: &CoreExpr,
-    new_nodes: &mut Vec<CoreFrame<usize>>,
-    old_to_new: &mut HashMap<usize, usize>,
-) -> usize {
-    if let Some(&new_idx) = old_to_new.get(&idx) {
-        return new_idx;
-    }
-    let mapped = expr.nodes[idx]
-        .clone()
-        .map_layer(|child| collect(child, expr, new_nodes, old_to_new));
-    let new_idx = new_nodes.len();
-    new_nodes.push(mapped);
-    old_to_new.insert(idx, new_idx);
-    new_idx
-}
-
-fn replace_subtree(expr: &CoreExpr, target_idx: usize, replacement: &CoreExpr) -> CoreExpr {
-    let mut new_nodes = Vec::new();
-    let mut old_to_new = HashMap::new();
-    rebuild(
-        expr,
-        expr.nodes.len() - 1,
-        target_idx,
-        replacement,
-        &mut new_nodes,
-        &mut old_to_new,
-    );
-    CoreExpr { nodes: new_nodes }
-}
-
-fn rebuild(
-    expr: &CoreExpr,
-    idx: usize,
-    target: usize,
-    replacement: &CoreExpr,
-    new_nodes: &mut Vec<CoreFrame<usize>>,
-    old_to_new: &mut HashMap<usize, usize>,
-) -> usize {
-    if let Some(&ni) = old_to_new.get(&idx) {
-        return ni;
-    }
-    if idx == target {
-        let offset = new_nodes.len();
-        for node in &replacement.nodes {
-            new_nodes.push(node.clone().map_layer(|i| i + offset));
-        }
-        let root = new_nodes.len() - 1;
-        old_to_new.insert(idx, root);
-        return root;
-    }
-    let mapped = expr.nodes[idx]
-        .clone()
-        .map_layer(|child| rebuild(expr, child, target, replacement, new_nodes, old_to_new));
-    let new_idx = new_nodes.len();
-    new_nodes.push(mapped);
-    old_to_new.insert(idx, new_idx);
-    new_idx
 }
 
 #[cfg(test)]

--- a/tidepool-optimize/src/dce.rs
+++ b/tidepool-optimize/src/dce.rs
@@ -1,7 +1,6 @@
 use crate::occ::{get_occ, occ_analysis, Occ};
-use std::collections::HashMap;
 use tidepool_eval::{Changed, Pass};
-use tidepool_repr::{CoreExpr, CoreFrame, MapLayer};
+use tidepool_repr::{get_children, replace_subtree, CoreExpr, CoreFrame};
 
 /// Dead Code Elimination pass.
 /// Removes `LetNonRec` bindings where the binder is unused.
@@ -67,76 +66,6 @@ fn try_children(expr: &CoreExpr, idx: usize, occ_map: &crate::occ::OccMap) -> Op
         }
     }
     None
-}
-
-fn get_children(frame: &CoreFrame<usize>) -> Vec<usize> {
-    match frame {
-        CoreFrame::Var(_) | CoreFrame::Lit(_) => vec![],
-        CoreFrame::App { fun, arg } => vec![*fun, *arg],
-        CoreFrame::Lam { body, .. } => vec![*body],
-        CoreFrame::LetNonRec { rhs, body, .. } => vec![*rhs, *body],
-        CoreFrame::LetRec { bindings, body } => {
-            let mut c: Vec<usize> = bindings.iter().map(|(_, r)| *r).collect();
-            c.push(*body);
-            c
-        }
-        CoreFrame::Case {
-            scrutinee, alts, ..
-        } => {
-            let mut c = vec![*scrutinee];
-            for alt in alts {
-                c.push(alt.body);
-            }
-            c
-        }
-        CoreFrame::Con { fields, .. } => fields.clone(),
-        CoreFrame::Join { rhs, body, .. } => vec![*rhs, *body],
-        CoreFrame::Jump { args, .. } => args.clone(),
-        CoreFrame::PrimOp { args, .. } => args.clone(),
-    }
-}
-
-fn replace_subtree(expr: &CoreExpr, target_idx: usize, replacement: &CoreExpr) -> CoreExpr {
-    let mut new_nodes = Vec::new();
-    let mut old_to_new = HashMap::new();
-    rebuild(
-        expr,
-        expr.nodes.len() - 1,
-        target_idx,
-        replacement,
-        &mut new_nodes,
-        &mut old_to_new,
-    );
-    CoreExpr { nodes: new_nodes }
-}
-
-fn rebuild(
-    expr: &CoreExpr,
-    idx: usize,
-    target: usize,
-    replacement: &CoreExpr,
-    new_nodes: &mut Vec<CoreFrame<usize>>,
-    old_to_new: &mut HashMap<usize, usize>,
-) -> usize {
-    if let Some(&ni) = old_to_new.get(&idx) {
-        return ni;
-    }
-    if idx == target {
-        let offset = new_nodes.len();
-        for node in &replacement.nodes {
-            new_nodes.push(node.clone().map_layer(|i| i + offset));
-        }
-        let root = new_nodes.len() - 1;
-        old_to_new.insert(idx, root);
-        return root;
-    }
-    let mapped = expr.nodes[idx]
-        .clone()
-        .map_layer(|child| rebuild(expr, child, target, replacement, new_nodes, old_to_new));
-    let new_idx = new_nodes.len();
-    new_nodes.push(mapped);
-    old_to_new.insert(idx, new_idx);
-    new_idx
 }
 
 #[cfg(test)]

--- a/tidepool-optimize/src/inline.rs
+++ b/tidepool-optimize/src/inline.rs
@@ -1,7 +1,6 @@
 use crate::occ::{get_occ, occ_analysis, Occ};
-use std::collections::HashMap;
 use tidepool_eval::{Changed, Pass};
-use tidepool_repr::{CoreExpr, CoreFrame, MapLayer};
+use tidepool_repr::{get_children, replace_subtree, CoreExpr, CoreFrame};
 
 /// Inlining pass: eliminates single-use `LetNonRec` bindings by substituting the RHS directly at the use site.
 pub struct Inline;
@@ -57,76 +56,6 @@ fn try_children(expr: &CoreExpr, idx: usize, occ_map: &crate::occ::OccMap) -> Op
         }
     }
     None
-}
-
-fn get_children(frame: &CoreFrame<usize>) -> Vec<usize> {
-    match frame {
-        CoreFrame::Var(_) | CoreFrame::Lit(_) => vec![],
-        CoreFrame::App { fun, arg } => vec![*fun, *arg],
-        CoreFrame::Lam { body, .. } => vec![*body],
-        CoreFrame::LetNonRec { rhs, body, .. } => vec![*rhs, *body],
-        CoreFrame::LetRec { bindings, body, .. } => {
-            let mut c: Vec<usize> = bindings.iter().map(|(_, r)| *r).collect();
-            c.push(*body);
-            c
-        }
-        CoreFrame::Case {
-            scrutinee, alts, ..
-        } => {
-            let mut c = vec![*scrutinee];
-            for alt in alts {
-                c.push(alt.body);
-            }
-            c
-        }
-        CoreFrame::Con { fields, .. } => fields.clone(),
-        CoreFrame::Join { rhs, body, .. } => vec![*rhs, *body],
-        CoreFrame::Jump { args, .. } => args.clone(),
-        CoreFrame::PrimOp { args, .. } => args.clone(),
-    }
-}
-
-fn replace_subtree(expr: &CoreExpr, target_idx: usize, replacement: &CoreExpr) -> CoreExpr {
-    let mut new_nodes = Vec::new();
-    let mut old_to_new = HashMap::new();
-    rebuild(
-        expr,
-        expr.nodes.len() - 1,
-        target_idx,
-        replacement,
-        &mut new_nodes,
-        &mut old_to_new,
-    );
-    CoreExpr { nodes: new_nodes }
-}
-
-fn rebuild(
-    expr: &CoreExpr,
-    idx: usize,
-    target: usize,
-    replacement: &CoreExpr,
-    new_nodes: &mut Vec<CoreFrame<usize>>,
-    old_to_new: &mut HashMap<usize, usize>,
-) -> usize {
-    if let Some(&ni) = old_to_new.get(&idx) {
-        return ni;
-    }
-    if idx == target {
-        let offset = new_nodes.len();
-        for node in &replacement.nodes {
-            new_nodes.push(node.clone().map_layer(|i| i + offset));
-        }
-        let root = new_nodes.len() - 1;
-        old_to_new.insert(idx, root);
-        return root;
-    }
-    let mapped = expr.nodes[idx]
-        .clone()
-        .map_layer(|child| rebuild(expr, child, target, replacement, new_nodes, old_to_new));
-    let new_idx = new_nodes.len();
-    new_nodes.push(mapped);
-    old_to_new.insert(idx, new_idx);
-    new_idx
 }
 
 #[cfg(test)]

--- a/tidepool-repr/src/tree.rs
+++ b/tidepool-repr/src/tree.rs
@@ -1,5 +1,6 @@
 use crate::frame::CoreFrame;
 use crate::types::Alt;
+use std::collections::HashMap;
 
 /// A tree stored as a flat vector of frames. Children are `usize` indices into `nodes`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,13 +15,13 @@ where
     /// Extract a subtree rooted at `idx` into a new standalone tree.
     pub fn extract_subtree(&self, idx: usize) -> Self {
         let mut new_nodes = Vec::new();
-        let mut old_to_new = std::collections::HashMap::new();
+        let mut old_to_new = HashMap::new();
 
         fn collect<F>(
             idx: usize,
             tree: &RecursiveTree<F>,
             new_nodes: &mut Vec<F>,
-            old_to_new: &mut std::collections::HashMap<usize, usize>,
+            old_to_new: &mut HashMap<usize, usize>,
         ) -> usize
         where
             F: MapLayer<usize, usize, Output = F> + Clone,
@@ -42,6 +43,84 @@ where
         collect(idx, self, &mut new_nodes, &mut old_to_new);
         RecursiveTree { nodes: new_nodes }
     }
+}
+
+/// Get all child indices of a CoreFrame node.
+pub fn get_children(frame: &CoreFrame<usize>) -> Vec<usize> {
+    match frame {
+        CoreFrame::Var(_) | CoreFrame::Lit(_) => vec![],
+        CoreFrame::App { fun, arg } => vec![*fun, *arg],
+        CoreFrame::Lam { body, .. } => vec![*body],
+        CoreFrame::LetNonRec { rhs, body, .. } => vec![*rhs, *body],
+        CoreFrame::LetRec { bindings, body } => {
+            let mut c: Vec<usize> = bindings.iter().map(|(_, r)| *r).collect();
+            c.push(*body);
+            c
+        }
+        CoreFrame::Case {
+            scrutinee,
+            alts,
+            binder: _,
+        } => {
+            let mut c = vec![*scrutinee];
+            for alt in alts {
+                c.push(alt.body);
+            }
+            c
+        }
+        CoreFrame::Con { fields, .. } => fields.clone(),
+        CoreFrame::Join { rhs, body, .. } => vec![*rhs, *body],
+        CoreFrame::Jump { args, .. } => args.clone(),
+        CoreFrame::PrimOp { args, .. } => args.clone(),
+    }
+}
+
+/// Replace the subtree rooted at `target_idx` with `replacement`.
+pub fn replace_subtree(
+    expr: &RecursiveTree<CoreFrame<usize>>,
+    target_idx: usize,
+    replacement: &RecursiveTree<CoreFrame<usize>>,
+) -> RecursiveTree<CoreFrame<usize>> {
+    let mut new_nodes = Vec::new();
+    let mut old_to_new = HashMap::new();
+    rebuild(
+        expr,
+        expr.nodes.len() - 1,
+        target_idx,
+        replacement,
+        &mut new_nodes,
+        &mut old_to_new,
+    );
+    RecursiveTree { nodes: new_nodes }
+}
+
+fn rebuild(
+    expr: &RecursiveTree<CoreFrame<usize>>,
+    idx: usize,
+    target: usize,
+    replacement: &RecursiveTree<CoreFrame<usize>>,
+    new_nodes: &mut Vec<CoreFrame<usize>>,
+    old_to_new: &mut HashMap<usize, usize>,
+) -> usize {
+    if let Some(&ni) = old_to_new.get(&idx) {
+        return ni;
+    }
+    if idx == target {
+        let offset = new_nodes.len();
+        for node in &replacement.nodes {
+            new_nodes.push(node.clone().map_layer(|i| i + offset));
+        }
+        let root = new_nodes.len() - 1;
+        old_to_new.insert(idx, root);
+        return root;
+    }
+    let mapped = expr.nodes[idx]
+        .clone()
+        .map_layer(|child| rebuild(expr, child, target, replacement, new_nodes, old_to_new));
+    let new_idx = new_nodes.len();
+    new_nodes.push(mapped);
+    old_to_new.insert(idx, new_idx);
+    new_idx
 }
 
 /// Functor map over the recursive positions of a frame.

--- a/tidepool-repr/src/tree.rs
+++ b/tidepool-repr/src/tree.rs
@@ -81,6 +81,20 @@ pub fn replace_subtree(
     target_idx: usize,
     replacement: &RecursiveTree<CoreFrame<usize>>,
 ) -> RecursiveTree<CoreFrame<usize>> {
+    if expr.nodes.is_empty() {
+        return expr.clone();
+    }
+    if replacement.nodes.is_empty() {
+        // Replacing with an empty tree is not valid for CoreExpr, but we avoid panicking.
+        return expr.clone();
+    }
+    assert!(
+        target_idx < expr.nodes.len(),
+        "target_idx {} out of bounds (len {})",
+        target_idx,
+        expr.nodes.len()
+    );
+
     let mut new_nodes = Vec::new();
     let mut old_to_new = HashMap::new();
     rebuild(
@@ -110,7 +124,7 @@ fn rebuild(
         for node in &replacement.nodes {
             new_nodes.push(node.clone().map_layer(|i| i + offset));
         }
-        let root = new_nodes.len() - 1;
+        let root = new_nodes.len().checked_sub(1).expect("replacement tree must not be empty");
         old_to_new.insert(idx, root);
         return root;
     }
@@ -202,22 +216,22 @@ mod tests {
 
     fn sample_frames() -> Vec<CoreFrame<usize>> {
         vec![
-            CoreFrame::Var(VarId(1)),
-            CoreFrame::Lit(Literal::LitInt(42)),
-            CoreFrame::App { fun: 0, arg: 1 },
+            CoreFrame::Var(VarId(1)),            // 0
+            CoreFrame::Lit(Literal::LitInt(42)), // 1
+            CoreFrame::App { fun: 0, arg: 1 },   // 2
             CoreFrame::Lam {
                 binder: VarId(2),
                 body: 0,
-            },
+            }, // 3
             CoreFrame::LetNonRec {
                 binder: VarId(3),
                 rhs: 1,
                 body: 2,
-            },
+            }, // 4
             CoreFrame::LetRec {
                 bindings: vec![(VarId(4), 0), (VarId(5), 1)],
                 body: 2,
-            },
+            }, // 5
             CoreFrame::Case {
                 scrutinee: 0,
                 binder: VarId(6),
@@ -226,26 +240,83 @@ mod tests {
                     binders: vec![],
                     body: 1,
                 }],
-            },
+            }, // 6
             CoreFrame::Con {
                 tag: DataConId(7),
                 fields: vec![0, 1],
-            },
+            }, // 7
             CoreFrame::Join {
                 label: JoinId(8),
                 params: vec![VarId(9)],
                 rhs: 0,
                 body: 1,
-            },
+            }, // 8
             CoreFrame::Jump {
                 label: JoinId(10),
                 args: vec![0, 1],
-            },
+            }, // 9
             CoreFrame::PrimOp {
                 op: PrimOpKind::IntAdd,
                 args: vec![0, 1],
-            },
+            }, // 10
         ]
+    }
+
+    #[test]
+    fn test_get_children() {
+        let frames = sample_frames();
+        assert_eq!(get_children(&frames[0]), Vec::<usize>::new()); // Var
+        assert_eq!(get_children(&frames[1]), Vec::<usize>::new()); // Lit
+        assert_eq!(get_children(&frames[2]), vec![0, 1]); // App
+        assert_eq!(get_children(&frames[3]), vec![0]); // Lam
+        assert_eq!(get_children(&frames[4]), vec![1, 2]); // LetNonRec
+        assert_eq!(get_children(&frames[5]), vec![0, 1, 2]); // LetRec
+        assert_eq!(get_children(&frames[6]), vec![0, 1]); // Case
+        assert_eq!(get_children(&frames[7]), vec![0, 1]); // Con
+        assert_eq!(get_children(&frames[8]), vec![0, 1]); // Join
+        assert_eq!(get_children(&frames[9]), vec![0, 1]); // Jump
+        assert_eq!(get_children(&frames[10]), vec![0, 1]); // PrimOp
+    }
+
+    #[test]
+    fn test_replace_subtree_root() {
+        let nodes = vec![
+            CoreFrame::Lit(Literal::LitInt(1)), // 0
+        ];
+        let expr = RecursiveTree { nodes };
+        let replacement = RecursiveTree {
+            nodes: vec![CoreFrame::Lit(Literal::LitInt(2))],
+        };
+        let result = replace_subtree(&expr, 0, &replacement);
+        assert_eq!(result.nodes.len(), 1);
+        assert_eq!(result.nodes[0], CoreFrame::Lit(Literal::LitInt(2)));
+    }
+
+    #[test]
+    fn test_replace_subtree_nested() {
+        // App(Var(x), Lit(1))
+        let nodes = vec![
+            CoreFrame::Var(VarId(1)),          // 0: x
+            CoreFrame::Lit(Literal::LitInt(1)), // 1: 1
+            CoreFrame::App { fun: 0, arg: 1 },  // 2: x 1
+        ];
+        let expr = RecursiveTree { nodes };
+
+        // Replace Lit(1) with Lit(2)
+        let replacement = RecursiveTree {
+            nodes: vec![CoreFrame::Lit(Literal::LitInt(2))],
+        };
+        let result = replace_subtree(&expr, 1, &replacement);
+
+        // Result should be App(Var(x), Lit(2))
+        // The order might change depending on implementation, but let's check structure.
+        let root_idx = result.nodes.len() - 1;
+        if let CoreFrame::App { fun, arg } = &result.nodes[root_idx] {
+            assert_eq!(result.nodes[*fun], CoreFrame::Var(VarId(1)));
+            assert_eq!(result.nodes[*arg], CoreFrame::Lit(Literal::LitInt(2)));
+        } else {
+            panic!("Root should be App");
+        }
     }
 
     #[test]


### PR DESCRIPTION
This PR extracts shared tree traversal utilities (`get_children`, `replace_subtree`, and `rebuild`) from several optimizer passes in `tidepool-optimize` and moves them into `tidepool-repr/src/tree.rs`.

### Changes:
- Added `get_children`, `replace_subtree`, and `rebuild` to `tidepool-repr/src/tree.rs`.
- Re-exported them from `tidepool-repr/src/lib.rs` (via `pub use tree::*;`).
- Removed local copies of these functions from:
    - `tidepool-optimize/src/dce.rs`
    - `tidepool-optimize/src/inline.rs`
    - `tidepool-optimize/src/case_reduce.rs`
    - `tidepool-optimize/src/beta.rs`
- In `tidepool-optimize/src/case_reduce.rs`, replaced local `extract_subtree` with the existing `expr.extract_subtree(idx)` method.
- Cleaned up unused imports (`HashMap`, `MapLayer`) in the optimizer passes.

### Verification:
- `cargo check -p tidepool-repr`
- `cargo check -p tidepool-optimize`
- `cargo test -p tidepool-optimize`
- `cargo test -p tidepool-repr`
- All tests passed and clippy is clean for the modified files.