### PR TITLE
feat: introduce ScopedEnv and EnvScope for batch environment management

### DIFF
--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -83,11 +83,7 @@ pub fn emit_case(
     ctx.declare_env(builder);
 
     // 6. Restore case binder
-    if let Some(v) = old_case_binder {
-        ctx.env.insert(*binder, v);
-    } else {
-        ctx.env.remove(binder);
-    }
+    ctx.env.restore(*binder, old_case_binder);
 
     Ok(SsaVal::HeapPtr(result))
 }
@@ -186,7 +182,7 @@ fn emit_data_dispatch(
             //   - App collapse: tag check → heap_force on fun position
             //   - unbox_int/unbox_double/unbox_float: defensive trap on TAG_THUNK
             // See force_thunk_ssaval in expr.rs.
-            let mut old_bound_vals: Vec<(VarId, Option<SsaVal>)> = Vec::new();
+            let mut scope = EnvScope::new();
             for (i, &binder) in alt.binders.iter().enumerate() {
                 let offset = CON_FIELDS_START + (8 * i as i32);
                 let field_val =
@@ -194,8 +190,7 @@ fn emit_data_dispatch(
                         .ins()
                         .load(types::I64, MemFlags::trusted(), scrut_ptr, offset);
                 builder.declare_value_needs_stack_map(field_val);
-                let old_val = ctx.env.insert(binder, SsaVal::HeapPtr(field_val));
-                old_bound_vals.push((binder, old_val));
+                ctx.env.insert_scoped(&mut scope, binder, SsaVal::HeapPtr(field_val));
             }
 
             let result =
@@ -206,13 +201,7 @@ fn emit_data_dispatch(
                 .jump(merge_block, &[BlockArg::Value(result_ptr)]);
 
             // Restore pattern variable bindings
-            for (binder, old_val) in old_bound_vals {
-                if let Some(v) = old_val {
-                    ctx.env.insert(binder, v);
-                } else {
-                    ctx.env.remove(&binder);
-                }
-            }
+            ctx.env.restore_scope(scope);
 
             // Continue to next check
             builder.switch_to_block(next_check_block);

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -1253,9 +1253,11 @@ impl EmitContext {
                                 let bindings = bindings.clone();
                                 let body = *body;
                                 // Run phases 1-3b inline, push deferred evals + finish + cleanup
-                                let cleanup_vars: Vec<(VarId, Option<SsaVal>)> =
-                                    bindings.iter().map(|(b, _)| (*b, self.env.get(b).cloned())).collect();
-                                work.push(EmitWork::LetCleanupMark(LetCleanup::Rec(cleanup_vars)));
+                                let mut scope = EnvScope::new();
+                                for (b, _) in &bindings {
+                                    scope.saved.push((*b, self.env.get(b).copied()));
+                                }
+                                work.push(EmitWork::LetCleanupMark(LetCleanup::Rec(scope)));
                                 self.emit_letrec_phases(
                                     sess, builder, &bindings,
                                     body, &mut work,
@@ -1309,21 +1311,11 @@ impl EmitContext {
                 EmitWork::LetCleanupMark(cleanup) => match cleanup {
                     LetCleanup::Single(var, old_val) => {
                         self.trace_scope(&format!("restore LetCleanup {:?}", var));
-                        if let Some(v) = old_val {
-                            self.env.insert(var, v);
-                        } else {
-                            self.env.remove(&var);
-                        }
+                        self.env.restore(var, old_val);
                     }
-                    LetCleanup::Rec(entries) => {
-                        for (var, old_val) in entries {
-                            self.trace_scope(&format!("restore LetCleanup(rec) {:?}", var));
-                            if let Some(v) = old_val {
-                                self.env.insert(var, v);
-                            } else {
-                                self.env.remove(&var);
-                            }
-                        }
+                    LetCleanup::Rec(scope) => {
+                        self.trace_scope("restore LetCleanup(rec)");
+                        self.env.restore_scope(scope);
                     }
                 },
                 EmitWork::SetTailPosition(val) => {
@@ -2191,7 +2183,7 @@ struct DeferredConDep {
 
 enum LetCleanup {
     Single(VarId, Option<SsaVal>),
-    Rec(Vec<(VarId, Option<SsaVal>)>),
+    Rec(EnvScope),
 }
 
 fn emit_lit(

--- a/tidepool-codegen/src/emit/join.rs
+++ b/tidepool-codegen/src/emit/join.rs
@@ -53,12 +53,11 @@ pub fn emit_join(
 
     // Bind params to block params
     let block_params = builder.block_params(join_block).to_vec();
-    let mut old_env_vals = Vec::new();
+    let mut scope = EnvScope::new();
     for (i, param_var) in params.iter().enumerate() {
         let val = block_params[i];
         builder.declare_value_needs_stack_map(val); // CRITICAL
-        let old_val = ctx.env.insert(*param_var, SsaVal::HeapPtr(val));
-        old_env_vals.push((*param_var, old_val));
+        ctx.env.insert_scoped(&mut scope, *param_var, SsaVal::HeapPtr(val));
     }
 
     let rhs_result = ctx.emit_node(sess, builder, rhs_idx)?;
@@ -79,13 +78,7 @@ pub fn emit_join(
 
     // 9. Clean up
     ctx.join_blocks.remove(label);
-    for (param_var, old_val) in old_env_vals.into_iter().rev() {
-        if let Some(v) = old_val {
-            ctx.env.insert(param_var, v);
-        } else {
-            ctx.env.remove(&param_var);
-        }
-    }
+    ctx.env.restore_scope(scope);
 
     // 10. Return result
     Ok(SsaVal::HeapPtr(result))

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -62,9 +62,83 @@ impl SsaVal {
     }
 }
 
+/// A scoped environment mapping variables to SSA values.
+pub struct ScopedEnv {
+    inner: HashMap<VarId, SsaVal>,
+}
+
+impl ScopedEnv {
+    pub fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, var: &VarId) -> Option<&SsaVal> {
+        self.inner.get(var)
+    }
+
+    pub fn contains_key(&self, var: &VarId) -> bool {
+        self.inner.contains_key(var)
+    }
+
+    pub fn insert(&mut self, var: VarId, val: SsaVal) -> Option<SsaVal> {
+        self.inner.insert(var, val)
+    }
+
+    /// Restores a variable to its previous state.
+    pub fn restore(&mut self, var: VarId, old: Option<SsaVal>) {
+        if let Some(val) = old {
+            self.inner.insert(var, val);
+        } else {
+            self.inner.remove(&var);
+        }
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, VarId, SsaVal> {
+        self.inner.iter()
+    }
+
+    pub fn keys(&self) -> std::collections::hash_map::Keys<'_, VarId, SsaVal> {
+        self.inner.keys()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Inserts a variable into the environment and records the old value in the scope.
+    pub fn insert_scoped(&mut self, scope: &mut EnvScope, var: VarId, val: SsaVal) {
+        let old = self.insert(var, val);
+        scope.saved.push((var, old));
+    }
+
+    /// Restores all variables saved in the scope in reverse order.
+    pub fn restore_scope(&mut self, scope: EnvScope) {
+        for (var, old) in scope.saved.into_iter().rev() {
+            self.restore(var, old);
+        }
+    }
+}
+
+/// A set of saved environment bindings to be restored.
+pub struct EnvScope {
+    pub(crate) saved: Vec<(VarId, Option<SsaVal>)>,
+}
+
+impl EnvScope {
+    pub fn new() -> Self {
+        Self { saved: Vec::new() }
+    }
+}
+
 /// Emission context — bundles state during IR generation for one function.
 pub struct EmitContext {
-    pub env: HashMap<VarId, SsaVal>,
+    pub env: ScopedEnv,
     pub join_blocks: HashMap<JoinId, JoinInfo>,
     pub lambda_counter: u32,
     pub prefix: String,
@@ -127,7 +201,7 @@ impl From<crate::pipeline::PipelineError> for EmitError {
 impl EmitContext {
     pub fn new(prefix: String) -> Self {
         Self {
-            env: HashMap::new(),
+            env: ScopedEnv::new(),
             join_blocks: HashMap::new(),
             lambda_counter: 0,
             prefix,
@@ -145,8 +219,8 @@ impl EmitContext {
         let mut keys: Vec<_> = self.env.keys().collect();
         keys.sort_by_key(|v| v.0);
         for &k in keys {
-            if let SsaVal::HeapPtr(v) = self.env[&k] {
-                builder.declare_value_needs_stack_map(v);
+            if let Some(SsaVal::HeapPtr(v)) = self.env.get(&k) {
+                builder.declare_value_needs_stack_map(*v);
             }
         }
     }


### PR DESCRIPTION
This PR introduces `ScopedEnv` and `EnvScope` to `tidepool-codegen` for batch environment save/restore operations.

Key changes:
- `ScopedEnv` struct wrapping `HashMap<VarId, SsaVal>` with `insert`, `restore`, and `restore_scope` methods.
- `EnvScope` struct for batching saved bindings.
- `EmitContext.env` now uses `ScopedEnv`.
- `emit_case`, `emit_data_dispatch`, `emit_join`, and `emit_node` (for `LetNonRec`/`LetRec`) updated to use the new scoped API.
- All manual save/restore patterns replaced with `restore` or `restore_scope`.

Note: `test_compile_identity` in `tidepool-runtime` fails with `left: 4, right: 2` on both `main` and this branch, so it is not a regression. All other workspace tests pass.