### PR TITLE
feat: concurrent eval limit + nursery size cap

### DIFF
--- a/tidepool-heap/src/arena.rs
+++ b/tidepool-heap/src/arena.rs
@@ -27,6 +27,8 @@ pub struct ArenaHeap {
     used: AtomicUsize,
 }
 
+const MAX_NURSERY_SIZE: usize = 512 * 1024 * 1024; // 512 MiB
+
 impl ArenaHeap {
     /// Create a new ArenaHeap with 4MB default nursery capacity.
     pub fn new() -> Self {
@@ -137,7 +139,9 @@ impl ArenaHeap {
             let pre_gc_capacity = self.nursery_limit;
             let live_bytes = self.thunks.len() * std::mem::size_of::<ThunkState>();
             if live_bytes > pre_gc_capacity * 3 / 4 {
-                self.nursery_limit *= 2;
+                if self.nursery_limit < MAX_NURSERY_SIZE {
+                    self.nursery_limit = (self.nursery_limit * 2).min(MAX_NURSERY_SIZE);
+                }
             }
         }
 
@@ -361,6 +365,26 @@ mod tests {
             }
             _ => panic!("Expected Unevaluated"),
         }
+    }
+
+    #[test]
+    fn test_nursery_doubling() {
+        let mut heap = ArenaHeap::with_capacity(1024 * 1024); // 1MB
+        let env = Env::new();
+        let expr = RecursiveTree {
+            nodes: vec![CoreFrame::Var(VarId(0))],
+        };
+        // Allocate enough to trigger doubling (> 750KB)
+        // Assume ThunkState is at least 32 bytes
+        let count = (1024 * 1024 * 3 / 4 / 32) + 1000;
+        let mut roots = Vec::new();
+        for _ in 0..count {
+            roots.push(heap.alloc(env.clone(), expr.clone()));
+        }
+
+        heap.collect_garbage(&roots);
+        // Should have doubled to 2MB
+        assert_eq!(heap.nursery_limit(), 2 * 1024 * 1024);
     }
 
     #[test]

--- a/tidepool-heap/src/arena.rs
+++ b/tidepool-heap/src/arena.rs
@@ -135,6 +135,12 @@ impl ArenaHeap {
         self.used.store(0, Ordering::SeqCst);
 
         // Nursery doubling: if live thunks > 75% of pre-GC count, grow capacity
+        self.grow_nursery_if_needed(reachable_count);
+
+        table
+    }
+
+    fn grow_nursery_if_needed(&mut self, reachable_count: usize) {
         if reachable_count > 0 {
             let pre_gc_capacity = self.nursery_limit;
             let live_bytes = self.thunks.len() * std::mem::size_of::<ThunkState>();
@@ -144,8 +150,6 @@ impl ArenaHeap {
                 }
             }
         }
-
-        table
     }
 
     /// Return all ThunkIds directly referenced by this thunk.
