### PR TITLE
feat: replace raw JoinId HashMap with JoinPointRegistry newtype

### DIFF
--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -568,13 +568,7 @@ fn collapse_frame(
             ctx, sess, builder, &label, &params, rhs_idx, body_idx,
         ),
         EmitFrame::Jump { label, args } => {
-            let join_block = ctx
-                .join_blocks
-                .get(&label)
-                .ok_or_else(|| {
-                    EmitError::NotYetImplemented(format!("Jump to unknown label {:?}", label))
-                })?
-                .block;
+            let join_block = ctx.join_blocks.get(&label)?.block;
 
             let arg_values: Vec<BlockArg> = args
                 .iter()

--- a/tidepool-codegen/src/emit/join.rs
+++ b/tidepool-codegen/src/emit/join.rs
@@ -32,7 +32,7 @@ pub fn emit_join(
     // 4. Register the join point in ctx
     // We use a dummy Value(0) for param_types since Jump just needs to know they are heap pointers.
     let dummy_val = Value::from_u32(0);
-    ctx.join_blocks.insert(
+    ctx.join_blocks.register(
         *label,
         JoinInfo {
             block: join_block,
@@ -95,11 +95,7 @@ pub fn emit_jump(
     arg_indices: &[usize],
 ) -> Result<SsaVal, EmitError> {
     // 1. Look up label in ctx.join_blocks
-    let join_block = ctx
-        .join_blocks
-        .get(label)
-        .ok_or_else(|| EmitError::NotYetImplemented(format!("Jump to unknown label {:?}", label)))?
-        .block;
+    let join_block = ctx.join_blocks.get(label)?.block;
 
     // 2. Emit each arg
     let mut arg_values: Vec<BlockArg> = Vec::new();

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -163,23 +163,23 @@ pub(crate) struct JoinPointRegistry {
 }
 
 impl JoinPointRegistry {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             blocks: HashMap::new(),
         }
     }
 
-    pub fn register(&mut self, label: JoinId, info: JoinInfo) {
+    pub(crate) fn register(&mut self, label: JoinId, info: JoinInfo) {
         self.blocks.insert(label, info);
     }
 
-    pub fn get(&self, label: &JoinId) -> Result<&JoinInfo, EmitError> {
+    pub(crate) fn get(&self, label: &JoinId) -> Result<&JoinInfo, EmitError> {
         self.blocks.get(label).ok_or_else(|| {
             EmitError::NotYetImplemented(format!("Jump to unregistered join {:?}", label))
         })
     }
 
-    pub fn remove(&mut self, label: &JoinId) -> Option<JoinInfo> {
+    pub(crate) fn remove(&mut self, label: &JoinId) -> Option<JoinInfo> {
         self.blocks.remove(label)
     }
 }

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -151,11 +151,37 @@ impl EnvScope {
 /// Emission context — bundles state during IR generation for one function.
 pub struct EmitContext {
     pub env: ScopedEnv,
-    pub join_blocks: HashMap<JoinId, JoinInfo>,
+    pub(crate) join_blocks: JoinPointRegistry,
     pub lambda_counter: u32,
     pub prefix: String,
     /// Storage for LetRec deferred state, indexed by work items.
     pub(crate) letrec_states: Vec<crate::emit::expr::LetRecDeferredState>,
+}
+
+pub(crate) struct JoinPointRegistry {
+    blocks: HashMap<JoinId, JoinInfo>,
+}
+
+impl JoinPointRegistry {
+    pub fn new() -> Self {
+        Self {
+            blocks: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, label: JoinId, info: JoinInfo) {
+        self.blocks.insert(label, info);
+    }
+
+    pub fn get(&self, label: &JoinId) -> Result<&JoinInfo, EmitError> {
+        self.blocks.get(label).ok_or_else(|| {
+            EmitError::NotYetImplemented(format!("Jump to unregistered join {:?}", label))
+        })
+    }
+
+    pub fn remove(&mut self, label: &JoinId) -> Option<JoinInfo> {
+        self.blocks.remove(label)
+    }
 }
 
 /// Placeholder for join point info (used by case/join leaf later).
@@ -212,7 +238,7 @@ impl EmitContext {
     pub fn new(prefix: String) -> Self {
         Self {
             env: ScopedEnv::new(),
-            join_blocks: HashMap::new(),
+            join_blocks: JoinPointRegistry::new(),
             lambda_counter: 0,
             prefix,
             letrec_states: Vec::new(),


### PR DESCRIPTION
This PR replaces the `pub join_blocks: HashMap<JoinId, JoinInfo>` field on `EmitContext` with a typed `JoinPointRegistry` newtype.

Benefits:
- Centralizes join point lookup and registration.
- Simplifies call sites by returning `Result<&JoinInfo, EmitError>` from `get()`, removing redundant `ok_or_else` blocks.
- Improves encapsulation of internal IR emission state.

Verification:
- `cargo check -p tidepool-codegen` passes (with a fix for field visibility to match the type).
- `cargo test -p tidepool-codegen` passes all 71 unit tests and many integration tests.