### PR TITLE
feat(mcp): improve server robustness (crash log limit, mutex logging, drain ordering)

### DIFF
--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -1568,13 +1568,25 @@ impl TidepoolMcpServerImpl {
             Ok(None) => {
                 tracing::error!("{} thread crashed", op);
                 let mut crash_info = String::new();
-                if let Ok(content) = tokio::fs::read_to_string(".tidepool/crash.log").await {
-                    let crash_log = if content.len() > 65536 {
-                        content[content.len() - 65536..].to_string()
-                    } else {
-                        content
-                    };
-                    let lines: Vec<&str> = crash_log.lines().rev().take(5).collect();
+                let crash_log = async {
+                    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+                    let mut file = tokio::fs::File::open(".tidepool/crash.log").await.ok()?;
+                    let meta = file.metadata().await.ok()?;
+                    let len = meta.len();
+                    const MAX_CRASH_LOG_BYTES: u64 = 65536;
+                    if len > MAX_CRASH_LOG_BYTES {
+                        file.seek(std::io::SeekFrom::End(-(MAX_CRASH_LOG_BYTES as i64)))
+                            .await
+                            .ok()?;
+                    }
+                    let mut buf = Vec::new();
+                    file.read_to_end(&mut buf).await.ok()?;
+                    Some(String::from_utf8_lossy(&buf).into_owned())
+                }
+                .await;
+
+                if let Some(content) = crash_log {
+                    let lines: Vec<&str> = content.lines().rev().take(5).collect();
                     if !lines.is_empty() {
                         crash_info.push_str("\n\n## Recent Crash Log Entries\n```\n");
                         for line in lines.into_iter().rev() {

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -1303,14 +1303,31 @@ impl CapturedOutput {
     pub fn push(&self, line: String) {
         self.lines
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(|e| {
+                tracing::warn!("[tidepool-mcp] WARNING: CapturedOutput mutex was poisoned, recovering");
+                e.into_inner()
+            })
             .push(line);
     }
 
     /// Drain all captured lines, returning them and clearing the buffer.
     pub fn drain(&self) -> Vec<String> {
-        let mut lines = self.lines.lock().unwrap_or_else(|e| e.into_inner());
+        let mut lines = self.lines.lock().unwrap_or_else(|e| {
+            tracing::warn!("[tidepool-mcp] WARNING: CapturedOutput mutex was poisoned, recovering");
+            e.into_inner()
+        });
         std::mem::take(&mut *lines)
+    }
+
+    /// Snapshot current captured lines without clearing the buffer.
+    pub fn snapshot(&self) -> Vec<String> {
+        self.lines
+            .lock()
+            .unwrap_or_else(|e| {
+                tracing::warn!("[tidepool-mcp] WARNING: CapturedOutput mutex was poisoned, recovering");
+                e.into_inner()
+            })
+            .clone()
     }
 }
 
@@ -1323,7 +1340,7 @@ enum SessionMessage {
     /// The program hit an Ask effect and is waiting for a response.
     Suspended { prompt: String },
     /// The program completed successfully.
-    Completed { result: String, output: Vec<String> },
+    Completed { result: String },
     /// The program encountered an error.
     Error { error: String },
 }
@@ -1338,6 +1355,8 @@ struct EvalSession {
     source: Arc<str>,
     /// When this session was created, for TTL cleanup.
     created_at: std::time::Instant,
+    /// Output capture for this session.
+    captured_output: CapturedOutput,
 }
 
 /// Wraps an existing effect dispatcher and intercepts the Ask effect tag.
@@ -1458,7 +1477,10 @@ impl TidepoolMcpServerImpl {
     }
 
     fn cleanup_stale_continuations(&self) {
-        let mut conts = self.continuations.lock().unwrap_or_else(|e| e.into_inner());
+        let mut conts = self.continuations.lock().unwrap_or_else(|e| {
+            tracing::warn!("[tidepool-mcp] WARNING: continuation store mutex was poisoned, recovering");
+            e.into_inner()
+        });
         let now = std::time::Instant::now();
         conts.retain(|_, session| now.duration_since(session.created_at) < CONTINUATION_TTL);
     }
@@ -1469,57 +1491,90 @@ impl TidepoolMcpServerImpl {
         mut session_rx: tokio::sync::mpsc::UnboundedReceiver<SessionMessage>,
         source: Arc<str>,
         response_tx: std::sync::mpsc::Sender<String>,
+        captured_output: CapturedOutput,
     ) -> Result<CallToolResult, McpError> {
         let eval_timeout = Duration::from_secs(EVAL_TIMEOUT_SECS);
         match timeout(eval_timeout, session_rx.recv()).await {
-            Ok(Some(SessionMessage::Completed { result, output })) => {
-                tracing::info!("{} completed", op);
-                let mut response = String::new();
-                if !output.is_empty() {
-                    response.push_str("## Output\n");
-                    for line in &output {
-                        response.push_str(line);
-                        response.push('\n');
+            Ok(Some(message)) => {
+                let output = match &message {
+                    SessionMessage::Completed { .. } | SessionMessage::Error { .. } => {
+                        captured_output.drain()
                     }
-                    response.push_str("\n## Result\n");
+                    SessionMessage::Suspended { .. } => captured_output.snapshot(),
+                };
+
+                match message {
+                    SessionMessage::Completed { result } => {
+                        tracing::info!("{} completed", op);
+                        let mut response = String::new();
+                        if !output.is_empty() {
+                            response.push_str("## Output\n");
+                            for line in &output {
+                                response.push_str(line);
+                                response.push('\n');
+                            }
+                            response.push_str("\n## Result\n");
+                        }
+                        response.push_str(&result);
+                        Ok(CallToolResult::success(vec![Content::text(response)]))
+                    }
+                    SessionMessage::Suspended { prompt } => {
+                        tracing::info!(prompt = %prompt, "{} suspended on Ask", op);
+                        let cont_id = self.next_continuation_id();
+                        let mut json_obj = serde_json::json!({
+                            "suspended": true,
+                            "continuation_id": cont_id,
+                            "prompt": prompt,
+                        });
+                        if !output.is_empty() {
+                            if let Some(obj) = json_obj.as_object_mut() {
+                                obj.insert("output".into(), serde_json::Value::from(output));
+                            }
+                        }
+                        self.continuations
+                            .lock()
+                            .unwrap_or_else(|e| {
+                                tracing::warn!("[tidepool-mcp] WARNING: continuation store mutex was poisoned, recovering");
+                                e.into_inner()
+                            })
+                            .insert(
+                                cont_id.clone(),
+                                EvalSession {
+                                    response_tx,
+                                    session_rx,
+                                    source: Arc::clone(&source),
+                                    created_at: std::time::Instant::now(),
+                                    captured_output,
+                                },
+                            );
+                        Ok(CallToolResult::success(vec![Content::text(
+                            json_obj.to_string(),
+                        )]))
+                    }
+                    SessionMessage::Error { error } => {
+                        let mut error_msg = format_error_with_source("Error", &error, &source);
+                        if !output.is_empty() {
+                            error_msg.push_str("\n\n## Output So Far\n");
+                            for line in &output {
+                                error_msg.push_str(line);
+                                error_msg.push('\n');
+                            }
+                        }
+                        tracing::error!("{} failed: {}", op, error);
+                        Ok(CallToolResult::error(vec![Content::text(error_msg)]))
+                    }
                 }
-                response.push_str(&result);
-                Ok(CallToolResult::success(vec![Content::text(response)]))
-            }
-            Ok(Some(SessionMessage::Suspended { prompt })) => {
-                tracing::info!(prompt = %prompt, "{} suspended on Ask", op);
-                let cont_id = self.next_continuation_id();
-                let json = serde_json::json!({
-                    "suspended": true,
-                    "continuation_id": cont_id,
-                    "prompt": prompt,
-                });
-                self.continuations
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .insert(
-                        cont_id.clone(),
-                        EvalSession {
-                            response_tx,
-                            session_rx,
-                            source: Arc::clone(&source),
-                            created_at: std::time::Instant::now(),
-                        },
-                    );
-                Ok(CallToolResult::success(vec![Content::text(
-                    json.to_string(),
-                )]))
-            }
-            Ok(Some(SessionMessage::Error { error })) => {
-                let error_msg = format_error_with_source("Error", &error, &source);
-                tracing::error!("{} failed: {}", op, error);
-                Ok(CallToolResult::error(vec![Content::text(error_msg)]))
             }
             Ok(None) => {
                 tracing::error!("{} thread crashed", op);
                 let mut crash_info = String::new();
                 if let Ok(content) = tokio::fs::read_to_string(".tidepool/crash.log").await {
-                    let lines: Vec<&str> = content.lines().rev().take(5).collect();
+                    let crash_log = if content.len() > 65536 {
+                        content[content.len() - 65536..].to_string()
+                    } else {
+                        content
+                    };
+                    let lines: Vec<&str> = crash_log.lines().rev().take(5).collect();
                     if !lines.is_empty() {
                         crash_info.push_str("\n\n## Recent Crash Log Entries\n```\n");
                         for line in lines.into_iter().rev() {
@@ -1639,19 +1694,24 @@ impl TidepoolMcpServerImpl {
                     )
                 }));
 
-                let output_lines = captured_for_blocking.drain();
                 match result {
                     Ok(Ok(eval_result)) => {
                         let _ = thread_session_tx.send(SessionMessage::Completed {
                             result: eval_result.to_string_pretty(),
-                            output: output_lines,
                         });
                     }
                     Ok(Err(e)) => {
                         let diagnostics = tidepool_runtime::drain_diagnostics();
                         let mut error_detail = e.to_string();
                         // Annotate UnhandledEffect with effect names
-                        if error_detail.starts_with("Unhandled effect at tag") {
+                        if let Some(tag_str) = error_detail.strip_prefix("Unhandled effect at tag ") {
+                            if let Ok(tag) = tag_str.trim().parse::<usize>() {
+                                if tag < effect_names.len() {
+                                    let effect_name = &effect_names[tag];
+                                    error_detail = format!("{} (effect: {})", error_detail, effect_name);
+                                }
+                            }
+                            
                             let effects_list: String = effect_names
                                 .iter()
                                 .enumerate()
@@ -1691,7 +1751,7 @@ impl TidepoolMcpServerImpl {
             .map_err(|e| McpError::internal_error(format!("thread spawn error: {}", e), None))?;
 
         // Await first message from the eval thread
-        self.handle_session_result("eval", session_rx, source, response_tx)
+        self.handle_session_result("eval", session_rx, source, response_tx, captured)
             .await
     }
 
@@ -1700,7 +1760,10 @@ impl TidepoolMcpServerImpl {
         self.cleanup_stale_continuations();
 
         let session = {
-            let mut conts = self.continuations.lock().unwrap_or_else(|e| e.into_inner());
+            let mut conts = self.continuations.lock().unwrap_or_else(|e| {
+                tracing::warn!("[tidepool-mcp] WARNING: continuation store mutex was poisoned, recovering");
+                e.into_inner()
+            });
             conts.remove(&req.continuation_id).ok_or_else(|| {
                 McpError::invalid_params(
                     format!(
@@ -1720,9 +1783,10 @@ impl TidepoolMcpServerImpl {
 
         let source = session.source.clone();
         let response_tx = session.response_tx.clone();
+        let captured = session.captured_output.clone();
 
         // Await the next message from the eval thread
-        self.handle_session_result("resume", session.session_rx, source, response_tx)
+        self.handle_session_result("resume", session.session_rx, source, response_tx, captured)
             .await
     }
 }
@@ -2464,15 +2528,16 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
         let source: Arc<str> = "test source".into();
+        let captured = CapturedOutput::new();
+        captured.push("log1".into());
 
         tx.send(SessionMessage::Completed {
             result: "42".into(),
-            output: vec!["log1".into()],
         })
         .unwrap();
 
         let res = server
-            .handle_session_result("eval", rx, source, resp_tx)
+            .handle_session_result("eval", rx, source, resp_tx, captured)
             .await
             .unwrap();
         assert_eq!(res.is_error, Some(false));
@@ -2490,6 +2555,7 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
         let source: Arc<str> = "test source".into();
+        let captured = CapturedOutput::new();
 
         tx.send(SessionMessage::Suspended {
             prompt: "what is your name?".into(),
@@ -2497,7 +2563,7 @@ mod tests {
         .unwrap();
 
         let res = server
-            .handle_session_result("eval", rx, source, resp_tx)
+            .handle_session_result("eval", rx, source, resp_tx, captured)
             .await
             .unwrap();
         assert_eq!(res.is_error, Some(false));
@@ -2522,6 +2588,7 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
         let source: Arc<str> = "test source".into();
+        let captured = CapturedOutput::new();
 
         tx.send(SessionMessage::Error {
             error: "oops".into(),
@@ -2529,7 +2596,7 @@ mod tests {
         .unwrap();
 
         let res = server
-            .handle_session_result("eval", rx, source, resp_tx)
+            .handle_session_result("eval", rx, source, resp_tx, captured)
             .await
             .unwrap();
         assert_eq!(res.is_error, Some(true));
@@ -2547,12 +2614,13 @@ mod tests {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
         let source: Arc<str> = "test source".into();
+        let captured = CapturedOutput::new();
 
         // Close the channel without sending anything
         drop(tx);
 
         let res = server
-            .handle_session_result("eval", rx, source, resp_tx)
+            .handle_session_result("eval", rx, source, resp_tx, captured)
             .await
             .unwrap();
         assert_eq!(res.is_error, Some(true));
@@ -2572,10 +2640,11 @@ mod tests {
         let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let (resp_tx, _resp_rx) = std::sync::mpsc::channel();
         let source: Arc<str> = "test source".into();
+        let captured = CapturedOutput::new();
 
         let handle = tokio::spawn(async move {
             server
-                .handle_session_result("eval", rx, source, resp_tx)
+                .handle_session_result("eval", rx, source, resp_tx, captured)
                 .await
         });
 


### PR DESCRIPTION
This PR improves the robustness of the MCP server with several key fixes:

1. **Crash log size limit**: Reads only the last 64KB of `.tidepool/crash.log` in `handle_session_result` to prevent excessive memory consumption when reporting crashes.
2. **Mutex poisoning logging**: Adds `tracing::warn!` logs whenever a mutex (for `CapturedOutput` or the continuation store) is found to be poisoned, facilitating easier debugging of concurrency issues.
3. **CapturedOutput drain ordering**: 
    - Ensures `CapturedOutput::drain()` is only called when the evaluation thread has finished (Terminal states: `Completed` or `Error`).
    - Uses `CapturedOutput::snapshot()` during `Suspended` states to report progress without clearing the buffer.
    - Added `output` to the `Suspended` JSON response if not empty.
    - Updated `EvalSession` to correctly persist `CapturedOutput` across resumes.
4. **Unhandled effect matching**: Replaces `starts_with` with a more robust `strip_prefix` and tag parsing approach to look up the effect name from the registered declarations.
5. **Tests**: Updated all existing tests to match the new `SessionMessage` variants and the `handle_session_result` signature.

Verification:
- `cargo check -p tidepool-mcp`
- `cargo test -p tidepool-mcp` (All 42 tests passed)