### PR TITLE
feat: MCP eval/resume dedup + miscellaneous fixes (updated)

### DIFF
--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -290,11 +290,6 @@ pub fn last_gc_roots() -> Vec<StackRoot> {
     LAST_ROOTS.with(|roots_cell| roots_cell.borrow().clone())
 }
 
-/// Heap allocation: called by JIT code for large or slow-path allocations.
-pub extern "C" fn heap_alloc(_vmctx: *mut VMContext, _size: u64) -> *mut u8 {
-    std::ptr::null_mut() // Placeholder for scaffold
-}
-
 /// Force a thunk to WHNF. Loops to handle chains (thunk returning thunk).
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn heap_force(vmctx: *mut VMContext, obj: *mut u8) -> *mut u8 {
@@ -1355,7 +1350,6 @@ pub fn host_fn_symbols() -> Vec<(&'static str, *const u8)> {
             "runtime_bad_thunk_state_trap",
             runtime_bad_thunk_state_trap as *const u8,
         ),
-        ("heap_alloc", heap_alloc as *const u8),
         ("heap_force", heap_force as *const u8),
         ("unresolved_var_trap", unresolved_var_trap as *const u8),
         ("runtime_error", runtime_error as *const u8),

--- a/tidepool-mcp/Cargo.toml
+++ b/tidepool-mcp/Cargo.toml
@@ -22,6 +22,6 @@ serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 dyn-clone = "1.0"
 frunk = "0.4"
-schemars = "=1.2.1"
+schemars = "1.2"
 serde_json = "1"
 tidepool-bridge = { version = "0.1.0", path = "../tidepool-bridge" }

--- a/tidepool-mcp/Cargo.toml
+++ b/tidepool-mcp/Cargo.toml
@@ -17,7 +17,7 @@ tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }
 rmcp = { version = "0.16", features = ["server", "transport-io", "transport-streamable-http-server"] }
 axum = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-util", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-util", "signal", "fs", "test-util"] }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 dyn-clone = "1.0"

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -1464,6 +1464,7 @@ impl TidepoolMcpServerImpl {
 
     async fn handle_session_result(
         &self,
+        op: &str,
         mut session_rx: tokio::sync::mpsc::UnboundedReceiver<SessionMessage>,
         source: Arc<str>,
         response_tx: std::sync::mpsc::Sender<String>,
@@ -1471,7 +1472,7 @@ impl TidepoolMcpServerImpl {
         let eval_timeout = Duration::from_secs(EVAL_TIMEOUT_SECS);
         match timeout(eval_timeout, session_rx.recv()).await {
             Ok(Some(SessionMessage::Completed { result, output })) => {
-                tracing::info!("eval completed");
+                tracing::info!("{} completed", op);
                 let mut response = String::new();
                 if !output.is_empty() {
                     response.push_str("## Output\n");
@@ -1485,7 +1486,7 @@ impl TidepoolMcpServerImpl {
                 Ok(CallToolResult::success(vec![Content::text(response)]))
             }
             Ok(Some(SessionMessage::Suspended { prompt })) => {
-                tracing::info!(prompt = %prompt, "eval suspended on Ask");
+                tracing::info!(prompt = %prompt, "{} suspended on Ask", op);
                 let cont_id = self.next_continuation_id();
                 let json = serde_json::json!({
                     "suspended": true,
@@ -1510,14 +1511,14 @@ impl TidepoolMcpServerImpl {
             }
             Ok(Some(SessionMessage::Error { error })) => {
                 let error_msg = format_error_with_source("Error", &error, &source);
-                tracing::error!("eval failed: {}", error);
+                tracing::error!("{} failed: {}", op, error);
                 Ok(CallToolResult::error(vec![Content::text(error_msg)]))
             }
             Ok(None) => {
-                tracing::error!("eval thread crashed");
+                tracing::error!("{} thread crashed", op);
                 let mut crash_info = String::new();
-                if let Ok(content) = std::fs::read_to_string(".tidepool/crash.log") {
-                    let lines: Vec<_> = content.lines().rev().take(5).collect();
+                if let Ok(content) = tokio::fs::read_to_string(".tidepool/crash.log").await {
+                    let lines: Vec<&str> = content.lines().rev().take(5).collect();
                     if !lines.is_empty() {
                         crash_info.push_str("\n\n## Recent Crash Log Entries\n```\n");
                         for line in lines.into_iter().rev() {
@@ -1530,20 +1531,20 @@ impl TidepoolMcpServerImpl {
                 let error_msg = format_error_with_source(
                     "Crash",
                     &format!(
-                        "Eval thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.{}",
-                        crash_info
+                        "{} thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.{}",
+                        op, crash_info
                     ),
                     &source,
                 );
                 Ok(CallToolResult::error(vec![Content::text(error_msg)]))
             }
             Err(_elapsed) => {
-                tracing::error!("eval timed out after {}s", EVAL_TIMEOUT_SECS);
+                tracing::error!("{} timed out after {}s", op, EVAL_TIMEOUT_SECS);
                 let error_msg = format_error_with_source(
                     "Timeout",
                     &format!(
-                        "Evaluation timed out after {}s. This usually means an infinite loop or unbounded recursion.",
-                        EVAL_TIMEOUT_SECS
+                        "{} timed out after {}s. This usually means an infinite loop or unbounded recursion.",
+                        op, EVAL_TIMEOUT_SECS
                     ),
                     &source,
                 );
@@ -1677,7 +1678,7 @@ impl TidepoolMcpServerImpl {
             .map_err(|e| McpError::internal_error(format!("thread spawn error: {}", e), None))?;
 
         // Await first message from the eval thread
-        self.handle_session_result(session_rx, source, response_tx)
+        self.handle_session_result("eval", session_rx, source, response_tx)
             .await
     }
 
@@ -1708,7 +1709,7 @@ impl TidepoolMcpServerImpl {
         let response_tx = session.response_tx.clone();
 
         // Await the next message from the eval thread
-        self.handle_session_result(session.session_rx, source, response_tx)
+        self.handle_session_result("resume", session.session_rx, source, response_tx)
             .await
     }
 }
@@ -2442,4 +2443,170 @@ mod tests {
             haskell.contains("\"obj\" .= object [\"a\" .= Aeson.Number (fromIntegral (1 :: Int))]")
         );
     }
+
+    #[tokio::test]
+    async fn test_handle_session_result_completed() {
+        let server = create_mock_server();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
+        let source: Arc<str> = "test source".into();
+
+        tx.send(SessionMessage::Completed {
+            result: "42".into(),
+            output: vec!["log1".into()],
+        })
+        .unwrap();
+
+        let res = server
+            .handle_session_result("eval", rx, source, resp_tx)
+            .await
+            .unwrap();
+        assert_eq!(res.is_error, Some(false));
+        let text = match &res.content[0].raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("Expected text content"),
+        };
+        assert!(text.contains("## Output\nlog1\n"));
+        assert!(text.contains("\n## Result\n42"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_session_result_suspended() {
+        let server = create_mock_server();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
+        let source: Arc<str> = "test source".into();
+
+        tx.send(SessionMessage::Suspended {
+            prompt: "what is your name?".into(),
+        })
+        .unwrap();
+
+        let res = server
+            .handle_session_result("eval", rx, source, resp_tx)
+            .await
+            .unwrap();
+        assert_eq!(res.is_error, Some(false));
+        let text = match &res.content[0].raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("Expected text content"),
+        };
+        let json: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(json["suspended"], true);
+        assert_eq!(json["prompt"], "what is your name?");
+        assert!(json["continuation_id"].as_str().unwrap().starts_with("cont_"));
+
+        // Check if it's in the continuations map
+        let cont_id = json["continuation_id"].as_str().unwrap();
+        let conts = server.continuations.lock().unwrap();
+        assert!(conts.contains_key(cont_id));
+    }
+
+    #[tokio::test]
+    async fn test_handle_session_result_error() {
+        let server = create_mock_server();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
+        let source: Arc<str> = "test source".into();
+
+        tx.send(SessionMessage::Error {
+            error: "oops".into(),
+        })
+        .unwrap();
+
+        let res = server
+            .handle_session_result("eval", rx, source, resp_tx)
+            .await
+            .unwrap();
+        assert_eq!(res.is_error, Some(true));
+        let text = match &res.content[0].raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("Expected text content"),
+        };
+        assert!(text.contains("## Error"));
+        assert!(text.contains("oops"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_session_result_crash() {
+        let server = create_mock_server();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
+        let source: Arc<str> = "test source".into();
+
+        // Close the channel without sending anything
+        drop(tx);
+
+        let res = server
+            .handle_session_result("eval", rx, source, resp_tx)
+            .await
+            .unwrap();
+        assert_eq!(res.is_error, Some(true));
+        let text = match &res.content[0].raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("Expected text content"),
+        };
+        assert!(text.contains("## Crash"));
+        assert!(text.contains("eval thread crashed"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_session_result_timeout() {
+        tokio::time::pause();
+
+        let server = create_mock_server();
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
+        let source: Arc<str> = "test source".into();
+
+        let handle = tokio::spawn(async move {
+            server
+                .handle_session_result("eval", rx, source, resp_tx)
+                .await
+        });
+
+        // Advance time past EVAL_TIMEOUT_SECS
+        tokio::time::advance(Duration::from_secs(EVAL_TIMEOUT_SECS + 1)).await;
+
+        let res = handle.await.unwrap().unwrap();
+        assert_eq!(res.is_error, Some(true));
+        let text = match &res.content[0].raw {
+            RawContent::Text(t) => &t.text,
+            _ => panic!("Expected text content"),
+        };
+        assert!(text.contains("## Timeout"));
+        assert!(text.contains("timed out"));
+    }
+
+    fn create_mock_server() -> TidepoolMcpServerImpl {
+        #[derive(Clone)]
+        struct MockHandler;
+        impl DispatchEffect<CapturedOutput> for MockHandler {
+            fn dispatch(
+                &mut self,
+                _tag: u64,
+                _request: &tidepool_eval::value::Value,
+                _cx: &tidepool_effect::EffectContext<'_, CapturedOutput>,
+            ) -> Result<tidepool_eval::value::Value, tidepool_effect::error::EffectError>
+            {
+                Ok(tidepool_eval::value::Value::Lit(
+                    tidepool_repr::Literal::LitInt(0),
+                ))
+            }
+        }
+
+        TidepoolMcpServerImpl {
+            handler_factory: Arc::new(MockHandler),
+            include: Vec::new(),
+            haskell_preamble: String::new(),
+            effect_stack_type: String::new(),
+            eval_tool_description: String::new(),
+            has_user_library: false,
+            ask_tag: 0,
+            effect_names: Vec::new(),
+            continuations: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            next_cont_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
 }
+

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -1462,131 +1462,12 @@ impl TidepoolMcpServerImpl {
         conts.retain(|_, session| now.duration_since(session.created_at) < CONTINUATION_TTL);
     }
 
-    async fn eval(&self, req: EvalRequest) -> Result<CallToolResult, McpError> {
-        tracing::info!(len = req.code.len(), "eval request");
-        self.cleanup_stale_continuations();
-
-        // Reject unsafe/IO imports before compilation
-        for imp in req
-            .imports
-            .lines()
-            .map(|l| l.trim())
-            .filter(|l| !l.is_empty())
-        {
-            if let Some(module) = rejected_import(imp) {
-                return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Blocked import: `{}` is not available in the Tidepool sandbox.",
-                    module,
-                ))]));
-            }
-        }
-
-        let mut all_imports = aeson_imports();
-        all_imports.push_str(&req.imports);
-        let source: Arc<str> = template_haskell(
-            &self.haskell_preamble,
-            &self.effect_stack_type,
-            &req.code,
-            &all_imports,
-            &req.helpers,
-            req.input.as_ref(),
-            Some(req.max_len.unwrap_or(4096)),
-        )
-        .into();
-
-        let handlers = dyn_clone::clone_box(&*self.handler_factory);
-        let include_refs: Vec<PathBuf> = self.include.clone();
-        let source_for_blocking = Arc::clone(&source);
-        let captured = CapturedOutput::new();
-        let captured_for_blocking = captured.clone();
-        let ask_tag = self.ask_tag;
-        let effect_names = self.effect_names.clone();
-
-        // Create channels for Ask effect communication
-        let (session_tx, mut session_rx) = tokio::sync::mpsc::unbounded_channel::<SessionMessage>();
-        let (response_tx, response_rx) = std::sync::mpsc::channel::<String>();
-
-        // Spawn eval thread — does NOT join; communicates via channels
-        let thread_session_tx = session_tx;
-        let _handle = std::thread::Builder::new()
-            .name("tidepool-eval".into())
-            .stack_size(32 * 1024 * 1024)
-            .spawn(move || {
-                // Install signal handlers so SIGILL/SIGSEGV from JIT code
-                // are caught via sigsetjmp/siglongjmp instead of killing
-                // the whole server process.
-                tidepool_codegen::signal_safety::install();
-
-                let include_paths: Vec<&Path> = include_refs.iter().map(|p| p.as_path()).collect();
-                let mut ask_dispatcher = AskDispatcher {
-                    inner: handlers,
-                    ask_tag,
-                    session_tx: thread_session_tx.clone(),
-                    response_rx,
-                };
-
-                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    tidepool_runtime::compile_and_run(
-                        &source_for_blocking,
-                        "result",
-                        &include_paths,
-                        &mut ask_dispatcher,
-                        &captured_for_blocking,
-                    )
-                }));
-
-                let output_lines = captured_for_blocking.drain();
-                match result {
-                    Ok(Ok(eval_result)) => {
-                        let _ = thread_session_tx.send(SessionMessage::Completed {
-                            result: eval_result.to_string_pretty(),
-                            output: output_lines,
-                        });
-                    }
-                    Ok(Err(e)) => {
-                        let diagnostics = tidepool_runtime::drain_diagnostics();
-                        let mut error_detail = e.to_string();
-                        // Annotate UnhandledEffect with effect names
-                        if error_detail.starts_with("Unhandled effect at tag") {
-                            let effects_list: String = effect_names
-                                .iter()
-                                .enumerate()
-                                .map(|(i, name)| format!("  {} = {}", i, name))
-                                .collect::<Vec<_>>()
-                                .join("\n");
-                            error_detail
-                                .push_str(&format!("\n\nRegistered effects:\n{}", effects_list));
-                        }
-                        if !diagnostics.is_empty() {
-                            error_detail.push_str("\n\n## JIT Diagnostics\n");
-                            for d in &diagnostics {
-                                error_detail.push_str(d);
-                                error_detail.push('\n');
-                            }
-                        }
-                        let _ = thread_session_tx.send(SessionMessage::Error {
-                            error: error_detail,
-                        });
-                    }
-                    Err(panic_payload) => {
-                        let diagnostics = tidepool_runtime::drain_diagnostics();
-                        let mut error_detail = format_panic_payload(panic_payload);
-                        if !diagnostics.is_empty() {
-                            error_detail.push_str("\n\n## JIT Diagnostics\n");
-                            for d in &diagnostics {
-                                error_detail.push_str(d);
-                                error_detail.push('\n');
-                            }
-                        }
-                        let _ = thread_session_tx.send(SessionMessage::Error {
-                            error: error_detail,
-                        });
-                    }
-                }
-            })
-            .map_err(|e| McpError::internal_error(format!("thread spawn error: {}", e), None))?;
-
-        // Await first message from the eval thread
+    async fn handle_session_result(
+        &self,
+        mut session_rx: tokio::sync::mpsc::UnboundedReceiver<SessionMessage>,
+        source: Arc<str>,
+        response_tx: std::sync::mpsc::Sender<String>,
+    ) -> Result<CallToolResult, McpError> {
         let eval_timeout = Duration::from_secs(EVAL_TIMEOUT_SECS);
         match timeout(eval_timeout, session_rx.recv()).await {
             Ok(Some(SessionMessage::Completed { result, output })) => {
@@ -1671,11 +1552,140 @@ impl TidepoolMcpServerImpl {
         }
     }
 
+    async fn eval(&self, req: EvalRequest) -> Result<CallToolResult, McpError> {
+        tracing::info!(len = req.code.len(), "eval request");
+        self.cleanup_stale_continuations();
+
+        // Reject unsafe/IO imports before compilation
+        for imp in req
+            .imports
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+        {
+            if let Some(module) = rejected_import(imp) {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "Blocked import: `{}` is not available in the Tidepool sandbox.",
+                    module,
+                ))]));
+            }
+        }
+
+        let mut all_imports = aeson_imports();
+        all_imports.push_str(&req.imports);
+        let source: Arc<str> = template_haskell(
+            &self.haskell_preamble,
+            &self.effect_stack_type,
+            &req.code,
+            &all_imports,
+            &req.helpers,
+            req.input.as_ref(),
+            Some(req.max_len.unwrap_or(4096)),
+        )
+        .into();
+
+        let handlers = dyn_clone::clone_box(&*self.handler_factory);
+        let include_refs: Vec<PathBuf> = self.include.clone();
+        let source_for_blocking = Arc::clone(&source);
+        let captured = CapturedOutput::new();
+        let captured_for_blocking = captured.clone();
+        let ask_tag = self.ask_tag;
+        let effect_names = self.effect_names.clone();
+
+        // Create channels for Ask effect communication
+        let (session_tx, session_rx) = tokio::sync::mpsc::unbounded_channel::<SessionMessage>();
+        let (response_tx, response_rx) = std::sync::mpsc::channel::<String>();
+
+        // Spawn eval thread — does NOT join; communicates via channels
+        let thread_session_tx = session_tx;
+        let _handle = std::thread::Builder::new()
+            .name("tidepool-eval".into())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                // Install signal handlers so SIGILL/SIGSEGV from JIT code
+                // are caught via sigsetjmp/siglongjmp instead of killing
+                // the whole server process.
+                tidepool_codegen::signal_safety::install();
+
+                let include_paths: Vec<&Path> = include_refs.iter().map(|p| p.as_path()).collect();
+                let mut ask_dispatcher = AskDispatcher {
+                    inner: handlers,
+                    ask_tag,
+                    session_tx: thread_session_tx.clone(),
+                    response_rx,
+                };
+
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    tidepool_runtime::compile_and_run(
+                        &source_for_blocking,
+                        "result",
+                        &include_paths,
+                        &mut ask_dispatcher,
+                        &captured_for_blocking,
+                    )
+                }));
+
+                let output_lines = captured_for_blocking.drain();
+                match result {
+                    Ok(Ok(eval_result)) => {
+                        let _ = thread_session_tx.send(SessionMessage::Completed {
+                            result: eval_result.to_string_pretty(),
+                            output: output_lines,
+                        });
+                    }
+                    Ok(Err(e)) => {
+                        let diagnostics = tidepool_runtime::drain_diagnostics();
+                        let mut error_detail = e.to_string();
+                        // Annotate UnhandledEffect with effect names
+                        if error_detail.starts_with("Unhandled effect at tag") {
+                            let effects_list: String = effect_names
+                                .iter()
+                                .enumerate()
+                                .map(|(i, name)| format!("  {} = {}", i, name))
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            error_detail
+                                .push_str(&format!("\n\nRegistered effects:\n{}", effects_list));
+                        }
+                        if !diagnostics.is_empty() {
+                            error_detail.push_str("\n\n## JIT Diagnostics\n");
+                            for d in &diagnostics {
+                                error_detail.push_str(d);
+                                error_detail.push('\n');
+                            }
+                        }
+                        let _ = thread_session_tx.send(SessionMessage::Error {
+                            error: error_detail,
+                        });
+                    }
+                    Err(panic_payload) => {
+                        let diagnostics = tidepool_runtime::drain_diagnostics();
+                        let mut error_detail = format_panic_payload(panic_payload);
+                        if !diagnostics.is_empty() {
+                            error_detail.push_str("\n\n## JIT Diagnostics\n");
+                            for d in &diagnostics {
+                                error_detail.push_str(d);
+                                error_detail.push('\n');
+                            }
+                        }
+                        let _ = thread_session_tx.send(SessionMessage::Error {
+                            error: error_detail,
+                        });
+                    }
+                }
+            })
+            .map_err(|e| McpError::internal_error(format!("thread spawn error: {}", e), None))?;
+
+        // Await first message from the eval thread
+        self.handle_session_result(session_rx, source, response_tx)
+            .await
+    }
+
     async fn resume(&self, req: ResumeRequest) -> Result<CallToolResult, McpError> {
         tracing::info!(continuation_id = %req.continuation_id, "resume request");
         self.cleanup_stale_continuations();
 
-        let mut session = {
+        let session = {
             let mut conts = self.continuations.lock().unwrap_or_else(|e| e.into_inner());
             conts.remove(&req.continuation_id).ok_or_else(|| {
                 McpError::invalid_params(
@@ -1698,88 +1708,8 @@ impl TidepoolMcpServerImpl {
         let response_tx = session.response_tx.clone();
 
         // Await the next message from the eval thread
-        let eval_timeout = Duration::from_secs(EVAL_TIMEOUT_SECS);
-        match timeout(eval_timeout, session.session_rx.recv()).await {
-            Ok(Some(SessionMessage::Completed { result, output })) => {
-                tracing::info!("resumed eval completed");
-                let mut response = String::new();
-                if !output.is_empty() {
-                    response.push_str("## Output\n");
-                    for line in &output {
-                        response.push_str(line);
-                        response.push('\n');
-                    }
-                    response.push_str("\n## Result\n");
-                }
-                response.push_str(&result);
-                Ok(CallToolResult::success(vec![Content::text(response)]))
-            }
-            Ok(Some(SessionMessage::Suspended { prompt })) => {
-                tracing::info!(prompt = %prompt, "resumed eval suspended again");
-                let cont_id = self.next_continuation_id();
-                let json = serde_json::json!({
-                    "suspended": true,
-                    "continuation_id": cont_id,
-                    "prompt": prompt,
-                });
-                self.continuations
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .insert(
-                        cont_id.clone(),
-                        EvalSession {
-                            response_tx,
-                            session_rx: session.session_rx,
-                            source,
-                            created_at: std::time::Instant::now(),
-                        },
-                    );
-                Ok(CallToolResult::success(vec![Content::text(
-                    json.to_string(),
-                )]))
-            }
-            Ok(Some(SessionMessage::Error { error })) => {
-                let error_msg = format_error_with_source("Error", &error, &source);
-                tracing::error!("resumed eval failed: {}", error);
-                Ok(CallToolResult::error(vec![Content::text(error_msg)]))
-            }
-            Ok(None) => {
-                tracing::error!("eval thread crashed");
-                let mut crash_info = String::new();
-                if let Ok(content) = std::fs::read_to_string(".tidepool/crash.log") {
-                    let lines: Vec<_> = content.lines().rev().take(5).collect();
-                    if !lines.is_empty() {
-                        crash_info.push_str("\n\n## Recent Crash Log Entries\n```\n");
-                        for line in lines.into_iter().rev() {
-                            crash_info.push_str(line);
-                            crash_info.push('\n');
-                        }
-                        crash_info.push_str("```\n");
-                    }
-                }
-                let error_msg = format_error_with_source(
-                    "Crash",
-                    &format!(
-                        "Eval thread crashed (likely SIGILL from exhausted case branch or SIGSEGV from invalid memory access). Set RUST_LOG=debug for JIT diagnostics on stderr.{}",
-                        crash_info
-                    ),
-                    &source,
-                );
-                Ok(CallToolResult::error(vec![Content::text(error_msg)]))
-            }
-            Err(_elapsed) => {
-                tracing::error!("resumed eval timed out after {}s", EVAL_TIMEOUT_SECS);
-                let error_msg = format_error_with_source(
-                    "Timeout",
-                    &format!(
-                        "Evaluation timed out after {}s. This usually means an infinite loop or unbounded recursion.",
-                        EVAL_TIMEOUT_SECS
-                    ),
-                    &source,
-                );
-                Ok(CallToolResult::error(vec![Content::text(error_msg)]))
-            }
-        }
+        self.handle_session_result(session.session_rx, source, response_tx)
+            .await
     }
 }
 

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -267,7 +267,7 @@ pub fn compile_and_run_pure(
 }
 
 /// Compile Haskell source and run it with the given effect handlers,
-/// using the default nursery size (1 MiB).
+/// using the default nursery size (64 MiB).
 ///
 /// # Arguments
 /// * `source` - The Haskell source code to compile.

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -1298,13 +1298,7 @@ impl EffectHandler<CapturedOutput> for LlmHandler {
                     .and_then(|block| block.get("input"))
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
-                eprintln!(
-                    "[llm-structured] API response input: {}",
-                    serde_json::to_string(&input).unwrap_or_default()
-                );
-                let result = cx.respond(input);
-                eprintln!("[llm-structured] cx.respond result: {}", result.is_ok());
-                result
+                cx.respond(input)
             }
         }
     }


### PR DESCRIPTION
This PR addresses 5 small fixes across several crates in the Tidepool project, now updated to address review comments:

1.  **tidepool-mcp**: Extracted a shared `handle_session_result` method in `TidepoolMcpServerImpl` to deduplicate code between `eval` and `resume`.
    - Added an `op` label parameter to distinguish between 'eval' and 'resume' in logs.
    - Switched to `tokio::fs::read_to_string` for crash logs to avoid blocking the executor.
    - Added focused unit tests for `handle_session_result` covering all result variants and timeouts.
2.  **tidepool-runtime**: Updated the doc comment for `compile_and_run` to correctly state the default nursery size as 64 MiB.
3.  **tidepool-mcp**: Relaxed the `schemars` version pin from `=1.2.1` to `1.2`. Added `fs` and `test-util` features to `tokio`.
4.  **tidepool-codegen**: Removed the unused `heap_alloc` placeholder function and its registration.
5.  **tidepool**: Removed debug `eprintln!` statements from the `LlmHandler` structured output logic.

Verified with `cargo check --workspace` and relevant crate tests. New unit tests for `handle_session_result` in `tidepool-mcp` are passing.