### PR TITLE
fix: haskell library issues (ix, converge, dedent, parseDelimited)

### DIFF
--- a/.tidepool/lib/Library.hs
+++ b/.tidepool/lib/Library.hs
@@ -79,12 +79,12 @@ _1 f (a, b) = (\a' -> (a', b)) <$> f a
 _2 :: Functor f => (b -> f b) -> (a, b) -> f (a, b)
 _2 f (a, b) = (\b' -> (a, b')) <$> f b
 
-ix :: Int -> Functor f => (a -> f a) -> [a] -> f [a]
-ix i f xs = case splitAt i xs of
-  (before, x:after) -> (\x' -> before ++ [x'] ++ after) <$> f x
-  _ -> case xs of
-    (x:_) -> (\_ -> xs) <$> f x
-    []    -> (\_ -> xs) <$> f (error "ix: empty list")
+ix :: Int -> Applicative f => (a -> f a) -> [a] -> f [a]
+ix i f xs
+  | i < 0     = pure xs
+  | otherwise = case splitAt i xs of
+      (before, x:after) -> (\x' -> before ++ [x'] ++ after) <$> f x
+      _                 -> pure xs  -- index out of bounds: no-op
 
 -- ===========================================================================
 -- § Bounded Iteration
@@ -95,7 +95,11 @@ iterateN 0 f x = []
 iterateN n f x = x : iterateN (n - 1) f (f x)
 
 converge :: Eq a => (a -> a) -> a -> a
-converge f x = let x' = f x in if x == x' then x else converge f x'
+converge = convergeN 1000
+
+convergeN :: Eq a => Int -> (a -> a) -> a -> a
+convergeN 0 _ x = x
+convergeN n f x = let x' = f x in if x == x' then x else convergeN (n - 1) f x'
 
 scanl' :: (b -> a -> b) -> b -> [a] -> [b]
 scanl' f z []     = [z]

--- a/.tidepool/lib/Library.hs
+++ b/.tidepool/lib/Library.hs
@@ -79,7 +79,7 @@ _1 f (a, b) = (\a' -> (a', b)) <$> f a
 _2 :: Functor f => (b -> f b) -> (a, b) -> f (a, b)
 _2 f (a, b) = (\b' -> (a, b')) <$> f b
 
-ix :: Int -> Applicative f => (a -> f a) -> [a] -> f [a]
+ix :: Applicative f => Int -> (a -> f a) -> [a] -> f [a]
 ix i f xs
   | i < 0     = pure xs
   | otherwise = case splitAt i xs of
@@ -98,7 +98,7 @@ converge :: Eq a => (a -> a) -> a -> a
 converge = convergeN 1000
 
 convergeN :: Eq a => Int -> (a -> a) -> a -> a
-convergeN 0 _ x = x
+convergeN n _ x | n <= 0 = x
 convergeN n f x = let x' = f x in if x == x' then x else convergeN (n - 1) f x'
 
 scanl' :: (b -> a -> b) -> b -> [a] -> [b]

--- a/haskell/lib/Tidepool/Table.hs
+++ b/haskell/lib/Tidepool/Table.hs
@@ -27,7 +27,7 @@ import Prelude
   )
 import Data.Text (Text)
 import qualified Data.Text as T
-import Tidepool.Prelude (enumFromTo, lines, splitOn, sortBy, comparing)
+import Tidepool.Prelude (enumFromTo, lines, splitOn, sortBy, comparing, strip)
 
 -- ---------------------------------------------------------------------------
 -- Parsing
@@ -45,7 +45,7 @@ parseTsv = parseDelimited '\t'
 -- | Parse text delimited by the given character into rows of fields.
 parseDelimited :: Char -> Text -> [[Text]]
 parseDelimited delim t =
-  let ls = filter (not . T.null) (lines t)
+  let ls = filter (not . T.null . strip) (lines t)
   in  map (splitOn (T.singleton delim)) ls
 
 -- ---------------------------------------------------------------------------

--- a/haskell/lib/Tidepool/Text.hs
+++ b/haskell/lib/Tidepool/Text.hs
@@ -116,8 +116,8 @@ dedent t =
   let ls = lines t
       nonEmpty = filter (not . T.null . T.stripStart) ls
       minIndent = case nonEmpty of
-        [] -> 0
-        _  -> foldl' (\acc l -> min' acc (countLeading l)) 999999 nonEmpty
+        []     -> 0
+        (x:xs) -> foldl' (\acc l -> min' acc (countLeading l)) (countLeading x) xs
   in  T.unlines (map (T.drop minIndent) ls)
   where
     countLeading = T.length . T.takeWhile (== ' ')


### PR DESCRIPTION
This PR addresses four issues in the Haskell library:

1.  **Fixed `ix` lens out-of-bounds behavior**: It now returns the list unchanged instead of crashing. Move Applicative constraint to the front per review.
2.  **Added iteration limit to `converge`**: It now uses `convergeN 1000` to prevent infinite loops in the MCP eval timeout. Added guard for non-positive iteration counts per review.
3.  **Fixed `dedent` magic constant**: Replaced the `999999` magic constant with the indentation of the first non-empty line.
4.  **Fixed `parseDelimited` whitespace handling**: It now filters out whitespace-only lines using `strip`.

Verified with `cabal build` and manual verification tests for the new behaviors. Note that some existing tests in `user_library.rs` (`test_compose_hylo_is_fused_ana_cata` and `test_compose_producer_consumer`) are already failing/segfaulting in the baseline; these failures persist but are not introduced by this PR.