### PR TITLE
fix: Haskell translation safety improvements

### DIFF
--- a/haskell/src/Tidepool/GhcPipeline.hs
+++ b/haskell/src/Tidepool/GhcPipeline.hs
@@ -54,11 +54,12 @@ runPipeline path includes = do
     -- Merge: dependency module bindings first, target module last
     let targetModName = capitalize (takeBaseName path)
         isTargetMod g = moduleNameString (moduleName (mg_module g)) == targetModName
-        (targetGuts, depGuts) = case filter isTargetMod results of
-          (tgt:_) -> (tgt, [g | g <- results, mg_module g /= mg_module tgt])
-          []       -> error $ "Target module '" ++ targetModName ++ "' not found among compiled modules: "
-                     ++ show (map (moduleNameString . moduleName . mg_module) results)
-        allBinds = concatMap mg_binds depGuts ++ mg_binds targetGuts
+    (targetGuts, depGuts) <- case filter isTargetMod results of
+      (tgt:_) -> return (tgt, [g | g <- results, mg_module g /= mg_module tgt])
+      []      -> liftIO $ ioError $ userError $
+        "Target module '" ++ targetModName ++ "' not found among compiled modules: "
+        ++ show (map (moduleNameString . moduleName . mg_module) results)
+    let allBinds = concatMap mg_binds depGuts ++ mg_binds targetGuts
         allTyCons = concatMap mg_tcs depGuts ++ mg_tcs targetGuts
     hscEnv <- getSession
     return PipelineResult

--- a/haskell/src/Tidepool/GhcPipeline.hs
+++ b/haskell/src/Tidepool/GhcPipeline.hs
@@ -56,7 +56,8 @@ runPipeline path includes = do
         isTargetMod g = moduleNameString (moduleName (mg_module g)) == targetModName
         (targetGuts, depGuts) = case filter isTargetMod results of
           (tgt:_) -> (tgt, [g | g <- results, mg_module g /= mg_module tgt])
-          []       -> (head results, tail results)
+          []       -> error $ "Target module '" ++ targetModName ++ "' not found among compiled modules: "
+                     ++ show (map (moduleNameString . moduleName . mg_module) results)
         allBinds = concatMap mg_binds depGuts ++ mg_binds targetGuts
         allTyCons = concatMap mg_tcs depGuts ++ mg_tcs targetGuts
     hscEnv <- getSession

--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -290,23 +290,24 @@ translateModule allBinds targetName unresolvedIds =
           keyToIdx = Map.fromList
             [(k, i) | (i, (_, k, _)) <- zip [0..] pairInfo]
 
+          pairInfoLen = length pairInfo
+          pairInfoAt idx = case drop idx pairInfo of
+            (x:_) -> x
+            []    -> error $ "reachableBinds: index " ++ show idx ++ " out of bounds (length " ++ show pairInfoLen ++ ")"
+
           -- DFS collecting reachable pair indices
           go :: Set.Set Int -> [Word64] -> Set.Set Int
           go visited [] = visited
           go visited (v:vs) = case Map.lookup v keyToIdx of
             Just idx | not (Set.member idx visited) ->
-              let (_, _, fvs) = case drop idx pairInfo of
-                    (x:_) -> x
-                    []    -> error $ "reachableBinds: index " ++ show idx ++ " out of bounds (length " ++ show (length pairInfo) ++ ")"
+              let (_, _, fvs) = pairInfoAt idx
               in go (Set.insert idx visited) (Set.toList fvs ++ vs)
             _ -> go visited vs
 
           targetKey = varId target
           reachable = case Map.lookup targetKey keyToIdx of
             Just idx ->
-              let (_, _, fvs) = case drop idx pairInfo of
-                    (x:_) -> x
-                    []    -> error $ "reachableBinds: index " ++ show idx ++ " out of bounds (length " ++ show (length pairInfo) ++ ")"
+              let (_, _, fvs) = pairInfoAt idx
               in go (Set.singleton idx) (Set.toList fvs)
             Nothing -> Set.empty
 
@@ -751,11 +752,9 @@ translate expr =
     -- buffer allocation, and --all-closed inlining exposes the runRW# call.
     -- Desugar: runRW# f  →  f ()   (state token is erased at runtime)
     Var v | isRunRWVar v
-          , length args == 1 -> do
+          , [f] <- args -> do
       recordDC unitDataCon
-      fIdx <- case args of
-        [a] -> translate a
-        _   -> error $ "runRW#: expected 1 arg, got " ++ show (length args)
+      fIdx <- translate f
       tokIdx <- emitNode $ NCon (varId (dataConWorkId unitDataCon)) []
       emitNode $ NApp fIdx tokIdx
 
@@ -773,14 +772,12 @@ translate expr =
     -- We desugar here because type information is erased downstream.
     Var v | Just pop <- isPrimOpId_maybe v
           , pop == TagToEnumOp
-          , length args == 1 -> do
+          , [arg] <- args -> do
         let typeArgs = filter (not . isValueArg) allArgs
         case typeArgs of
           [Type ty] | Just (tc, _) <- splitTyConApp_maybe ty -> do
             let dcs = tyConDataCons tc
-            argIdx <- case args of
-              [a] -> translate a
-              _   -> error $ "tagToEnum#: expected 1 arg, got " ++ show (length args)
+            argIdx <- translate arg
             altData <- forM (zip [0..] dcs) $ \(i :: Int, dc) -> do
               recordDC dc
               conIdx <- emitNode $ NCon (varId (dataConWorkId dc)) []
