### PR TITLE
fix: KV deserialization warning, glob symlink safety, and cache atomicity (Updated)

### DIFF
--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -74,31 +74,37 @@ pub(crate) fn cache_load(key: &str) -> Option<(Vec<u8>, Vec<u8>)> {
     Some((expr, meta))
 }
 
-/// Stores the compilation results in the cache atomically.
+/// Stores the compilation results in the cache. Each file is replaced atomically
+/// via rename, but the two-file update as a whole is not atomic.
 pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
     let Some(dir) = cache_dir() else { return };
     if fs::create_dir_all(&dir).is_err() {
         return;
     }
 
-    // Write both to temp files first
-    let tmp_expr = dir.join(format!("{}.cbor.tmp", key));
-    let tmp_meta = dir.join(format!("{}.meta.cbor.tmp", key));
+    use std::io::Write;
 
-    if fs::write(&tmp_expr, expr_bytes).is_err() {
+    // Use NamedTempFile to get random names and automatic cleanup if we return early.
+    let Ok(mut tmp_expr) = tempfile::NamedTempFile::new_in(&dir) else {
+        return;
+    };
+    let Ok(mut tmp_meta) = tempfile::NamedTempFile::new_in(&dir) else {
+        return;
+    };
+
+    if tmp_expr.write_all(expr_bytes).is_err() {
         return;
     }
-    if fs::write(&tmp_meta, meta_bytes).is_err() {
-        let _ = fs::remove_file(&tmp_expr);
+    if tmp_meta.write_all(meta_bytes).is_err() {
         return;
     }
 
-    // Atomic rename
+    // Atomic renames via persist
     let final_expr = dir.join(format!("{}.cbor", key));
     let final_meta = dir.join(format!("{}.meta.cbor", key));
 
-    if fs::rename(&tmp_expr, &final_expr).is_ok() {
-        let _ = fs::rename(&tmp_meta, &final_meta);
+    if tmp_expr.persist(&final_expr).is_ok() {
+        let _ = tmp_meta.persist(&final_meta);
     }
 }
 

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -81,23 +81,25 @@ pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
         return;
     }
 
-    let expr_path = dir.join(format!("{}.cbor", key));
-    let meta_path = dir.join(format!("{}.meta.cbor", key));
+    // Write both to temp files first
+    let tmp_expr = dir.join(format!("{}.cbor.tmp", key));
+    let tmp_meta = dir.join(format!("{}.meta.cbor.tmp", key));
 
-    let _ = atomic_write(&expr_path, expr_bytes);
-    let _ = atomic_write(&meta_path, meta_bytes);
-}
+    if fs::write(&tmp_expr, expr_bytes).is_err() {
+        return;
+    }
+    if fs::write(&tmp_meta, meta_bytes).is_err() {
+        let _ = fs::remove_file(&tmp_expr);
+        return;
+    }
 
-/// Writes data to a temporary file then renames it to the target path
-/// to ensure that readers never see partially written or corrupted files.
-fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
-    let dir = path
-        .parent()
-        .ok_or_else(|| std::io::Error::other("no parent dir"))?;
-    let mut temp = tempfile::NamedTempFile::new_in(dir)?;
-    use std::io::Write;
-    temp.write_all(data)?;
-    temp.persist(path).map(|_| ()).map_err(|e| e.error)
+    // Atomic rename
+    let final_expr = dir.join(format!("{}.cbor", key));
+    let final_meta = dir.join(format!("{}.meta.cbor", key));
+
+    if fs::rename(&tmp_expr, &final_expr).is_ok() {
+        let _ = fs::rename(&tmp_meta, &final_meta);
+    }
 }
 
 #[cfg(test)]

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -70,7 +70,16 @@ impl KvHandler {
     fn new(path: PathBuf) -> Self {
         let store = if path.exists() {
             match std::fs::read_to_string(&path) {
-                Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+                Ok(contents) => match serde_json::from_str(&contents) {
+                    Ok(map) => map,
+                    Err(e) => {
+                        eprintln!(
+                            "[tidepool] WARNING: KV store at {:?} contains invalid JSON ({}), starting fresh",
+                            path, e
+                        );
+                        HashMap::new()
+                    }
+                },
                 Err(_) => HashMap::new(),
             }
         } else {
@@ -250,10 +259,24 @@ impl EffectHandler<CapturedOutput> for FsHandler {
                 if pattern.contains("..") {
                     return cx.respond(Vec::<String>::new());
                 }
+                if pattern.starts_with('/') || pattern.starts_with('\\') {
+                    return Err(EffectError::Handler(
+                        "absolute glob patterns not allowed".to_string(),
+                    ));
+                }
                 let full_pattern = self.root.join(&pattern).to_string_lossy().to_string();
+                let canonical_root = self
+                    .root
+                    .canonicalize()
+                    .unwrap_or_else(|_| self.root.clone());
                 let paths: Vec<String> = glob::glob(&full_pattern)
                     .map_err(|e| EffectError::Handler(format!("invalid glob: {}", e)))?
                     .filter_map(|e| e.ok())
+                    .filter(|p| {
+                        p.canonicalize()
+                            .map(|cp| cp.starts_with(&canonical_root))
+                            .unwrap_or(false)
+                    })
                     .filter_map(|p| {
                         p.strip_prefix(&self.root)
                             .ok()

--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -268,7 +268,7 @@ impl EffectHandler<CapturedOutput> for FsHandler {
                 let canonical_root = self
                     .root
                     .canonicalize()
-                    .unwrap_or_else(|_| self.root.clone());
+                    .map_err(|e| EffectError::Handler(e.to_string()))?;
                 let paths: Vec<String> = glob::glob(&full_pattern)
                     .map_err(|e| EffectError::Handler(format!("invalid glob: {}", e)))?
                     .filter_map(|e| e.ok())


### PR DESCRIPTION
This PR addresses runtime fixes for KV deserialization, glob symlink safety, and cache write robustness.

### Updates in response to review comments:
- **`cache_store`**: Reverted to using `NamedTempFile` to ensure random temp file names (preventing race conditions) and automatic cleanup on failure.
- **`cache_store`**: Updated docstring to clarify that while individual file replacements are atomic, the two-file update as a whole is not.
- **`FsReq::Glob`**: Propagated canonicalization errors for the sandbox root to ensure consistency with other filesystem operations.
- **`FsReq::Glob`**: Explicitly rejected absolute patterns.

### Original Changes:
- Added explicit warning when KV store JSON is invalid.
- Added canonicalization and sandbox root filtering to glob results.
- Implemented rename-based atomicity for cache writes.

Verified with `cargo check --workspace` and `cargo test -p tidepool-runtime`. Pre-existing SIGSEGV in `user_library.rs` remains unchanged.