### PR TITLE
fix: update current pointer after GC in heap_force

### DIFF
--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -333,6 +333,12 @@ pub extern "C" fn heap_force(vmctx: *mut VMContext, obj: *mut u8) -> *mut u8 {
                             std::mem::transmute(code_ptr);
                         let result = f(vmctx, current);
 
+                        // If GC ran during the call, current may have been forwarded.
+                        // Check for forwarding pointer and follow it.
+                        if layout::read_tag(current) == layout::TAG_FORWARDED {
+                            current = *(current.add(8) as *const *mut u8);
+                        }
+
                         // 4. Write indirection (offset 16, overwriting code_ptr)
                         *(current.add(layout::THUNK_INDIRECTION_OFFSET) as *mut *mut u8) = result;
 


### PR DESCRIPTION
In `tidepool-codegen/src/host_fns.rs`, the `heap_force` function holds a `current` pointer to a thunk. At line 334 (in the original file), it calls the thunk's entry function, which may trigger a GC. After the call, `current` might point to the from-space copy of the thunk. Subsequent writes to set the indirection and state update would then go to from-space, leaving the to-space copy in a permanent `BLACKHOLE` state.

This PR adds a forwarding check after the JIT call in `heap_force`. If `current` was forwarded during the call, it is updated to point to the to-space copy by following the forwarding pointer at offset 8.

Verified by running `cargo check` and `cargo test` in `tidepool-codegen`. All tests pass.