### PR TITLE
feat: add EnvGuard RAII type for automatic env restore

### DIFF
--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -22,6 +22,8 @@ pub fn emit_case(
     let scrut_ptr = scrut.value();
 
     // 2. Bind case binder (save old value for restore)
+    // NOTE: EnvGuard cannot be used here because it would borrow ctx.env mutably,
+    // preventing the use of ctx in subsequent emit_* calls.
     let old_case_binder = ctx.env.insert(*binder, scrut);
 
     // 3. Classify alts
@@ -187,6 +189,8 @@ fn emit_data_dispatch(
             //   - unbox_int/unbox_double/unbox_float: defensive trap on TAG_THUNK
             // See force_thunk_ssaval in expr.rs.
             let mut scope = EnvScope::new();
+            // NOTE: EnvGuard cannot be used here because it would borrow ctx.env
+            // mutably, preventing the use of ctx in emit_node.
             for (i, &binder) in alt.binders.iter().enumerate() {
                 let offset = CON_FIELDS_START + (8 * i as i32);
                 let field_val =

--- a/tidepool-codegen/src/emit/join.rs
+++ b/tidepool-codegen/src/emit/join.rs
@@ -54,6 +54,8 @@ pub fn emit_join(
     // Bind params to block params
     let block_params = builder.block_params(join_block).to_vec();
     let mut scope = EnvScope::new();
+    // NOTE: EnvGuard cannot be used here because it would borrow ctx.env mutably,
+    // preventing the use of ctx in emit_node.
     for (i, param_var) in params.iter().enumerate() {
         let val = block_params[i];
         builder.declare_value_needs_stack_map(val); // CRITICAL

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -148,6 +148,43 @@ impl EnvScope {
     }
 }
 
+impl Default for EnvScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII guard that automatically restores environment bindings when dropped.
+///
+/// Note: Due to borrow checker constraints, this cannot be used where the
+/// parent `EmitContext` needs to be used (e.g., in `emit_node` calls) since it
+/// mutably borrows `ctx.env`. It is primarily for use in future refactorings
+/// that split `EmitContext` or in simple leaf functions.
+pub(crate) struct EnvGuard<'a> {
+    env: &'a mut ScopedEnv,
+    scope: EnvScope,
+}
+
+impl<'a> EnvGuard<'a> {
+    pub fn new(env: &'a mut ScopedEnv) -> Self {
+        Self {
+            env,
+            scope: EnvScope::new(),
+        }
+    }
+
+    pub fn insert(&mut self, var: VarId, val: SsaVal) {
+        self.env.insert_scoped(&mut self.scope, var, val);
+    }
+}
+
+impl<'a> Drop for EnvGuard<'a> {
+    fn drop(&mut self) {
+        let scope = std::mem::take(&mut self.scope);
+        self.env.restore_scope(scope);
+    }
+}
+
 /// Emission context — bundles state during IR generation for one function.
 pub struct EmitContext {
     pub env: ScopedEnv,


### PR DESCRIPTION
This PR adds the `EnvGuard` RAII type to `tidepool-codegen/src/emit/mod.rs` to support automatic environment restoration using `Drop`. It also implements `Default` for `EnvScope`.

Due to Rust's borrow checker constraints, `EnvGuard` cannot currently be used in `emit_case` or `emit_join` because it mutably borrows `ctx.env`, which prevents passing `ctx: &mut EmitContext` to other functions like `emit_node`. I've added comments to these sites explaining why the manual `EnvScope` pattern is still used. `EnvGuard` is available for future refactorings that might split `EmitContext` or for use in simpler leaf functions.

Verification:
- `cargo check -p tidepool-codegen` passes (with warnings about unused code, as expected since it's added for future use).
- `cargo test -p tidepool-codegen` passes (flaky tests like `test_gc_trigger_called_from_jit` observed but unrelated).
