### PR TITLE
feat: fix ignored cache tests and add MCP test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,6 +3065,7 @@ dependencies = [
  "frunk",
  "proptest",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tidepool-bridge",
  "tidepool-bridge-derive",

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -1264,16 +1264,15 @@ fn rejected_import(import_str: &str) -> Option<&str> {
         "Network",
         "Control.Concurrent",
     ];
-    // Extract module name (first whitespace-delimited token, or before '(')
-    let module = import_str
-        .split(|c: char| c.is_whitespace() || c == '(')
-        .next()
-        .unwrap_or(import_str)
-        .trim_start_matches("qualified ");
-    let module = module
-        .split(|c: char| c.is_whitespace() || c == '(')
-        .next()
-        .unwrap_or(module);
+    // Extract module name: skip 'qualified' if present, then take the first token
+    let mut parts = import_str.split_whitespace();
+    let mut module = parts.next().unwrap_or("");
+    if module == "qualified" {
+        module = parts.next().unwrap_or("");
+    }
+    // Remove anything from '(' onwards (for imports like "Data.Map (Map)")
+    let module = module.split('(').next().unwrap_or("").trim();
+    
     for prefix in BLOCKED {
         if module.starts_with(prefix) {
             return Some(module);
@@ -2607,6 +2606,55 @@ mod tests {
             continuations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             next_cont_id: Arc::new(AtomicU64::new(1)),
         }
+    }
+
+    #[test]
+    fn test_rejected_import_edge_cases() {
+        // Qualified unsafe
+        assert!(rejected_import("qualified System.IO.Unsafe as Safe").is_some());
+        // Extra whitespace
+        assert!(rejected_import("  System.IO.Unsafe  ").is_some());
+        // Safe Data imports
+        assert!(rejected_import("Data.Map (Map, fromList)").is_none());
+        // Tidepool modules
+        assert!(rejected_import("Tidepool.Table").is_none());
+        // Empty string
+        assert!(rejected_import("").is_none());
+    }
+
+    #[test]
+    fn test_format_error_with_source_multiline() {
+        let title = "Compile Error";
+        let error = "Variable not in scope: x";
+        let source = "module Test where\n-- [user]\nmain = do\n  print x\n  print y\n  print z";
+        let formatted = format_error_with_source(title, error, source);
+
+        assert!(formatted.contains("## Compile Error"));
+        assert!(formatted.contains("Variable not in scope: x"));
+        assert!(formatted.contains("## User Code"));
+        assert!(formatted.contains("main = do\n  print x\n  print y\n  print z"));
+        assert!(!formatted.contains("module Test where"));
+    }
+
+    #[test]
+    fn test_format_error_empty_source() {
+        let formatted = format_error_with_source("Error", "msg", "");
+        assert!(formatted.contains("## Error"));
+        assert!(formatted.contains("msg"));
+        assert!(formatted.contains("## User Code"));
+    }
+
+    #[test]
+    fn test_captured_output_drain() {
+        let output = CapturedOutput::new();
+        output.push("line 1".to_string());
+        output.push("line 2".to_string());
+        
+        let drained = output.drain();
+        assert_eq!(drained, vec!["line 1", "line 2"]);
+        
+        let empty = output.drain();
+        assert!(empty.is_empty());
     }
 }
 

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -29,3 +29,4 @@ tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-mcp = { version = "0.1.0", path = "../tidepool-mcp" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+serial_test = "3"

--- a/tidepool-runtime/tests/cache_tests.rs
+++ b/tidepool-runtime/tests/cache_tests.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use tidepool_runtime::compile_haskell;
+use serial_test::serial;
 
 fn prelude_path() -> PathBuf {
     let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -34,7 +35,7 @@ impl Drop for EnvGuard {
 }
 
 #[test]
-#[ignore = "mutates env vars, run with --test-threads=1"]
+#[serial]
 fn test_cache_hit_same_source() {
     let cache_root = TempDir::new().unwrap();
     let _guard = EnvGuard::set("XDG_CACHE_HOME", cache_root.path().to_path_buf());
@@ -62,7 +63,7 @@ fn test_cache_hit_same_source() {
 }
 
 #[test]
-#[ignore = "mutates env vars, run with --test-threads=1"]
+#[serial]
 fn test_cache_miss_different_source() {
     let cache_root = TempDir::new().unwrap();
     let _guard = EnvGuard::set("XDG_CACHE_HOME", cache_root.path().to_path_buf());
@@ -86,7 +87,7 @@ fn test_cache_miss_different_source() {
 }
 
 #[test]
-#[ignore = "mutates env vars, run with --test-threads=1"]
+#[serial]
 fn test_cache_miss_modified_include() {
     let cache_root = TempDir::new().unwrap();
     let _guard = EnvGuard::set("XDG_CACHE_HOME", cache_root.path().to_path_buf());
@@ -115,7 +116,7 @@ fn test_cache_miss_modified_include() {
 }
 
 #[test]
-#[ignore = "mutates env vars, run with --test-threads=1"]
+#[serial]
 fn test_corrupted_cache_recovery() {
     let cache_root = TempDir::new().unwrap();
     let _guard = EnvGuard::set("XDG_CACHE_HOME", cache_root.path().to_path_buf());

--- a/tidepool-runtime/tests/concurrent_eval.rs
+++ b/tidepool-runtime/tests/concurrent_eval.rs
@@ -1,50 +1,50 @@
-use std::env;
 use std::path::{Path, PathBuf};
 use tidepool_runtime::{compile_and_run_pure, EvalResult, value_to_json};
+use std::thread;
 
 fn prelude_path() -> PathBuf {
     let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
     manifest.parent().unwrap().join("haskell").join("lib")
 }
 
-async fn run_pure(src: &str, target: &str) -> EvalResult {
+fn run_pure(src: &str, target: &str) -> EvalResult {
     let pp = prelude_path();
     compile_and_run_pure(src, target, &[pp.as_path()]).expect("Run failed")
 }
 
-#[tokio::test]
-async fn test_concurrent_eval_pure() {
+#[test]
+fn test_concurrent_eval_pure() {
     let mut handles = vec![];
 
     // Thread 1: Simple math
-    handles.push(tokio::spawn(async move {
-        let res = run_pure("module T1 where\nval = 2 + 2", "val").await;
+    handles.push(thread::spawn(|| {
+        let res = run_pure("module T1 where\nval = 2 + 2", "val");
         let json = value_to_json(res.value(), res.table(), 0);
         assert_eq!(json, serde_json::json!(4));
     }));
 
     // Thread 2: String concatenation
-    handles.push(tokio::spawn(async move {
-        let res = run_pure("module T2 where\nval = \"hello \" <> \"world\"", "val").await;
+    handles.push(thread::spawn(|| {
+        let res = run_pure("module T2 where\nval = \"hello \" <> \"world\"", "val");
         let json = value_to_json(res.value(), res.table(), 0);
         assert_eq!(json, serde_json::json!("hello world"));
     }));
 
     // Thread 3: List operations
-    handles.push(tokio::spawn(async move {
-        let res = run_pure("module T3 where\nimport Data.List (sort)\nval = sort [3, 1, 2]", "val").await;
+    handles.push(thread::spawn(|| {
+        let res = run_pure("module T3 where\nimport Data.List (sort)\nval = sort [3, 1, 2]", "val");
         let json = value_to_json(res.value(), res.table(), 0);
         assert_eq!(json, serde_json::json!([1, 2, 3]));
     }));
 
     // Thread 4: Higher-order functions
-    handles.push(tokio::spawn(async move {
-        let res = run_pure("module T4 where\nval = map (+1) [1, 2, 3]", "val").await;
+    handles.push(thread::spawn(|| {
+        let res = run_pure("module T4 where\nval = map (+1) [1, 2, 3]", "val");
         let json = value_to_json(res.value(), res.table(), 0);
         assert_eq!(json, serde_json::json!([2, 3, 4]));
     }));
 
     for handle in handles {
-        handle.await.expect("Thread failed");
+        handle.join().expect("Thread panicked");
     }
 }

--- a/tidepool-runtime/tests/concurrent_eval.rs
+++ b/tidepool-runtime/tests/concurrent_eval.rs
@@ -1,0 +1,50 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use tidepool_runtime::{compile_and_run_pure, EvalResult, value_to_json};
+
+fn prelude_path() -> PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().unwrap().join("haskell").join("lib")
+}
+
+async fn run_pure(src: &str, target: &str) -> EvalResult {
+    let pp = prelude_path();
+    compile_and_run_pure(src, target, &[pp.as_path()]).expect("Run failed")
+}
+
+#[tokio::test]
+async fn test_concurrent_eval_pure() {
+    let mut handles = vec![];
+
+    // Thread 1: Simple math
+    handles.push(tokio::spawn(async move {
+        let res = run_pure("module T1 where\nval = 2 + 2", "val").await;
+        let json = value_to_json(res.value(), res.table(), 0);
+        assert_eq!(json, serde_json::json!(4));
+    }));
+
+    // Thread 2: String concatenation
+    handles.push(tokio::spawn(async move {
+        let res = run_pure("module T2 where\nval = \"hello \" <> \"world\"", "val").await;
+        let json = value_to_json(res.value(), res.table(), 0);
+        assert_eq!(json, serde_json::json!("hello world"));
+    }));
+
+    // Thread 3: List operations
+    handles.push(tokio::spawn(async move {
+        let res = run_pure("module T3 where\nimport Data.List (sort)\nval = sort [3, 1, 2]", "val").await;
+        let json = value_to_json(res.value(), res.table(), 0);
+        assert_eq!(json, serde_json::json!([1, 2, 3]));
+    }));
+
+    // Thread 4: Higher-order functions
+    handles.push(tokio::spawn(async move {
+        let res = run_pure("module T4 where\nval = map (+1) [1, 2, 3]", "val").await;
+        let json = value_to_json(res.value(), res.table(), 0);
+        assert_eq!(json, serde_json::json!([2, 3, 4]));
+    }));
+
+    for handle in handles {
+        handle.await.expect("Thread failed");
+    }
+}


### PR DESCRIPTION
This PR addresses several test gaps and fixes ignored tests in `tidepool-runtime` and `tidepool-mcp`.

### Changes:
1.  **Cache Tests Fix**: Added `serial_test` as a dev-dependency to `tidepool-runtime` and updated `tidepool-runtime/tests/cache_tests.rs` to use `#[serial]` instead of `#[ignore]`. This allows environment-variable-mutating tests to run safely in parallel with other tests.
2.  **MCP Test Coverage**: 
    *   Improved `rejected_import` logic to correctly handle `qualified` imports and added edge-case tests.
    *   Added tests for `format_error_with_source` with multi-line input and empty source.
    *   Added tests for `CapturedOutput` draining.
3.  **Concurrent Evaluation Test**: Added `tidepool-runtime/tests/concurrent_eval.rs` which verifies that the JIT compilation and execution pipeline is thread-safe by running multiple Haskell expressions concurrently.

### Verification:
Ran the following commands, all passing:
```bash
cargo test -p tidepool-runtime --test cache_tests
cargo test -p tidepool-mcp
cargo test -p tidepool-runtime --test concurrent_eval
```