### PR TITLE
test: add coverage for heap_force, GC, and heap_bridge

### DIFF
--- a/tidepool-codegen/tests/heap_bridge_tests.rs
+++ b/tidepool-codegen/tests/heap_bridge_tests.rs
@@ -1,0 +1,112 @@
+use tidepool_codegen::heap_bridge::heap_to_value;
+use tidepool_heap::layout;
+use tidepool_repr::*;
+use tidepool_eval::value::Value;
+
+#[repr(align(8))]
+struct AlignedBuf<const N: usize>([u8; N]);
+
+#[test]
+fn test_heap_to_value_lit_int() {
+    let mut buf_data = AlignedBuf::<{layout::LIT_SIZE}>([0u8; layout::LIT_SIZE]);
+    let buf = &mut buf_data.0;
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(ptr.add(layout::LIT_TAG_OFFSET)) = layout::LitTag::Int as u8;
+        *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 42;
+
+        let res = heap_to_value(ptr).expect("heap_to_value failed");
+        if let Value::Lit(Literal::LitInt(n)) = res {
+            assert_eq!(n, 42);
+        } else {
+            panic!("Expected LitInt, got {:?}", res);
+        }
+    }
+}
+
+#[test]
+fn test_heap_to_value_con_pair() {
+    // A pair: Con(DataConId(1), [LitInt(10), LitInt(20)])
+    let mut buf_data = AlignedBuf::<1024>([0u8; 1024]);
+    let buf = &mut buf_data.0;
+    let start = buf.as_mut_ptr();
+    unsafe {
+        let lit1 = start;
+        layout::write_header(lit1, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(lit1.add(layout::LIT_TAG_OFFSET)) = layout::LitTag::Int as u8;
+        *(lit1.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 10;
+
+        let lit2 = start.add(layout::LIT_SIZE);
+        layout::write_header(lit2, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(lit2.add(layout::LIT_TAG_OFFSET)) = layout::LitTag::Int as u8;
+        *(lit2.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 20;
+
+        let con = start.add(2 * layout::LIT_SIZE);
+        let num_fields = 2;
+        let con_size = layout::CON_FIELDS_OFFSET + num_fields * 8;
+        layout::write_header(con, layout::TAG_CON, con_size as u16);
+        *(con.add(layout::CON_TAG_OFFSET) as *mut u64) = 1;
+        *(con.add(layout::CON_NUM_FIELDS_OFFSET) as *mut u16) = num_fields as u16;
+        *(con.add(layout::CON_FIELDS_OFFSET) as *mut *const u8) = lit1;
+        *(con.add(layout::CON_FIELDS_OFFSET + 8) as *mut *const u8) = lit2;
+
+        let res = heap_to_value(con).expect("heap_to_value failed");
+        if let Value::Con(DataConId(1), fields) = res {
+            assert_eq!(fields.len(), 2);
+            match (&fields[0], &fields[1]) {
+                (Value::Lit(Literal::LitInt(10)), Value::Lit(Literal::LitInt(20))) => (),
+                _ => panic!("Expected [LitInt(10), LitInt(20)], got {:?}", fields),
+            }
+        } else {
+            panic!("Expected Con, got {:?}", res);
+        }
+    }
+}
+
+#[test]
+fn test_heap_to_value_deeply_nested_cons() {
+    // Chain of 100 nested Cons: Con(0, [Con(0, [ ... LitInt(0) ... ])])
+    let mut buf_data = AlignedBuf::<{1024 * 64}>([0u8; 1024 * 64]);
+    let buf = &mut buf_data.0;
+    let start = buf.as_mut_ptr();
+    unsafe {
+        let mut current = start;
+        
+        // Leaf LitInt(0)
+        layout::write_header(current, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(current.add(layout::LIT_TAG_OFFSET)) = layout::LitTag::Int as u8;
+        *(current.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 0;
+        
+        let mut last_ptr = current;
+        current = current.add(layout::LIT_SIZE);
+        
+        for _ in 0..100 {
+            let num_fields = 1;
+            let con_size = layout::CON_FIELDS_OFFSET + num_fields * 8;
+            layout::write_header(current, layout::TAG_CON, con_size as u16);
+            *(current.add(layout::CON_TAG_OFFSET) as *mut u64) = 0;
+            *(current.add(layout::CON_NUM_FIELDS_OFFSET) as *mut u16) = num_fields as u16;
+            *(current.add(layout::CON_FIELDS_OFFSET) as *mut *const u8) = last_ptr;
+            
+            last_ptr = current;
+            current = current.add(con_size);
+        }
+
+        let res = heap_to_value(last_ptr).expect("heap_to_value failed on deep structure");
+        
+        // Verify depth
+        let mut depth = 0;
+        let mut v = res;
+        while let Value::Con(_, fields) = v {
+            depth += 1;
+            v = fields[0].clone();
+        }
+        assert_eq!(depth, 100);
+        if let Value::Lit(Literal::LitInt(0)) = v {
+            // OK
+        } else {
+            panic!("Expected terminal LitInt(0), got {:?}", v);
+        }
+    }
+}

--- a/tidepool-codegen/tests/heap_bridge_tests.rs
+++ b/tidepool-codegen/tests/heap_bridge_tests.rs
@@ -9,8 +9,7 @@ struct AlignedBuf<const N: usize>([u8; N]);
 #[test]
 fn test_heap_to_value_lit_int() {
     let mut buf_data = AlignedBuf::<{layout::LIT_SIZE}>([0u8; layout::LIT_SIZE]);
-    let buf = &mut buf_data.0;
-    let ptr = buf.as_mut_ptr();
+    let ptr = buf_data.0.as_mut_ptr();
     unsafe {
         layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
         *(ptr.add(layout::LIT_TAG_OFFSET)) = layout::LitTag::Int as u8;
@@ -29,8 +28,7 @@ fn test_heap_to_value_lit_int() {
 fn test_heap_to_value_con_pair() {
     // A pair: Con(DataConId(1), [LitInt(10), LitInt(20)])
     let mut buf_data = AlignedBuf::<1024>([0u8; 1024]);
-    let buf = &mut buf_data.0;
-    let start = buf.as_mut_ptr();
+    let start = buf_data.0.as_mut_ptr();
     unsafe {
         let lit1 = start;
         layout::write_header(lit1, layout::TAG_LIT, layout::LIT_SIZE as u16);
@@ -68,8 +66,7 @@ fn test_heap_to_value_con_pair() {
 fn test_heap_to_value_deeply_nested_cons() {
     // Chain of 100 nested Cons: Con(0, [Con(0, [ ... LitInt(0) ... ])])
     let mut buf_data = AlignedBuf::<{1024 * 64}>([0u8; 1024 * 64]);
-    let buf = &mut buf_data.0;
-    let start = buf.as_mut_ptr();
+    let start = buf_data.0.as_mut_ptr();
     unsafe {
         let mut current = start;
         

--- a/tidepool-codegen/tests/heap_force_tests.rs
+++ b/tidepool-codegen/tests/heap_force_tests.rs
@@ -56,8 +56,7 @@ extern "C" fn mock_gc_trigger(_vmctx: *mut VMContext) {}
 fn test_heap_force_on_evaluated_thunk() {
     unsafe {
         let mut nursery_u64 = vec![0u64; 128]; // 1024 bytes
-        let nursery_ptr = nursery_u64.as_mut_ptr() as *mut u8;
-        let start = nursery_ptr;
+        let start = nursery_u64.as_mut_ptr() as *mut u8;
         let end = start.add(1024);
         let mut vmctx = VMContext::new(start, end, mock_gc_trigger);
 
@@ -83,8 +82,7 @@ fn test_heap_force_on_evaluated_thunk() {
 fn test_heap_force_on_lit_object() {
     unsafe {
         let mut nursery_u64 = vec![0u64; 128]; // 1024 bytes
-        let nursery_ptr = nursery_u64.as_mut_ptr() as *mut u8;
-        let start = nursery_ptr;
+        let start = nursery_u64.as_mut_ptr() as *mut u8;
         let end = start.add(1024);
         let mut vmctx = VMContext::new(start, end, mock_gc_trigger);
 
@@ -103,8 +101,7 @@ fn test_heap_force_on_lit_object() {
 fn test_heap_force_on_con_object() {
     unsafe {
         let mut nursery_u64 = vec![0u64; 128]; // 1024 bytes
-        let nursery_ptr = nursery_u64.as_mut_ptr() as *mut u8;
-        let start = nursery_ptr;
+        let start = nursery_u64.as_mut_ptr() as *mut u8;
         let end = start.add(1024);
         let mut vmctx = VMContext::new(start, end, mock_gc_trigger);
 

--- a/tidepool-codegen/tests/heap_force_tests.rs
+++ b/tidepool-codegen/tests/heap_force_tests.rs
@@ -1,0 +1,151 @@
+use tidepool_codegen::context::VMContext;
+use tidepool_codegen::emit::expr::compile_expr;
+use tidepool_codegen::host_fns;
+use tidepool_codegen::pipeline::CodegenPipeline;
+use tidepool_heap::layout;
+use tidepool_repr::*;
+
+struct TestResult {
+    result_ptr: *mut u8,
+    vmctx: VMContext,
+    _nursery: Vec<u8>,
+    _pipeline: CodegenPipeline,
+}
+
+impl TestResult {
+    /// Force a heap pointer (resolve thunks to WHNF).
+    unsafe fn force(&mut self, ptr: *mut u8) -> *mut u8 {
+        host_fns::heap_force(&mut self.vmctx, ptr)
+    }
+}
+
+/// Helper: set up pipeline + nursery, compile expr, call it, return result ptr.
+fn compile_and_run(tree: &CoreExpr) -> TestResult {
+    let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols()).unwrap();
+    let func_id = compile_expr(&mut pipeline, tree, "test_fn").expect("compile_expr failed");
+    pipeline.finalize().expect("failed to finalize");
+
+    let mut nursery = vec![0u8; 65536]; // 64KB nursery
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(nursery.len()) };
+    let mut vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    host_fns::set_gc_state(start, nursery.len());
+    host_fns::set_stack_map_registry(&pipeline.stack_maps);
+
+    let ptr = pipeline.get_function_ptr(func_id);
+    let func: unsafe extern "C" fn(*mut VMContext) -> i64 = unsafe { std::mem::transmute(ptr) };
+    let result = unsafe { func(&mut vmctx as *mut VMContext) };
+
+    TestResult {
+        result_ptr: result as *mut u8,
+        vmctx,
+        _nursery: nursery,
+        _pipeline: pipeline,
+    }
+}
+
+unsafe fn read_lit_int(ptr: *const u8) -> i64 {
+    assert_eq!(layout::read_tag(ptr), layout::TAG_LIT);
+    *(ptr.add(layout::LIT_VALUE_OFFSET) as *const i64)
+}
+
+extern "C" fn mock_gc_trigger(_vmctx: *mut VMContext) {}
+
+#[test]
+fn test_heap_force_on_evaluated_thunk() {
+    unsafe {
+        let mut nursery_u64 = vec![0u64; 128]; // 1024 bytes
+        let nursery_ptr = nursery_u64.as_mut_ptr() as *mut u8;
+        let start = nursery_ptr;
+        let end = start.add(1024);
+        let mut vmctx = VMContext::new(start, end, mock_gc_trigger);
+
+        // 1. Result object (Lit)
+        let lit_ptr = start;
+        layout::write_header(lit_ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(lit_ptr.add(layout::LIT_TAG_OFFSET)) = layout::LitTag::Int as u8;
+        *(lit_ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 42;
+
+        // 2. Already evaluated thunk pointing to that Lit
+        let thunk_ptr = start.add(layout::LIT_SIZE);
+        layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
+        *(thunk_ptr.add(layout::THUNK_STATE_OFFSET)) = layout::THUNK_EVALUATED;
+        *(thunk_ptr.add(layout::THUNK_INDIRECTION_OFFSET) as *mut *mut u8) = lit_ptr;
+
+        let res = host_fns::heap_force(&mut vmctx, thunk_ptr);
+        assert_eq!(res, lit_ptr);
+        assert_eq!(read_lit_int(res), 42);
+    }
+}
+
+#[test]
+fn test_heap_force_on_lit_object() {
+    unsafe {
+        let mut nursery_u64 = vec![0u64; 128]; // 1024 bytes
+        let nursery_ptr = nursery_u64.as_mut_ptr() as *mut u8;
+        let start = nursery_ptr;
+        let end = start.add(1024);
+        let mut vmctx = VMContext::new(start, end, mock_gc_trigger);
+
+        let lit_ptr = start;
+        layout::write_header(lit_ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(lit_ptr.add(layout::LIT_TAG_OFFSET)) = layout::LitTag::Int as u8;
+        *(lit_ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 100;
+
+        let res = host_fns::heap_force(&mut vmctx, lit_ptr);
+        assert_eq!(res, lit_ptr, "heap_force on Lit should return the pointer unchanged");
+        assert_eq!(read_lit_int(res), 100);
+    }
+}
+
+#[test]
+fn test_heap_force_on_con_object() {
+    unsafe {
+        let mut nursery_u64 = vec![0u64; 128]; // 1024 bytes
+        let nursery_ptr = nursery_u64.as_mut_ptr() as *mut u8;
+        let start = nursery_ptr;
+        let end = start.add(1024);
+        let mut vmctx = VMContext::new(start, end, mock_gc_trigger);
+
+        let con_ptr = start;
+        let size = layout::CON_FIELDS_OFFSET;
+        layout::write_header(con_ptr, layout::TAG_CON, size as u16);
+        *(con_ptr.add(layout::CON_TAG_OFFSET) as *mut u64) = 7; // DataConId(7)
+        *(con_ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *mut u16) = 0;
+
+        let res = host_fns::heap_force(&mut vmctx, con_ptr);
+        assert_eq!(res, con_ptr, "heap_force on Con should return the pointer unchanged");
+        assert_eq!(layout::read_tag(res), layout::TAG_CON);
+    }
+}
+
+#[test]
+fn test_heap_force_thunk_evaluation() {
+    // let x = 1 + 2 in x
+    let tree = CoreExpr {
+        nodes: vec![
+            CoreFrame::Lit(Literal::LitInt(1)), // 0
+            CoreFrame::Lit(Literal::LitInt(2)), // 1
+            CoreFrame::PrimOp {
+                op: PrimOpKind::IntAdd,
+                args: vec![0, 1],
+            }, // 2
+            CoreFrame::Var(VarId(1)), // 3
+            CoreFrame::LetNonRec {
+                binder: VarId(1),
+                rhs: 2,
+                body: 3,
+            }, // 4 (root)
+        ],
+    };
+    
+    let mut result = compile_and_run(&tree);
+    unsafe {
+        // The result of LetNonRec might be a thunk if rhs was thunked.
+        // But here body is just Var(x), so result_ptr should be the thunk or the value of x.
+        let forced = result.force(result.result_ptr);
+        assert_eq!(layout::read_tag(forced), layout::TAG_LIT);
+        assert_eq!(read_lit_int(forced), 3);
+    }
+}

--- a/tidepool-heap/tests/gc_unit.rs
+++ b/tidepool-heap/tests/gc_unit.rs
@@ -8,8 +8,7 @@ struct AlignedBuf<const N: usize>([u8; N]);
 #[test]
 fn test_for_each_pointer_field_con_zero_fields() {
     let mut buf_data = AlignedBuf::<1024>([0u8; 1024]);
-    let buf = &mut buf_data.0;
-    let ptr = buf.as_mut_ptr();
+    let ptr = buf_data.0.as_mut_ptr();
     unsafe {
         let size = CON_FIELDS_OFFSET;
         write_header(ptr, TAG_CON, size as u16);
@@ -27,8 +26,7 @@ fn test_for_each_pointer_field_con_zero_fields() {
 #[test]
 fn test_for_each_pointer_field_closure_zero_captures() {
     let mut buf_data = AlignedBuf::<1024>([0u8; 1024]);
-    let buf = &mut buf_data.0;
-    let ptr = buf.as_mut_ptr();
+    let ptr = buf_data.0.as_mut_ptr();
     unsafe {
         let size = CLOSURE_CAPTURED_OFFSET;
         write_header(ptr, TAG_CLOSURE, size as u16);
@@ -69,8 +67,7 @@ fn test_offset_calculations() {
 #[test]
 fn test_thunk_state_machine() {
     let mut buf_data = AlignedBuf::<THUNK_MIN_SIZE>([0u8; THUNK_MIN_SIZE]);
-    let buf = &mut buf_data.0;
-    let ptr = buf.as_mut_ptr();
+    let ptr = buf_data.0.as_mut_ptr();
     unsafe {
         write_header(ptr, TAG_THUNK, THUNK_MIN_SIZE as u16);
         

--- a/tidepool-heap/tests/gc_unit.rs
+++ b/tidepool-heap/tests/gc_unit.rs
@@ -1,0 +1,89 @@
+use tidepool_heap::layout::*;
+use tidepool_heap::gc::raw::for_each_pointer_field;
+use std::collections::HashSet;
+
+#[repr(align(8))]
+struct AlignedBuf<const N: usize>([u8; N]);
+
+#[test]
+fn test_for_each_pointer_field_con_zero_fields() {
+    let mut buf_data = AlignedBuf::<1024>([0u8; 1024]);
+    let buf = &mut buf_data.0;
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let size = CON_FIELDS_OFFSET;
+        write_header(ptr, TAG_CON, size as u16);
+        *(ptr.add(CON_TAG_OFFSET) as *mut u64) = 42;
+        *(ptr.add(CON_NUM_FIELDS_OFFSET) as *mut u16) = 0;
+
+        let mut count = 0;
+        for_each_pointer_field(ptr, |_| {
+            count += 1;
+        });
+        assert_eq!(count, 0, "Con with 0 fields should have 0 pointer fields");
+    }
+}
+
+#[test]
+fn test_for_each_pointer_field_closure_zero_captures() {
+    let mut buf_data = AlignedBuf::<1024>([0u8; 1024]);
+    let buf = &mut buf_data.0;
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        let size = CLOSURE_CAPTURED_OFFSET;
+        write_header(ptr, TAG_CLOSURE, size as u16);
+        *(ptr.add(CLOSURE_CODE_PTR_OFFSET) as *mut usize) = 0x12345678;
+        *(ptr.add(CLOSURE_NUM_CAPTURED_OFFSET) as *mut u16) = 0;
+
+        let mut count = 0;
+        for_each_pointer_field(ptr, |_| {
+            count += 1;
+        });
+        assert_eq!(count, 0, "Closure with 0 captures should have 0 pointer fields");
+    }
+}
+
+#[test]
+fn test_layout_constant_sanity() {
+    let tags = vec![
+        TAG_CLOSURE,
+        TAG_THUNK,
+        TAG_CON,
+        TAG_LIT,
+        TAG_FORWARDED,
+    ];
+    let mut set = HashSet::new();
+    for tag in tags {
+        assert!(set.insert(tag), "Duplicate tag found: {}", tag);
+    }
+}
+
+#[test]
+fn test_offset_calculations() {
+    assert!(CON_FIELDS_OFFSET > CON_NUM_FIELDS_OFFSET);
+    assert!(CON_NUM_FIELDS_OFFSET > CON_TAG_OFFSET);
+    assert!(CLOSURE_CAPTURED_OFFSET > CLOSURE_NUM_CAPTURED_OFFSET);
+    assert!(CLOSURE_NUM_CAPTURED_OFFSET > CLOSURE_CODE_PTR_OFFSET);
+}
+
+#[test]
+fn test_thunk_state_machine() {
+    let mut buf_data = AlignedBuf::<THUNK_MIN_SIZE>([0u8; THUNK_MIN_SIZE]);
+    let buf = &mut buf_data.0;
+    let ptr = buf.as_mut_ptr();
+    unsafe {
+        write_header(ptr, TAG_THUNK, THUNK_MIN_SIZE as u16);
+        
+        // 1. Set Unevaluated
+        *(ptr.add(THUNK_STATE_OFFSET)) = THUNK_UNEVALUATED;
+        assert_eq!(*(ptr.add(THUNK_STATE_OFFSET)), THUNK_UNEVALUATED);
+
+        // 2. Transition to BlackHole (during evaluation)
+        *(ptr.add(THUNK_STATE_OFFSET)) = THUNK_BLACKHOLE;
+        assert_eq!(*(ptr.add(THUNK_STATE_OFFSET)), THUNK_BLACKHOLE);
+
+        // 3. Transition to Evaluated
+        *(ptr.add(THUNK_STATE_OFFSET)) = THUNK_EVALUATED;
+        assert_eq!(*(ptr.add(THUNK_STATE_OFFSET)), THUNK_EVALUATED);
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive test coverage for `heap_force`, GC raw pointer traversal, and `heap_bridge` conversion logic.

### Changes:
- Added `tidepool-codegen/tests/heap_force_tests.rs`:
    - Tests `heap_force` on evaluated thunks, literals, and constructors.
    - Verified thunk evaluation via `compile_and_run`.
- Added `tidepool-heap/tests/gc_unit.rs`:
    - Tests `for_each_pointer_field` for objects with zero fields/captures.
    - Verified layout constant sanity and offset calculations.
    - Verified thunk state machine transitions.
- Added `tidepool-codegen/tests/heap_bridge_tests.rs`:
    - Tests `heap_to_value` for literals, constructors, and deeply nested structures.

All tests pass and no existing source code was modified.