### PR TITLE
fix: path traversal in RunIn, SgReplace, and FsGlob handlers

### DIFF
--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -247,6 +247,9 @@ impl EffectHandler<CapturedOutput> for FsHandler {
                 cx.respond(entries)
             }
             FsReq::Glob(pattern) => {
+                if pattern.contains("..") {
+                    return cx.respond(Vec::<String>::new());
+                }
                 let full_pattern = self.root.join(&pattern).to_string_lossy().to_string();
                 let paths: Vec<String> = glob::glob(&full_pattern)
                     .map_err(|e| EffectError::Handler(format!("invalid glob: {}", e)))?
@@ -381,10 +384,16 @@ impl SgHandler {
         } else {
             for p in paths {
                 let full = self.root.join(p);
-                if full.is_file() {
-                    files.push(full);
-                } else if full.is_dir() {
-                    self.walk_dir(&full, lang, &mut files)?;
+                let canonical = full
+                    .canonicalize()
+                    .map_err(|e| EffectError::Handler(format!("Bad path {}: {}", p, e)))?;
+                if !canonical.starts_with(&self.root) {
+                    return Err(EffectError::Handler(format!("Path escapes sandbox: {}", p)));
+                }
+                if canonical.is_file() {
+                    files.push(canonical);
+                } else if canonical.is_dir() {
+                    self.walk_dir(&canonical, lang, &mut files)?;
                 }
             }
         }
@@ -810,6 +819,17 @@ impl ExecHandler {
     /// commands that produce unbounded output (e.g. `find /`, `yes`).
     const MAX_EXEC_OUTPUT_BYTES: usize = 2 * 1024 * 1024;
 
+    fn resolve_dir(&self, rel: &str) -> Result<PathBuf, EffectError> {
+        let target = self.root.join(rel);
+        let canonical = target
+            .canonicalize()
+            .map_err(|e| EffectError::Handler(format!("Cannot resolve directory: {}", e)))?;
+        if !canonical.starts_with(&self.root) {
+            return Err(EffectError::Handler(format!("Path escapes sandbox: {}", rel)));
+        }
+        Ok(canonical)
+    }
+
     fn run_command(
         &self,
         cmd: &str,
@@ -888,13 +908,7 @@ impl EffectHandler<CapturedOutput> for ExecHandler {
                 cx.respond(json_val)
             }
             ExecReq::RunIn(dir, cmd) => {
-                let target = self.root.join(&dir);
-                if !target.is_dir() {
-                    return Err(EffectError::Handler(format!(
-                        "directory '{}' does not exist",
-                        dir
-                    )));
-                }
+                let target = self.resolve_dir(&dir)?;
                 let (code, stdout, stderr) = self.run_command(&cmd, &target)?;
                 cx.respond((code, stdout, stderr))
             }

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -379,15 +379,19 @@ impl SgHandler {
         paths: &[String],
     ) -> Result<Vec<PathBuf>, EffectError> {
         let mut files = Vec::new();
+        let canonical_root = self
+            .root
+            .canonicalize()
+            .map_err(|e| EffectError::Handler(e.to_string()))?;
         if paths.is_empty() {
-            self.walk_dir(&self.root, lang, &mut files)?;
+            self.walk_dir(&canonical_root, lang, &mut files)?;
         } else {
             for p in paths {
                 let full = self.root.join(p);
                 let canonical = full
                     .canonicalize()
                     .map_err(|e| EffectError::Handler(format!("Bad path {}: {}", p, e)))?;
-                if !canonical.starts_with(&self.root) {
+                if !canonical.starts_with(&canonical_root) {
                     return Err(EffectError::Handler(format!("Path escapes sandbox: {}", p)));
                 }
                 if canonical.is_file() {
@@ -821,10 +825,14 @@ impl ExecHandler {
 
     fn resolve_dir(&self, rel: &str) -> Result<PathBuf, EffectError> {
         let target = self.root.join(rel);
+        let canonical_root = self
+            .root
+            .canonicalize()
+            .map_err(|e| EffectError::Handler(e.to_string()))?;
         let canonical = target
             .canonicalize()
             .map_err(|e| EffectError::Handler(format!("Cannot resolve directory: {}", e)))?;
-        if !canonical.starts_with(&self.root) {
+        if !canonical.starts_with(&canonical_root) {
             return Err(EffectError::Handler(format!("Path escapes sandbox: {}", rel)));
         }
         Ok(canonical)


### PR DESCRIPTION
This PR fixes several path traversal vulnerabilities in the `tidepool` MCP server handlers:

1. **RunIn path traversal**: `ExecReq::RunIn` now canonicalizes the target directory and verifies that it is within the sandbox root using `starts_with`.
2. **SgReplace/SgRuleReplace path traversal**: `SgHandler::collect_files` now canonicalizes all user-provided paths and verifies they are within the sandbox root.
3. **FsGlob path traversal**: `FsHandler::handle` for `FsGlob` now rejects patterns containing `..` to prevent probing outside the sandbox.

All changes follow the existing style and use `EffectError::Handler` for error reporting. `cargo check` passes for the workspace.