@@ -374,9 +378,9 @@ mod tests {
         let expr = RecursiveTree {
             nodes: vec![CoreFrame::Var(VarId(0))],
         };
-        // Allocate enough to trigger doubling (> 750KB)
-        // Assume ThunkState is at least 32 bytes
-        let count = (1024 * 1024 * 3 / 4 / 32) + 1000;
+        // Allocate enough to trigger doubling (> 75% of 1MB)
+        let thunk_size = std::mem::size_of::<ThunkState>();
+        let count = (1024 * 1024 * 3 / 4 / thunk_size) + 1000;
         let mut roots = Vec::new();
         for _ in 0..count {
             roots.push(heap.alloc(env.clone(), expr.clone()));
@@ -385,6 +389,22 @@ mod tests {
         heap.collect_garbage(&roots);
         // Should have doubled to 2MB
         assert_eq!(heap.nursery_limit(), 2 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_nursery_cap() {
+        let mut heap = ArenaHeap::with_capacity(MAX_NURSERY_SIZE - 1024);
+        
+        // Setup state to trigger doubling
+        let thunk_size = std::mem::size_of::<ThunkState>();
+        let count = (heap.nursery_limit * 3 / 4 / thunk_size) + 1000;
+        heap.thunks.resize(count, ThunkState::Evaluated(Value::Lit(tidepool_repr::Literal::LitInt(0))));
+        
+        // Trigger doubling directly via helper
+        heap.grow_nursery_if_needed(count);
+        
+        // Should be capped at MAX_NURSERY_SIZE
+        assert_eq!(heap.nursery_limit(), MAX_NURSERY_SIZE);
     }
 
     #[test]

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -1602,9 +1602,13 @@ impl TidepoolMcpServerImpl {
         let permit = self
             .eval_semaphore
             .clone()
-            .acquire_owned()
-            .await
-            .map_err(|_| McpError::internal_error("eval semaphore closed", None))?;
+            .try_acquire_owned()
+            .map_err(|_| {
+                McpError::internal_error(
+                    "Server busy: too many concurrent evaluations. Please try again in a moment.",
+                    None,
+                )
+            })?;
 
         // Spawn eval thread — does NOT join; communicates via channels
         let thread_session_tx = session_tx;

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -21,6 +21,7 @@ use tokio::io::{stdin, stdout};
 use tokio::time::{timeout, Duration};
 
 const EVAL_TIMEOUT_SECS: u64 = 120;
+const MAX_CONCURRENT_EVALS: usize = 4;
 
 // ---------------------------------------------------------------------------
 // Effect metadata — lives next to the handler, discovered via trait
@@ -1448,6 +1449,7 @@ pub struct TidepoolMcpServerImpl {
     effect_names: Vec<String>,
     continuations: Arc<std::sync::Mutex<HashMap<String, EvalSession>>>,
     next_cont_id: Arc<AtomicU64>,
+    eval_semaphore: Arc<tokio::sync::Semaphore>,
 }
 
 impl TidepoolMcpServerImpl {
@@ -1597,12 +1599,20 @@ impl TidepoolMcpServerImpl {
         let (session_tx, session_rx) = tokio::sync::mpsc::unbounded_channel::<SessionMessage>();
         let (response_tx, response_rx) = std::sync::mpsc::channel::<String>();
 
+        let permit = self
+            .eval_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| McpError::internal_error("eval semaphore closed", None))?;
+
         // Spawn eval thread — does NOT join; communicates via channels
         let thread_session_tx = session_tx;
         let _handle = std::thread::Builder::new()
             .name("tidepool-eval".into())
             .stack_size(32 * 1024 * 1024)
             .spawn(move || {
+                let _permit = permit;
                 // Install signal handlers so SIGILL/SIGSEGV from JIT code
                 // are caught via sigsetjmp/siglongjmp instead of killing
                 // the whole server process.
@@ -1836,6 +1846,7 @@ where
                 effect_names,
                 continuations: Arc::new(std::sync::Mutex::new(HashMap::new())),
                 next_cont_id: Arc::new(AtomicU64::new(1)),
+                eval_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_EVALS)),
             },
             _phantom: PhantomData,
         }
@@ -2606,6 +2617,7 @@ mod tests {
             effect_names: Vec::new(),
             continuations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             next_cont_id: Arc::new(AtomicU64::new(1)),
+            eval_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_EVALS)),
         }
     }
 }


### PR DESCRIPTION
This PR adds a concurrent evaluation limit (MAX_CONCURRENT_EVALS = 4) using a semaphore in the MCP server to manage memory usage (each thread uses ~96MB). It also adds a nursery size cap (MAX_NURSERY_SIZE = 512MB) in the heap arena to prevent unbounded memory growth during nursery doubling.

Changes:
- Added `eval_semaphore` to `TidepoolMcpServerImpl`.
- Acquired and moved a semaphore permit into the eval thread in `eval`.
- Added `MAX_NURSERY_SIZE` constant and capped growth in `collect_garbage`.
- Added `test_nursery_doubling` to verify heap doubling logic.