@@ -1450,9 +1447,9 @@ mapFfiCall :: String -> Text
 mapFfiCall pprName
   | "strlen" `isInfixOf` pprName                = T.pack "FfiStrlen"
   | "_hs_text_measure_off" `isInfixOf` pprName  = T.pack "FfiTextMeasureOff"
-    | "_hs_text_memchr" `isInfixOf` pprName  = T.pack "FfiTextMemchr"
-    | "_hs_text_reverse" `isInfixOf` pprName      = T.pack "FfiTextReverse"
-    | otherwise = error $ "Unsupported FFI call: " ++ pprName
+  | "_hs_text_memchr" `isInfixOf` pprName       = T.pack "FfiTextMemchr"
+  | "_hs_text_reverse" `isInfixOf` pprName      = T.pack "FfiTextReverse"
+  | otherwise = error $ "Unsupported FFI call: " ++ pprName
 
 isRuntimeErrorVar :: Id -> Bool
 isRuntimeErrorVar v =

--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -17,7 +17,6 @@ module Tidepool.Translate
   , UnresolvedVar(..)
   ) where
 
-import Debug.Trace (trace)
 import GHC
 import GHC.Core
 import GHC.Types.Id
@@ -296,14 +295,18 @@ translateModule allBinds targetName unresolvedIds =
           go visited [] = visited
           go visited (v:vs) = case Map.lookup v keyToIdx of
             Just idx | not (Set.member idx visited) ->
-              let (_, _, fvs) = pairInfo !! idx
+              let (_, _, fvs) = case drop idx pairInfo of
+                    (x:_) -> x
+                    []    -> error $ "reachableBinds: index " ++ show idx ++ " out of bounds (length " ++ show (length pairInfo) ++ ")"
               in go (Set.insert idx visited) (Set.toList fvs ++ vs)
             _ -> go visited vs
 
           targetKey = varId target
           reachable = case Map.lookup targetKey keyToIdx of
             Just idx ->
-              let (_, _, fvs) = pairInfo !! idx
+              let (_, _, fvs) = case drop idx pairInfo of
+                    (x:_) -> x
+                    []    -> error $ "reachableBinds: index " ++ show idx ++ " out of bounds (length " ++ show (length pairInfo) ++ ")"
               in go (Set.singleton idx) (Set.toList fvs)
             Nothing -> Set.empty
 
@@ -750,7 +753,9 @@ translate expr =
     Var v | isRunRWVar v
           , length args == 1 -> do
       recordDC unitDataCon
-      fIdx <- translate (head args)
+      fIdx <- case args of
+        [a] -> translate a
+        _   -> error $ "runRW#: expected 1 arg, got " ++ show (length args)
       tokIdx <- emitNode $ NCon (varId (dataConWorkId unitDataCon)) []
       emitNode $ NApp fIdx tokIdx
 
@@ -773,7 +778,9 @@ translate expr =
         case typeArgs of
           [Type ty] | Just (tc, _) <- splitTyConApp_maybe ty -> do
             let dcs = tyConDataCons tc
-            argIdx <- translate (head args)
+            argIdx <- case args of
+              [a] -> translate a
+              _   -> error $ "tagToEnum#: expected 1 arg, got " ++ show (length args)
             altData <- forM (zip [0..] dcs) $ \(i :: Int, dc) -> do
               recordDC dc
               conIdx <- emitNode $ NCon (varId (dataConWorkId dc)) []
@@ -1342,7 +1349,7 @@ mapPrimOp = \case
   Ctz64Op                     -> "Ctz64"
   -- Exception
   RaiseOp     -> "Raise"
-  other       -> trace ("WARNING: unsupported primop: " ++ showPprUnsafe other ++ " (emitting Raise)") "Raise"
+  other       -> error $ "Unsupported primop: " ++ showPprUnsafe other
 
 -- | Check whether a named top-level binding has IO in its result type.
 targetBindingHasIO :: [CoreBind] -> String -> Bool
@@ -1443,9 +1450,9 @@ mapFfiCall :: String -> Text
 mapFfiCall pprName
   | "strlen" `isInfixOf` pprName                = T.pack "FfiStrlen"
   | "_hs_text_measure_off" `isInfixOf` pprName  = T.pack "FfiTextMeasureOff"
-  | "_hs_text_memchr" `isInfixOf` pprName       = T.pack "FfiTextMemchr"
-  | "_hs_text_reverse" `isInfixOf` pprName      = T.pack "FfiTextReverse"
-  | otherwise = trace ("WARNING: unsupported FFI call: " ++ pprName ++ " (emitting Raise)") $ T.pack "Raise"
+    | "_hs_text_memchr" `isInfixOf` pprName  = T.pack "FfiTextMemchr"
+    | "_hs_text_reverse" `isInfixOf` pprName      = T.pack "FfiTextReverse"
+    | otherwise = error $ "Unsupported FFI call: " ++ pprName
 
 isRuntimeErrorVar :: Id -> Bool
 isRuntimeErrorVar v =


### PR DESCRIPTION
This PR addresses several safety issues in the Haskell translation code:
- Replaces unsafe `head` calls with pattern matching in `Translate.hs`.
- Adds bounds checks for `!!` indexing in `reachableBinds`.
- Converts `trace` catch-alls to `error` in `mapPrimOp` and `mapFfiCall` to fail loudly on unsupported operations.
- Removes `Debug.Trace` import.
- Replaces silent module fallback with a descriptive error in `GhcPipeline.hs`.

Verified with `cd haskell && cabal build tidepool-extract-bin` and `cargo check --workspace`.