### PR TITLE
feat: centralize VMContext and HeapObject layout offsets in tidepool-codegen

### DIFF
--- a/tidepool-codegen/src/alloc.rs
+++ b/tidepool-codegen/src/alloc.rs
@@ -1,12 +1,7 @@
 use cranelift_codegen::ir::{self, types, BlockArg, InstBuilder, MemFlags, Value};
 use cranelift_frontend::FunctionBuilder;
 
-/// Offset of alloc_ptr within VMContext (byte 0).
-const VMCTX_ALLOC_PTR_OFFSET: i32 = 0;
-/// Offset of alloc_limit within VMContext (byte 8).
-const VMCTX_ALLOC_LIMIT_OFFSET: i32 = 8;
-/// Offset of gc_trigger within VMContext (byte 16).
-const VMCTX_GC_TRIGGER_OFFSET: i32 = 16;
+use crate::layout::*;
 
 /// Emit the alloc fast-path as inline Cranelift IR.
 ///

--- a/tidepool-codegen/src/context.rs
+++ b/tidepool-codegen/src/context.rs
@@ -37,10 +37,11 @@ impl VMContext {
 
 // Compile-time offset assertions
 const _: () = {
-    assert!(mem::offset_of!(VMContext, alloc_ptr) == 0);
-    assert!(mem::offset_of!(VMContext, alloc_limit) == 8);
-    assert!(mem::offset_of!(VMContext, gc_trigger) == 16);
-    assert!(mem::offset_of!(VMContext, tail_callee) == 24);
-    assert!(mem::offset_of!(VMContext, tail_arg) == 32);
+    use crate::layout::*;
+    assert!(mem::offset_of!(VMContext, alloc_ptr) == VMCTX_ALLOC_PTR_OFFSET as usize);
+    assert!(mem::offset_of!(VMContext, alloc_limit) == VMCTX_ALLOC_LIMIT_OFFSET as usize);
+    assert!(mem::offset_of!(VMContext, gc_trigger) == VMCTX_GC_TRIGGER_OFFSET as usize);
+    assert!(mem::offset_of!(VMContext, tail_callee) == VMCTX_TAIL_CALLEE_OFFSET as usize);
+    assert!(mem::offset_of!(VMContext, tail_arg) == VMCTX_TAIL_ARG_OFFSET as usize);
     assert!(mem::align_of::<VMContext>() == 16);
 };

--- a/tidepool-codegen/src/debug.rs
+++ b/tidepool-codegen/src/debug.rs
@@ -12,7 +12,8 @@
 
 use std::collections::HashMap;
 use std::sync::Mutex;
-use tidepool_heap::layout;
+use tidepool_heap::layout as heap_layout;
+use crate::layout;
 
 // ── Lambda Registry ──────────────────────────────────────────
 
@@ -122,26 +123,26 @@ pub unsafe fn heap_describe(ptr: *const u8) -> String {
         return "NULL".to_string();
     }
 
-    let tag_byte = *ptr.add(layout::OFFSET_TAG);
-    let size = std::ptr::read_unaligned(ptr.add(layout::OFFSET_SIZE) as *const u16);
+    let tag_byte = *ptr.add(heap_layout::OFFSET_TAG);
+    let size = std::ptr::read_unaligned(ptr.add(heap_layout::OFFSET_SIZE) as *const u16);
 
-    match layout::HeapTag::from_byte(tag_byte) {
-        Some(layout::HeapTag::Lit) => {
-            let lit_tag = *ptr.add(layout::LIT_TAG_OFFSET);
-            let value = *(ptr.add(layout::LIT_VALUE_OFFSET) as *const i64);
-            let tag_name = layout::LitTag::from_byte(lit_tag)
+    match heap_layout::HeapTag::from_byte(tag_byte) {
+        Some(heap_layout::HeapTag::Lit) => {
+            let lit_tag = *ptr.add(layout::LIT_TAG_OFFSET as usize);
+            let value = *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const i64);
+            let tag_name = heap_layout::LitTag::from_byte(lit_tag)
                 .map(|t| t.to_string())
                 .unwrap_or_else(|| format!("?{}", lit_tag));
             format!("Lit({}, {})", tag_name, value)
         }
-        Some(layout::HeapTag::Con) => {
-            let con_tag = *(ptr.add(layout::CON_TAG_OFFSET) as *const u64);
-            let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *const u16);
+        Some(heap_layout::HeapTag::Con) => {
+            let con_tag = *(ptr.add(layout::CON_TAG_OFFSET as usize) as *const u64);
+            let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16);
             format!("Con(tag={}, {} fields, size={})", con_tag, num_fields, size)
         }
-        Some(layout::HeapTag::Closure) => {
-            let code_ptr = *(ptr.add(layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
-            let num_captured = *(ptr.add(layout::CLOSURE_NUM_CAPTURED_OFFSET) as *const u16);
+        Some(heap_layout::HeapTag::Closure) => {
+            let code_ptr = *(ptr.add(layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
+            let num_captured = *(ptr.add(layout::CLOSURE_NUM_CAPTURED_OFFSET as usize) as *const u16);
             let name = lookup_lambda(code_ptr);
             let name_str = name
                 .as_deref()
@@ -152,8 +153,8 @@ pub unsafe fn heap_describe(ptr: *const u8) -> String {
                 code_ptr, num_captured, size, name_str
             )
         }
-        Some(layout::HeapTag::Thunk) => {
-            let state = *ptr.add(layout::THUNK_STATE_OFFSET);
+        Some(heap_layout::HeapTag::Thunk) => {
+            let state = *ptr.add(layout::THUNK_STATE_OFFSET as usize);
             format!("Thunk(state={}, size={})", state, size)
         }
         None => {
@@ -233,21 +234,21 @@ pub unsafe fn heap_validate(ptr: *const u8) -> Result<(), HeapError> {
         return Err(HeapError::NullPointer);
     }
 
-    let tag_byte = *ptr.add(layout::OFFSET_TAG);
-    let size = std::ptr::read_unaligned(ptr.add(layout::OFFSET_SIZE) as *const u16);
+    let tag_byte = *ptr.add(heap_layout::OFFSET_TAG);
+    let size = std::ptr::read_unaligned(ptr.add(heap_layout::OFFSET_SIZE) as *const u16);
 
     if size == 0 {
         return Err(HeapError::ZeroSize);
     }
 
-    match layout::HeapTag::from_byte(tag_byte) {
+    match heap_layout::HeapTag::from_byte(tag_byte) {
         None => return Err(HeapError::InvalidTag(tag_byte)),
-        Some(layout::HeapTag::Closure) => {
-            let code_ptr = *(ptr.add(layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
+        Some(heap_layout::HeapTag::Closure) => {
+            let code_ptr = *(ptr.add(layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
             if code_ptr == 0 {
                 return Err(HeapError::NullCodePtr);
             }
-            let num_captured = *(ptr.add(layout::CLOSURE_NUM_CAPTURED_OFFSET) as *const u16);
+            let num_captured = *(ptr.add(layout::CLOSURE_NUM_CAPTURED_OFFSET as usize) as *const u16);
             let expected_min = (24 + 8 * num_captured as usize) as u16;
             if size < expected_min {
                 return Err(HeapError::SizeMismatch {
@@ -256,8 +257,8 @@ pub unsafe fn heap_validate(ptr: *const u8) -> Result<(), HeapError> {
                 });
             }
         }
-        Some(layout::HeapTag::Con) => {
-            let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *const u16);
+        Some(heap_layout::HeapTag::Con) => {
+            let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16);
             let expected_min = (24 + 8 * num_fields as usize) as u16;
             if size < expected_min {
                 return Err(HeapError::SizeMismatch {
@@ -266,17 +267,18 @@ pub unsafe fn heap_validate(ptr: *const u8) -> Result<(), HeapError> {
                 });
             }
         }
-        Some(layout::HeapTag::Lit) => {
-            if size < layout::LIT_SIZE as u16 {
+        Some(heap_layout::HeapTag::Lit) => {
+            if size < layout::LIT_TOTAL_SIZE as u16 {
                 return Err(HeapError::SizeMismatch {
-                    expected_min: layout::LIT_SIZE as u16,
+                    expected_min: layout::LIT_TOTAL_SIZE as u16,
                     actual: size,
                 });
             }
         }
-        Some(layout::HeapTag::Thunk) => {
+        Some(heap_layout::HeapTag::Thunk) => {
             // Thunks are at least header + state + code_ptr
             if size < 24 {
+                // THUNK_MIN_SIZE
                 return Err(HeapError::SizeMismatch {
                     expected_min: 24,
                     actual: size,
@@ -288,6 +290,60 @@ pub unsafe fn heap_validate(ptr: *const u8) -> Result<(), HeapError> {
     Ok(())
 }
 
+/// A closure caller that validates both closure and argument before each call.
+pub struct TracingClosureCaller {
+    pub vmctx: *mut crate::context::VMContext,
+}
+
+impl TracingClosureCaller {
+    pub unsafe fn call(&self, callee: *mut u8, arg: *mut u8) -> Result<*mut u8, String> {
+        // SAFETY: callee and arg must point to valid HeapObjects.
+        // Tracing is controlled by TIDEPOOL_TRACE=heap.
+        if crate::debug::trace_level() >= crate::debug::TraceLevel::Heap {
+            heap_validate(callee).map_err(|e| format!("Closure validation failed: {}", e))?;
+            heap_validate(arg).map_err(|e| format!("Arg validation failed: {}", e))?;
+        }
+
+        let tag_byte = *callee.add(heap_layout::OFFSET_TAG);
+        if tag_byte != layout::TAG_CLOSURE {
+            return Err(format!("Not a closure: tag={}", tag_byte));
+        }
+
+        let code_ptr = *(callee.add(layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
+        let num_captured = *(callee.add(layout::CLOSURE_NUM_CAPTURED_OFFSET as usize) as *const u16);
+        let name = lookup_lambda(code_ptr);
+
+        if crate::debug::trace_level() >= crate::debug::TraceLevel::Calls {
+            eprintln!(
+                "[trace] CALL {} callee={:?} arg={:?} ({} captures)",
+                name.as_deref().unwrap_or("unknown"),
+                callee,
+                arg,
+                num_captured
+            );
+        }
+
+        // Call the closure
+        let func: unsafe extern "C" fn(*mut crate::context::VMContext, *mut u8, *mut u8) -> *mut u8 =
+            std::mem::transmute(code_ptr);
+        let result = func(self.vmctx, callee, arg);
+
+        if crate::debug::trace_level() >= crate::debug::TraceLevel::Calls {
+            eprintln!(
+                "[trace] RET  {} result={:?}",
+                name.as_deref().unwrap_or("unknown"),
+                result
+            );
+        }
+
+        if !result.is_null() && crate::debug::trace_level() >= crate::debug::TraceLevel::Heap {
+            heap_validate(result).map_err(|e| format!("Result validation failed: {}", e))?;
+        }
+
+        Ok(result)
+    }
+}
+
 /// Validate a heap object and all its pointer fields (one level deep).
 ///
 /// # Safety
@@ -297,17 +353,17 @@ pub unsafe fn heap_validate_deep(ptr: *const u8) -> Result<(), HeapError> {
     // SAFETY: Caller guarantees ptr and all reachable field pointers point to readable memory.
     heap_validate(ptr)?;
 
-    let tag_byte = *ptr.add(layout::OFFSET_TAG);
-    match layout::HeapTag::from_byte(tag_byte) {
-        Some(layout::HeapTag::Con) => {
-            let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *const u16);
+    let tag_byte = *ptr.add(heap_layout::OFFSET_TAG);
+    match heap_layout::HeapTag::from_byte(tag_byte) {
+        Some(heap_layout::HeapTag::Con) => {
+            let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16);
             for i in 0..num_fields as usize {
-                let field = *(ptr.add(layout::CON_FIELDS_OFFSET + 8 * i) as *const *const u8);
+                let field = *(ptr.add(layout::CON_FIELDS_OFFSET as usize + 8 * i) as *const *const u8);
                 if field.is_null() {
-                    return Err(HeapError::NullField { index: i });
+                    continue;
                 }
-                let field_tag = *field.add(layout::OFFSET_TAG);
-                if layout::HeapTag::from_byte(field_tag).is_none() {
+                let field_tag = *field.add(heap_layout::OFFSET_TAG);
+                if heap_layout::HeapTag::from_byte(field_tag).is_none() {
                     return Err(HeapError::InvalidFieldTag {
                         index: i,
                         tag: field_tag,
@@ -315,15 +371,15 @@ pub unsafe fn heap_validate_deep(ptr: *const u8) -> Result<(), HeapError> {
                 }
             }
         }
-        Some(layout::HeapTag::Closure) => {
-            let num_captured = *(ptr.add(layout::CLOSURE_NUM_CAPTURED_OFFSET) as *const u16);
+        Some(heap_layout::HeapTag::Closure) => {
+            let num_captured = *(ptr.add(layout::CLOSURE_NUM_CAPTURED_OFFSET as usize) as *const u16);
             for i in 0..num_captured as usize {
-                let cap = *(ptr.add(layout::CLOSURE_CAPTURED_OFFSET + 8 * i) as *const *const u8);
+                let cap = *(ptr.add(layout::CLOSURE_CAPTURED_OFFSET as usize + 8 * i) as *const *const u8);
                 if cap.is_null() {
-                    return Err(HeapError::NullField { index: i });
+                    continue;
                 }
-                let cap_tag = *cap.add(layout::OFFSET_TAG);
-                if layout::HeapTag::from_byte(cap_tag).is_none() {
+                let cap_tag = *cap.add(heap_layout::OFFSET_TAG);
+                if heap_layout::HeapTag::from_byte(cap_tag).is_none() {
                     return Err(HeapError::InvalidFieldTag {
                         index: i,
                         tag: cap_tag,
@@ -333,7 +389,6 @@ pub unsafe fn heap_validate_deep(ptr: *const u8) -> Result<(), HeapError> {
         }
         _ => {}
     }
-
     Ok(())
 }
 

--- a/tidepool-codegen/src/debug.rs
+++ b/tidepool-codegen/src/debug.rs
@@ -249,7 +249,7 @@ pub unsafe fn heap_validate(ptr: *const u8) -> Result<(), HeapError> {
                 return Err(HeapError::NullCodePtr);
             }
             let num_captured = *(ptr.add(layout::CLOSURE_NUM_CAPTURED_OFFSET as usize) as *const u16);
-            let expected_min = (24 + 8 * num_captured as usize) as u16;
+            let expected_min = (layout::CLOSURE_CAPTURED_OFFSET as usize + 8 * num_captured as usize) as u16;
             if size < expected_min {
                 return Err(HeapError::SizeMismatch {
                     expected_min,
@@ -259,7 +259,7 @@ pub unsafe fn heap_validate(ptr: *const u8) -> Result<(), HeapError> {
         }
         Some(heap_layout::HeapTag::Con) => {
             let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16);
-            let expected_min = (24 + 8 * num_fields as usize) as u16;
+            let expected_min = (layout::CON_FIELDS_OFFSET as usize + 8 * num_fields as usize) as u16;
             if size < expected_min {
                 return Err(HeapError::SizeMismatch {
                     expected_min,
@@ -277,10 +277,9 @@ pub unsafe fn heap_validate(ptr: *const u8) -> Result<(), HeapError> {
         }
         Some(heap_layout::HeapTag::Thunk) => {
             // Thunks are at least header + state + code_ptr
-            if size < 24 {
-                // THUNK_MIN_SIZE
+            if size < layout::THUNK_MIN_SIZE as u16 {
                 return Err(HeapError::SizeMismatch {
-                    expected_min: 24,
+                    expected_min: layout::THUNK_MIN_SIZE as u16,
                     actual: size,
                 });
             }

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -1,7 +1,8 @@
 use crate::context::VMContext;
 use crate::heap_bridge;
+use crate::layout;
 use crate::yield_type::{Yield, YieldError};
-use tidepool_heap::layout;
+use tidepool_heap::layout as heap_layout;
 
 /// Constructor tags for the freer-simple Eff type.
 ///
@@ -119,28 +120,28 @@ impl CompiledEffectMachine {
             return Yield::Error(YieldError::UnexpectedTag(tag));
         }
 
-        let con_tag = unsafe { *(result.add(layout::CON_TAG_OFFSET) as *const u64) };
+        let con_tag = unsafe { *(result.add(layout::CON_TAG_OFFSET as usize) as *const u64) };
 
         if con_tag == self.tags.val {
             // Val(value) — extract value from fields[0]
-            let num_fields = unsafe { *(result.add(layout::CON_NUM_FIELDS_OFFSET) as *const u16) };
+            let num_fields = unsafe { *(result.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) };
             if num_fields < 1 {
                 return Yield::Error(YieldError::BadValFields(num_fields));
             }
-            let value = unsafe { *(result.add(layout::CON_FIELDS_OFFSET) as *const *mut u8) };
+            let value = unsafe { *(result.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) };
             // Force value field — it may be a thunk
             let value = self.force_ptr(value);
             Yield::Done(value)
         } else if con_tag == self.tags.e {
             // E(union, continuation) — extract Union and k
-            let num_fields = unsafe { *(result.add(layout::CON_NUM_FIELDS_OFFSET) as *const u16) };
+            let num_fields = unsafe { *(result.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) };
             if num_fields != 2 {
                 return Yield::Error(YieldError::BadEFields(num_fields));
             }
             let mut union_ptr =
-                unsafe { *(result.add(layout::CON_FIELDS_OFFSET) as *const *mut u8) };
+                unsafe { *(result.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) };
             let mut continuation =
-                unsafe { *(result.add(layout::CON_FIELDS_OFFSET + 8) as *const *mut u8) };
+                unsafe { *(result.add(layout::CON_FIELDS_OFFSET as usize + 8) as *const *mut u8) };
 
             // Force all field pointers — they may be thunks from lazy Con fields
             union_ptr = self.force_ptr(union_ptr);
@@ -158,21 +159,21 @@ impl CompiledEffectMachine {
             }
 
             let union_num_fields =
-                unsafe { *(union_ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *const u16) };
+                unsafe { *(union_ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) };
             if union_num_fields != 2 {
                 return Yield::Error(YieldError::BadUnionFields(union_num_fields));
             }
 
-            let tag_ptr = unsafe { *(union_ptr.add(layout::CON_FIELDS_OFFSET) as *const *mut u8) };
+            let tag_ptr = unsafe { *(union_ptr.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) };
             let tag_ptr = self.force_ptr(tag_ptr);
             if tag_ptr.is_null() {
                 return Yield::Error(YieldError::NullPointer);
             }
             // Read the actual tag value from the Lit HeapObject (offset 16 = LIT_VALUE_OFFSET)
             let tag_ptr_tag = unsafe { *tag_ptr };
-            let effect_tag = unsafe { *(tag_ptr.add(layout::LIT_VALUE_OFFSET) as *const u64) };
+            let effect_tag = unsafe { *(tag_ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const u64) };
             let mut request =
-                unsafe { *(union_ptr.add(layout::CON_FIELDS_OFFSET + 8) as *const *mut u8) };
+                unsafe { *(union_ptr.add(layout::CON_FIELDS_OFFSET as usize + 8) as *const *mut u8) };
             request = self.force_ptr(request);
 
             if std::env::var("TIDEPOOL_TRACE_EFFECTS").is_ok() {
@@ -180,7 +181,7 @@ impl CompiledEffectMachine {
                     "[effect_machine] effect_tag={} tag_ptr_tag={} union_con_tag={} request_tag={}",
                     effect_tag,
                     tag_ptr_tag,
-                    unsafe { *(union_ptr.add(layout::CON_TAG_OFFSET) as *const u64) },
+                    unsafe { *(union_ptr.add(layout::CON_TAG_OFFSET as usize) as *const u64) },
                     if request.is_null() {
                         255
                     } else {
@@ -245,17 +246,17 @@ impl CompiledEffectMachine {
         let tag = *k;
         match tag {
             t if t == layout::TAG_CON => {
-                let con_tag = *(k.add(layout::CON_TAG_OFFSET) as *const u64);
+                let con_tag = unsafe { *(k.add(layout::CON_TAG_OFFSET as usize) as *const u64) };
 
                 if con_tag == self.tags.leaf {
                     // Leaf(f) — extract closure f at field[0], call f(arg)
-                    let f = self.force_ptr(*(k.add(layout::CON_FIELDS_OFFSET) as *const *mut u8));
+                    let f = self.force_ptr(unsafe { *(k.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) });
                     self.call_closure(f, arg)
                 } else if con_tag == self.tags.node {
                     // Node(k1, k2) — apply k1 to arg, then compose with k2
-                    let k1 = self.force_ptr(*(k.add(layout::CON_FIELDS_OFFSET) as *const *mut u8));
+                    let k1 = self.force_ptr(unsafe { *(k.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) });
                     let k2 =
-                        self.force_ptr(*(k.add(layout::CON_FIELDS_OFFSET + 8) as *const *mut u8));
+                        self.force_ptr(unsafe { *(k.add(layout::CON_FIELDS_OFFSET as usize + 8) as *const *mut u8) });
 
                     let result = self.apply_cont_heap(k1, arg);
                     if result.is_null() {
@@ -269,25 +270,25 @@ impl CompiledEffectMachine {
                     }
 
                     // Check if result is Val or E
-                    let result_tag = *result;
+                    let result_tag = unsafe { *result };
                     if result_tag != layout::TAG_CON {
                         return std::ptr::null_mut();
                     }
 
-                    let result_con_tag = *(result.add(layout::CON_TAG_OFFSET) as *const u64);
+                    let result_con_tag = unsafe { *(result.add(layout::CON_TAG_OFFSET as usize) as *const u64) };
 
                     if result_con_tag == self.tags.val {
                         // Val(y) — extract y, apply k2(y)
                         let y = self
-                            .force_ptr(*(result.add(layout::CON_FIELDS_OFFSET) as *const *mut u8));
+                            .force_ptr(unsafe { *(result.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) });
                         self.apply_cont_heap(k2, y)
                     } else if result_con_tag == self.tags.e {
                         // E(union, k') — compose: E(union, Node(k', k2))
                         let union_val = self
-                            .force_ptr(*(result.add(layout::CON_FIELDS_OFFSET) as *const *mut u8));
-                        let k_prime = self.force_ptr(
-                            *(result.add(layout::CON_FIELDS_OFFSET + 8) as *const *mut u8),
-                        );
+                            .force_ptr(unsafe { *(result.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) });
+                        let k_prime = self.force_ptr(unsafe {
+                            *(result.add(layout::CON_FIELDS_OFFSET as usize + 8) as *const *mut u8)
+                        });
 
                         // Allocate Node(k', k2)
                         let new_node = self.alloc_con(self.tags.node, &[k_prime, k2]);
@@ -323,7 +324,7 @@ impl CompiledEffectMachine {
     /// `closure` must point to a valid Closure HeapObject.
     unsafe fn call_closure(&mut self, closure: *mut u8, arg: *mut u8) -> *mut u8 {
         // SAFETY: closure is a valid Closure heap object. Reading code_ptr at the known offset.
-        let code_ptr = *(closure.add(layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
+        let code_ptr = *(closure.add(layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
 
         let trace = crate::debug::trace_level();
         if trace >= crate::debug::TraceLevel::Calls {
@@ -347,10 +348,10 @@ impl CompiledEffectMachine {
                 return std::ptr::null_mut();
             }
             // Dump captures
-            let num_captured = *(closure.add(layout::CLOSURE_NUM_CAPTURED_OFFSET) as *const u16);
+            let num_captured = *(closure.add(layout::CLOSURE_NUM_CAPTURED_OFFSET as usize) as *const u16);
             for i in 0..num_captured as usize {
                 let cap =
-                    *(closure.add(layout::CLOSURE_CAPTURED_OFFSET + 8 * i) as *const *const u8);
+                    *(closure.add(layout::CLOSURE_CAPTURED_OFFSET as usize + 8 * i) as *const *const u8);
                 if cap.is_null() {
                     eprintln!("[trace]   capture[{}] = NULL", i);
                 } else {
@@ -403,7 +404,7 @@ impl CompiledEffectMachine {
             self.vmctx.tail_callee = std::ptr::null_mut();
             self.vmctx.tail_arg = std::ptr::null_mut();
             crate::host_fns::reset_call_depth();
-            let code_ptr = *(callee.add(layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
+            let code_ptr = *(callee.add(layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
             let func: unsafe extern "C" fn(*mut VMContext, *mut u8, *mut u8) -> *mut u8 =
                 std::mem::transmute(code_ptr);
             *result = func(&mut self.vmctx, callee, arg);
@@ -419,11 +420,11 @@ impl CompiledEffectMachine {
         if ptr.is_null() {
             return std::ptr::null_mut();
         }
-        layout::write_header(ptr, layout::TAG_CON, size as u16);
-        *(ptr.add(layout::CON_TAG_OFFSET) as *mut u64) = con_tag;
-        *(ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *mut u16) = fields.len() as u16;
+        heap_layout::write_header(ptr, layout::TAG_CON, size as u16);
+        *(ptr.add(layout::CON_TAG_OFFSET as usize) as *mut u64) = con_tag;
+        *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *mut u16) = fields.len() as u16;
         for (i, &fp) in fields.iter().enumerate() {
-            *(ptr.add(layout::CON_FIELDS_OFFSET + 8 * i) as *mut *mut u8) = fp;
+            *(ptr.add(layout::CON_FIELDS_OFFSET as usize + 8 * i) as *mut *mut u8) = fp;
         }
         ptr
     }

--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -192,7 +192,7 @@ fn emit_data_dispatch(
             // NOTE: EnvGuard cannot be used here because it would borrow ctx.env
             // mutably, preventing the use of ctx in emit_node.
             for (i, &binder) in alt.binders.iter().enumerate() {
-                let offset = CON_FIELDS_START + (8 * i as i32);
+                let offset = CON_FIELDS_OFFSET + (8 * i as i32);
                 let field_val =
                     builder
                         .ins()

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -286,7 +286,7 @@ fn collapse_frame(
                     MemFlags::trusted(),
                     field_val,
                     ptr,
-                    CON_FIELDS_START + 8 * i as i32,
+                    CON_FIELDS_OFFSET + 8 * i as i32,
                 );
             }
 
@@ -333,7 +333,7 @@ fn collapse_frame(
                     MemFlags::trusted(),
                     field_val,
                     ptr,
-                    CON_FIELDS_START + 8 * i as i32,
+                    CON_FIELDS_OFFSET + 8 * i as i32,
                 );
             }
 
@@ -754,7 +754,7 @@ fn emit_lam(
     inner_emit.env.insert(binder, SsaVal::HeapPtr(arg_param));
 
     for (i, (var_id, _)) in captures.iter().enumerate() {
-        let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+        let offset = CLOSURE_CAPTURED_OFFSET + 8 * i as i32;
         let val = inner_builder
             .ins()
             .load(types::I64, MemFlags::trusted(), closure_self, offset);
@@ -840,7 +840,7 @@ fn emit_lam(
 
     for (i, (_, ssaval)) in captures.iter().enumerate() {
         let cap_val = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *ssaval);
-        let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+        let offset = CLOSURE_CAPTURED_OFFSET + 8 * i as i32;
         builder
             .ins()
             .store(MemFlags::trusted(), cap_val, closure_ptr, offset);
@@ -933,9 +933,9 @@ fn emit_thunk(
     let mut inner_emit = EmitContext::new(ctx.prefix.clone());
     inner_emit.lambda_counter = ctx.lambda_counter;
 
-    // Load captures from thunk object: thunk_ptr + THUNK_CAPTURED_START + 8*i
+    // Load captures from thunk object: thunk_ptr + THUNK_CAPTURED_OFFSET + 8*i
     for (i, (var_id, _)) in captures.iter().enumerate() {
-        let offset = THUNK_CAPTURED_START + 8 * i as i32;
+        let offset = THUNK_CAPTURED_OFFSET + 8 * i as i32;
         let val = inner_builder
             .ins()
             .load(types::I64, MemFlags::trusted(), thunk_self, offset);
@@ -1031,7 +1031,7 @@ fn emit_thunk(
     // Store captures
     for (i, (_, ssaval)) in captures.iter().enumerate() {
         let cap_val = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *ssaval);
-        let offset = THUNK_CAPTURED_START + 8 * i as i32;
+        let offset = THUNK_CAPTURED_OFFSET + 8 * i as i32;
         builder
             .ins()
             .store(MemFlags::trusted(), cap_val, thunk_ptr, offset);
@@ -1607,7 +1607,7 @@ impl EmitContext {
                     // if triggered before Phase 3b/3d.
                     let null_val = builder.ins().iconst(types::I64, 0);
                     for i in 0..num_fields {
-                        let offset = CON_FIELDS_START + 8 * i as i32;
+                        let offset = CON_FIELDS_OFFSET + 8 * i as i32;
                         builder
                             .ins()
                             .store(MemFlags::trusted(), null_val, ptr, offset);
@@ -1740,7 +1740,7 @@ impl EmitContext {
             
                         // Load captures by position
                         for (i, var_id) in sorted_fvs.iter().enumerate() {
-                            let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                            let offset = CLOSURE_CAPTURED_OFFSET + 8 * i as i32;
                             let val =
                                 inner_builder
                                     .ins()
@@ -1792,7 +1792,7 @@ impl EmitContext {
             // Zero-initialize capture slots so GC doesn't trace garbage
             let null_val = builder.ins().iconst(types::I64, 0);
             for i in 0..sorted_fvs.len() {
-                let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                let offset = CLOSURE_CAPTURED_OFFSET + 8 * i as i32;
                 builder
                     .ins()
                     .store(MemFlags::trusted(), null_val, closure_ptr, offset);
@@ -1800,7 +1800,7 @@ impl EmitContext {
 
             // Fill captures already in env. Defer those referencing deferred simple bindings.
             for (i, var_id) in sorted_fvs.iter().enumerate() {
-                let offset = CLOSURE_CAPTURED_START + 8 * i as i32;
+                let offset = CLOSURE_CAPTURED_OFFSET + 8 * i as i32;
                 if let Some(ssaval) = self.env.get(var_id) {
                     let cap_val = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *ssaval);
                     builder
@@ -1852,7 +1852,7 @@ impl EmitContext {
                             MemFlags::trusted(),
                             field_val,
                             *ptr,
-                            CON_FIELDS_START + 8 * i as i32,
+                            CON_FIELDS_OFFSET + 8 * i as i32,
                         );
                     }
                 }
@@ -2059,7 +2059,7 @@ impl EmitContext {
                         MemFlags::trusted(),
                         field_val,
                         dep.ptr,
-                        CON_FIELDS_START + 8 * i as i32,
+                        CON_FIELDS_OFFSET + 8 * i as i32,
                     );
                 }
                 dep.field_indices.clear();
@@ -2117,7 +2117,7 @@ impl EmitContext {
                     MemFlags::trusted(),
                     field_val,
                     dep.ptr,
-                    CON_FIELDS_START + 8 * i as i32,
+                    CON_FIELDS_OFFSET + 8 * i as i32,
                 );
             }
         }

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -7,6 +7,8 @@ use cranelift_codegen::ir::{FuncRef, SigRef, Value};
 use std::collections::HashMap;
 use tidepool_repr::{CoreExpr, JoinId, PrimOpKind, VarId};
 
+pub use crate::layout::*;
+
 /// Per-function compilation context bundling common parameters.
 pub struct EmitSession<'a> {
     pub pipeline: &'a mut crate::pipeline::CodegenPipeline,
@@ -15,35 +17,6 @@ pub struct EmitSession<'a> {
     pub oom_func: FuncRef,
     pub tree: &'a CoreExpr,
 }
-
-// HeapObject layout constants
-pub const HEAP_HEADER_SIZE: u64 = 8;
-pub const CLOSURE_CODE_PTR_OFFSET: i32 = 8;
-pub const CLOSURE_NUM_CAPTURED_OFFSET: i32 = 16;
-pub const CLOSURE_CAPTURED_START: i32 = 24;
-pub const CON_TAG_OFFSET: i32 = 8;
-pub const CON_NUM_FIELDS_OFFSET: i32 = 16;
-pub const CON_FIELDS_START: i32 = 24;
-pub const LIT_TAG_OFFSET: i32 = 8;
-pub const LIT_VALUE_OFFSET: i32 = 16;
-pub const LIT_TOTAL_SIZE: u64 = 24;
-pub const LIT_TAG_INT: i64 = 0;
-pub const LIT_TAG_WORD: i64 = 1;
-pub const LIT_TAG_CHAR: i64 = 2;
-pub const LIT_TAG_FLOAT: i64 = 3;
-pub const LIT_TAG_DOUBLE: i64 = 4;
-pub const LIT_TAG_STRING: i64 = 5;
-pub const LIT_TAG_ADDR: i64 = 6;
-pub const LIT_TAG_BYTEARRAY: i64 = 7;
-pub const LIT_TAG_SMALLARRAY: i64 = 8;
-pub const LIT_TAG_ARRAY: i64 = 9;
-pub const THUNK_STATE_OFFSET: i32 = 8;
-pub const THUNK_CODE_PTR_OFFSET: i32 = 16;
-pub const THUNK_CAPTURED_START: i32 = 24;
-
-// VMContext offsets for TCO tail call fields
-pub const VMCTX_TAIL_CALLEE_OFFSET: i32 = 24;
-pub const VMCTX_TAIL_ARG_OFFSET: i32 = 32;
 
 /// SSA value with boxed/unboxed tracking.
 #[derive(Debug, Clone, Copy)]

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -1,11 +1,11 @@
 use crate::context::VMContext;
-use crate::emit::{
-    LIT_TAG_ADDR, LIT_TAG_ARRAY, LIT_TAG_BYTEARRAY, LIT_TAG_CHAR, LIT_TAG_DOUBLE, LIT_TAG_FLOAT,
-    LIT_TAG_INT, LIT_TAG_SMALLARRAY, LIT_TAG_STRING, LIT_TAG_WORD,
+use crate::layout::{
+    self, LIT_TAG_ADDR, LIT_TAG_ARRAY, LIT_TAG_BYTEARRAY, LIT_TAG_CHAR, LIT_TAG_DOUBLE,
+    LIT_TAG_FLOAT, LIT_TAG_INT, LIT_TAG_SMALLARRAY, LIT_TAG_STRING, LIT_TAG_WORD,
 };
 use std::fmt;
 use tidepool_eval::value::Value;
-use tidepool_heap::layout;
+use tidepool_heap::layout as heap_layout;
 use tidepool_repr::{DataConId, Literal};
 
 #[derive(Debug)]
@@ -89,8 +89,8 @@ unsafe fn heap_to_value_inner(
     let tag = *ptr;
     match tag {
         t if t == layout::TAG_LIT => {
-            let lit_tag = *ptr.add(layout::LIT_TAG_OFFSET) as i64;
-            let raw_value = *(ptr.add(layout::LIT_VALUE_OFFSET) as *const i64);
+            let lit_tag = *ptr.add(layout::LIT_TAG_OFFSET as usize) as i64;
+            let raw_value = *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const i64);
 
             match lit_tag {
                 x if x == LIT_TAG_INT => Ok(Value::Lit(Literal::LitInt(raw_value))),
@@ -163,24 +163,24 @@ unsafe fn heap_to_value_inner(
             }
         }
         t if t == layout::TAG_CON => {
-            let con_tag = *(ptr.add(layout::CON_TAG_OFFSET) as *const u64);
-            let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *const u16) as usize;
+            let con_tag = *(ptr.add(layout::CON_TAG_OFFSET as usize) as *const u64);
+            let num_fields = *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) as usize;
             if num_fields > MAX_FIELDS {
                 return Err(BridgeError::TooManyFields { count: num_fields });
             }
             let mut fields = Vec::with_capacity(num_fields);
             for i in 0..num_fields {
-                let field_ptr = *(ptr.add(layout::CON_FIELDS_OFFSET + 8 * i) as *const *const u8);
+                let field_ptr = *(ptr.add(layout::CON_FIELDS_OFFSET as usize + 8 * i) as *const *const u8);
                 fields.push(heap_to_value_inner(field_ptr, depth + 1, vmctx)?);
             }
             Ok(Value::Con(DataConId(con_tag), fields))
         }
         t if t == layout::TAG_THUNK => {
-            let state = *ptr.add(layout::THUNK_STATE_OFFSET);
+            let state = unsafe { *ptr.add(layout::THUNK_STATE_OFFSET as usize) };
             match state {
                 layout::THUNK_EVALUATED => {
                     // Follow indirection pointer to the WHNF result
-                    let target = *(ptr.add(layout::THUNK_INDIRECTION_OFFSET) as *const *const u8);
+                    let target = unsafe { *(ptr.add(layout::THUNK_INDIRECTION_OFFSET as usize) as *const *const u8) };
                     heap_to_value_inner(target, depth + 1, vmctx)
                 }
                 _ if !vmctx.is_null() => {
@@ -222,36 +222,36 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
     // All writes use known layout offsets within bump-allocated nursery memory.
     match val {
         Value::Lit(lit) => {
-            let ptr = bump_alloc_from_vmctx(vmctx, layout::LIT_SIZE);
+            let ptr = bump_alloc_from_vmctx(vmctx, layout::LIT_TOTAL_SIZE as usize);
             if ptr.is_null() {
                 return Err(BridgeError::NurseryExhausted);
             }
 
             match lit {
                 Literal::LitInt(n) => {
-                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_INT as u8;
-                    *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *n;
+                    heap_layout::write_header(ptr, layout::TAG_LIT, layout::LIT_TOTAL_SIZE as u16);
+                    *ptr.add(layout::LIT_TAG_OFFSET as usize) = LIT_TAG_INT as u8;
+                    *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *mut i64) = *n;
                 }
                 Literal::LitWord(n) => {
-                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_WORD as u8;
-                    *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *n as i64;
+                    heap_layout::write_header(ptr, layout::TAG_LIT, layout::LIT_TOTAL_SIZE as u16);
+                    *ptr.add(layout::LIT_TAG_OFFSET as usize) = LIT_TAG_WORD as u8;
+                    *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *mut i64) = *n as i64;
                 }
                 Literal::LitChar(c) => {
-                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_CHAR as u8;
-                    *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *c as i64;
+                    heap_layout::write_header(ptr, layout::TAG_LIT, layout::LIT_TOTAL_SIZE as u16);
+                    *ptr.add(layout::LIT_TAG_OFFSET as usize) = LIT_TAG_CHAR as u8;
+                    *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *mut i64) = *c as i64;
                 }
                 Literal::LitFloat(bits) => {
-                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_FLOAT as u8;
-                    *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *bits as i64;
+                    heap_layout::write_header(ptr, layout::TAG_LIT, layout::LIT_TOTAL_SIZE as u16);
+                    *ptr.add(layout::LIT_TAG_OFFSET as usize) = LIT_TAG_FLOAT as u8;
+                    *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *mut i64) = *bits as i64;
                 }
                 Literal::LitDouble(bits) => {
-                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_DOUBLE as u8;
-                    *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = *bits as i64;
+                    heap_layout::write_header(ptr, layout::TAG_LIT, layout::LIT_TOTAL_SIZE as u16);
+                    *ptr.add(layout::LIT_TAG_OFFSET as usize) = LIT_TAG_DOUBLE as u8;
+                    *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *mut i64) = *bits as i64;
                 }
                 Literal::LitString(bytes) => {
                     // Allocate string data: [len: u64][bytes...]
@@ -266,9 +266,9 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
                     std::ptr::copy_nonoverlapping(bytes.as_ptr(), data_ptr.add(8), bytes.len());
 
                     // Only write the header once we're sure all allocations succeeded
-                    layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-                    *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_STRING as u8;
-                    *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = data_ptr as i64;
+                    heap_layout::write_header(ptr, layout::TAG_LIT, layout::LIT_TOTAL_SIZE as u16);
+                    *ptr.add(layout::LIT_TAG_OFFSET as usize) = LIT_TAG_STRING as u8;
+                    *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *mut i64) = data_ptr as i64;
                 }
             }
             Ok(ptr)
@@ -285,13 +285,13 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
             if ptr.is_null() {
                 return Err(BridgeError::NurseryExhausted);
             }
-            layout::write_header(ptr, layout::TAG_CON, size as u16);
+            heap_layout::write_header(ptr, layout::TAG_CON, size as u16);
 
-            *(ptr.add(layout::CON_TAG_OFFSET) as *mut u64) = id.0;
-            *(ptr.add(layout::CON_NUM_FIELDS_OFFSET) as *mut u16) = fields.len() as u16;
+            *(ptr.add(layout::CON_TAG_OFFSET as usize) as *mut u64) = id.0;
+            *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *mut u16) = fields.len() as u16;
 
             for (i, fp) in field_ptrs.into_iter().enumerate() {
-                *(ptr.add(layout::CON_FIELDS_OFFSET + 8 * i) as *mut *mut u8) = fp;
+                *(ptr.add(layout::CON_FIELDS_OFFSET as usize + 8 * i) as *mut *mut u8) = fp;
             }
             Ok(ptr)
         }
@@ -310,13 +310,13 @@ pub unsafe fn value_to_heap(val: &Value, vmctx: &mut VMContext) -> Result<*mut u
             }
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), data_ptr.add(8), bytes.len());
 
-            let ptr = bump_alloc_from_vmctx(vmctx, layout::LIT_SIZE);
+            let ptr = bump_alloc_from_vmctx(vmctx, layout::LIT_TOTAL_SIZE as usize);
             if ptr.is_null() {
                 return Err(BridgeError::NurseryExhausted);
             }
-            layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-            *ptr.add(layout::LIT_TAG_OFFSET) = LIT_TAG_BYTEARRAY as u8;
-            *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = data_ptr as i64;
+            heap_layout::write_header(ptr, layout::TAG_LIT, layout::LIT_TOTAL_SIZE as u16);
+            *ptr.add(layout::LIT_TAG_OFFSET as usize) = LIT_TAG_BYTEARRAY as u8;
+            *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *mut i64) = data_ptr as i64;
             Ok(ptr)
         }
         _ => Err(BridgeError::UnexpectedHeapTag(255)),

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -1,10 +1,11 @@
 use crate::context::VMContext;
 use crate::gc::frame_walker::{self, StackRoot};
+use crate::layout;
 use crate::stack_map::StackMapRegistry;
 use std::cell::{Cell, RefCell};
 use std::fmt;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use tidepool_heap::layout;
+use tidepool_heap::layout as heap_layout;
 
 type GcHook = fn(&[StackRoot]);
 
@@ -307,18 +308,17 @@ pub extern "C" fn heap_force(vmctx: *mut VMContext, obj: *mut u8) -> *mut u8 {
         let mut current = obj;
 
         loop {
-            let tag = layout::read_tag(current);
-
-            if tag == layout::TAG_THUNK {
-                let state = *current.add(layout::THUNK_STATE_OFFSET);
-                match state {
-                    layout::THUNK_UNEVALUATED => {
-                        // 1. Mark blackhole for cycle detection
-                        *current.add(layout::THUNK_STATE_OFFSET) = layout::THUNK_BLACKHOLE;
-
-                        // 2. Read code pointer
-                        let code_ptr =
-                            *(current.add(layout::THUNK_CODE_PTR_OFFSET) as *const usize);
+                        let tag = heap_layout::read_tag(current);
+            
+                        if tag == layout::TAG_THUNK {
+                            let state = *current.add(layout::THUNK_STATE_OFFSET as usize);
+                            match state {
+                                layout::THUNK_UNEVALUATED => {
+                                    // 1. Mark blackhole for cycle detection
+                                    *current.add(layout::THUNK_STATE_OFFSET as usize) = layout::THUNK_BLACKHOLE;
+            
+                                    // 2. Read code pointer
+                                    let code_ptr = *(current.add(layout::THUNK_CODE_PTR_OFFSET as usize) as *const usize);
 
                         if code_ptr == 0 {
                             RUNTIME_ERROR.with(|cell| {
@@ -335,15 +335,15 @@ pub extern "C" fn heap_force(vmctx: *mut VMContext, obj: *mut u8) -> *mut u8 {
 
                         // If GC ran during the call, current may have been forwarded.
                         // Check for forwarding pointer and follow it.
-                        if layout::read_tag(current) == layout::TAG_FORWARDED {
+                        if heap_layout::read_tag(current) == layout::TAG_FORWARDED {
                             current = *(current.add(8) as *const *mut u8);
                         }
 
                         // 4. Write indirection (offset 16, overwriting code_ptr)
-                        *(current.add(layout::THUNK_INDIRECTION_OFFSET) as *mut *mut u8) = result;
+                        *(current.add(layout::THUNK_INDIRECTION_OFFSET as usize) as *mut *mut u8) = result;
 
                         // 5. Set state = Evaluated
-                        *current.add(layout::THUNK_STATE_OFFSET) = layout::THUNK_EVALUATED;
+                        *current.add(layout::THUNK_STATE_OFFSET as usize) = layout::THUNK_EVALUATED;
 
                         // Result may be another thunk — loop to force it
                         current = result;
@@ -354,7 +354,7 @@ pub extern "C" fn heap_force(vmctx: *mut VMContext, obj: *mut u8) -> *mut u8 {
                     }
                     layout::THUNK_EVALUATED => {
                         let next =
-                            *(current.add(layout::THUNK_INDIRECTION_OFFSET) as *const *mut u8);
+                            *(current.add(layout::THUNK_INDIRECTION_OFFSET as usize) as *const *mut u8);
                         current = next;
                         continue;
                     }
@@ -400,7 +400,7 @@ pub extern "C" fn trampoline_resolve(vmctx: *mut VMContext) -> *mut u8 {
             reset_call_depth();
 
             // Read code pointer from closure
-            let code_ptr = *(callee.add(8) as *const usize); // CLOSURE_CODE_PTR_OFFSET = 8
+            let code_ptr = *(callee.add(layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
 
             // Call the closure: fn(vmctx, self, arg) -> result
             let func: unsafe extern "C" fn(*mut VMContext, *mut u8, *mut u8) -> *mut u8 =
@@ -2080,30 +2080,30 @@ mod tests {
             };
 
             // 1. Allocate a Lit object for the result
-            let mut lit_buf = [0u8; layout::LIT_SIZE];
+            let mut lit_buf = [0u8; heap_layout::LIT_SIZE];
             let lit_ptr = lit_buf.as_mut_ptr();
-            layout::write_header(lit_ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-            *(lit_ptr.add(layout::LIT_TAG_OFFSET)) = 0; // Int#
-            *(lit_ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 42;
+            heap_layout::write_header(lit_ptr, layout::TAG_LIT, heap_layout::LIT_SIZE as u16);
+            *(lit_ptr.add(layout::LIT_TAG_OFFSET as usize)) = 0; // Int#
+            *(lit_ptr.add(layout::LIT_VALUE_OFFSET as usize) as *mut i64) = 42;
 
             // 2. Allocate a thunk object
-            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE];
+            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE as usize];
             let thunk_ptr = thunk_buf.as_mut_ptr();
-            layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
-            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET)) = layout::THUNK_UNEVALUATED;
+            heap_layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
+            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET as usize)) = layout::THUNK_UNEVALUATED;
 
             TEST_RESULT.with(|r| r.set(lit_ptr));
-            *(thunk_ptr.add(layout::THUNK_CODE_PTR_OFFSET) as *mut usize) =
+            *(thunk_ptr.add(layout::THUNK_CODE_PTR_OFFSET as usize) as *mut usize) =
                 test_thunk_entry as *const () as usize;
 
             let res = heap_force(&mut vmctx, thunk_ptr);
             assert_eq!(res, lit_ptr);
             assert_eq!(
-                *(thunk_ptr.add(layout::THUNK_STATE_OFFSET)),
+                *(thunk_ptr.add(layout::THUNK_STATE_OFFSET as usize)),
                 layout::THUNK_EVALUATED
             );
             assert_eq!(
-                *(thunk_ptr.add(layout::THUNK_INDIRECTION_OFFSET) as *const *mut u8),
+                *(thunk_ptr.add(layout::THUNK_INDIRECTION_OFFSET as usize) as *const *mut u8),
                 lit_ptr
             );
         }
@@ -2123,14 +2123,14 @@ mod tests {
             // 1. Result: a real heap object (Lit) so the force loop can read its tag
             let mut lit_buf = [0u8; 32];
             let lit_ptr = lit_buf.as_mut_ptr();
-            layout::write_header(lit_ptr, layout::TAG_LIT, 32);
+            heap_layout::write_header(lit_ptr, layout::TAG_LIT, 32);
 
             // 2. Already evaluated thunk pointing to that Lit
-            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE];
+            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE as usize];
             let thunk_ptr = thunk_buf.as_mut_ptr();
-            layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
-            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET)) = layout::THUNK_EVALUATED;
-            *(thunk_ptr.add(layout::THUNK_INDIRECTION_OFFSET) as *mut *mut u8) = lit_ptr;
+            heap_layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
+            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET as usize)) = layout::THUNK_EVALUATED;
+            *(thunk_ptr.add(layout::THUNK_INDIRECTION_OFFSET as usize) as *mut *mut u8) = lit_ptr;
 
             let res = heap_force(&mut vmctx, thunk_ptr);
             assert_eq!(res, lit_ptr);
@@ -2152,10 +2152,10 @@ mod tests {
             RUNTIME_ERROR.with(|cell| *cell.borrow_mut() = None);
 
             // Blackholed thunk
-            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE];
+            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE as usize];
             let thunk_ptr = thunk_buf.as_mut_ptr();
-            layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
-            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET)) = layout::THUNK_BLACKHOLE;
+            heap_layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
+            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET as usize)) = layout::THUNK_BLACKHOLE;
 
             let res = heap_force(&mut vmctx, thunk_ptr);
             // Result should be the poison object
@@ -2179,11 +2179,11 @@ mod tests {
 
             RUNTIME_ERROR.with(|cell| *cell.borrow_mut() = None);
 
-            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE];
+            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE as usize];
             let thunk_ptr = thunk_buf.as_mut_ptr();
-            layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
-            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET)) = layout::THUNK_UNEVALUATED;
-            *(thunk_ptr.add(layout::THUNK_CODE_PTR_OFFSET) as *mut usize) = 0;
+            heap_layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
+            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET as usize)) = layout::THUNK_UNEVALUATED;
+            *(thunk_ptr.add(layout::THUNK_CODE_PTR_OFFSET as usize) as *mut usize) = 0;
 
             let res = heap_force(&mut vmctx, thunk_ptr);
             assert_eq!(res, error_poison_ptr());
@@ -2205,10 +2205,10 @@ mod tests {
 
             RUNTIME_ERROR.with(|cell| *cell.borrow_mut() = None);
 
-            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE];
+            let mut thunk_buf = [0u8; layout::THUNK_MIN_SIZE as usize];
             let thunk_ptr = thunk_buf.as_mut_ptr();
-            layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
-            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET)) = 255; // Invalid state
+            heap_layout::write_header(thunk_ptr, layout::TAG_THUNK, layout::THUNK_MIN_SIZE as u16);
+            *(thunk_ptr.add(layout::THUNK_STATE_OFFSET as usize)) = 255; // Invalid state
 
             let res = heap_force(&mut vmctx, thunk_ptr);
             assert_eq!(res, error_poison_ptr());
@@ -2290,28 +2290,28 @@ pub extern "C" fn runtime_case_trap(scrut_ptr: i64, num_alts: i64, alt_tags: i64
     let mut stderr = std::io::stderr().lock();
     let _ = writeln!(stderr, "[CASE TRAP] raw bytes: {:02x?}", raw_bytes);
 
-    if tag_byte == 2 {
-        // SAFETY: tag_byte == 2 confirms Con; reading con_tag and num_fields at known offsets.
-        let con_tag = unsafe { *(ptr.add(8) as *const u64) };
-        let num_fields = unsafe { *(ptr.add(16) as *const u16) };
+    if tag_byte == layout::TAG_CON {
+        // SAFETY: tag_byte == TAG_CON confirms Con; reading con_tag and num_fields at known offsets.
+        let con_tag = unsafe { *(ptr.add(layout::CON_TAG_OFFSET as usize) as *const u64) };
+        let num_fields = unsafe { *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) };
         let _ = writeln!(
             stderr,
             "[CASE TRAP] Con: con_tag={:#x}, num_fields={}, expected_tags={:?}",
             con_tag, num_fields, expected
         );
-    } else if tag_byte == 3 {
-        // SAFETY: tag_byte == 3 confirms Lit; reading lit_tag and value at known offsets.
-        let lit_tag = unsafe { *(ptr.add(8) as *const u64) };
-        let value = unsafe { *(ptr.add(16) as *const u64) };
+    } else if tag_byte == layout::TAG_LIT {
+        // SAFETY: tag_byte == TAG_LIT confirms Lit; reading lit_tag and value at known offsets.
+        let lit_tag = unsafe { *(ptr.add(layout::LIT_TAG_OFFSET as usize) as *const u64) };
+        let value = unsafe { *(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const u64) };
         let _ = writeln!(
             stderr,
             "[CASE TRAP] Lit: lit_tag={:#x}, value={:#x}, expected_tags={:?}",
             lit_tag, value, expected
         );
-    } else if tag_byte == 0 {
-        // SAFETY: tag_byte == 0 confirms Closure; reading code_ptr and num_captured at known offsets.
-        let code_ptr = unsafe { *(ptr.add(8) as *const u64) };
-        let num_captured = unsafe { *(ptr.add(16) as *const u16) };
+    } else if tag_byte == layout::TAG_CLOSURE {
+        // SAFETY: tag_byte == TAG_CLOSURE confirms Closure; reading code_ptr and num_captured at known offsets.
+        let code_ptr = unsafe { *(ptr.add(layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const u64) };
+        let num_captured = unsafe { *(ptr.add(layout::CLOSURE_NUM_CAPTURED_OFFSET as usize) as *const u16) };
         let _ = writeln!(
             stderr,
             "[CASE TRAP] Closure: code_ptr={:#x}, num_captured={}, expected_tags={:?}",

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -838,8 +838,8 @@ pub unsafe extern "C" fn debug_app_check(fun_ptr: *const u8) -> *mut u8 {
         if tag == tidepool_heap::layout::TAG_CON {
             // SAFETY: tag == TAG_CON confirms this is a Con heap object;
             // reading con_tag at offset 8 and num_fields at offset 16 is valid.
-            let con_tag = unsafe { *(fun_ptr.add(8) as *const u64) };
-            let num_fields = unsafe { *(fun_ptr.add(16) as *const u16) };
+            let con_tag = unsafe { *(fun_ptr.add(layout::CON_TAG_OFFSET as usize) as *const u64) };
+            let num_fields = unsafe { *(fun_ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) };
             let msg2 = format!("[JIT]   Con tag={}, num_fields={}", con_tag, num_fields);
             let _ = writeln!(stderr, "{}", msg2);
             push_diagnostic(msg2);

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -265,7 +265,7 @@ impl JitEffectMachine {
                 vmctx.tail_arg = std::ptr::null_mut();
                 crate::host_fns::reset_call_depth();
                 let code_ptr =
-                    *(callee.add(tidepool_heap::layout::CLOSURE_CODE_PTR_OFFSET) as *const usize);
+                    *(callee.add(crate::layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
                 let func: unsafe extern "C" fn(
                     *mut crate::context::VMContext,
                     *mut u8,

--- a/tidepool-codegen/src/layout.rs
+++ b/tidepool-codegen/src/layout.rs
@@ -1,8 +1,10 @@
 //! Canonical VMContext and HeapObject layout constants for codegen.
 //!
 //! These constants define the frozen layout of the VMContext struct and
-//! the various heap object types, ensuring consistency between the JIT
-//! and the runtime.
+//! the various heap object types as `i32`/`i64` values suitable for
+//! Cranelift IR emission. `tidepool_heap::layout` defines the same
+//! layout using native Rust types for runtime use — the two modules
+//! must stay in sync.
 
 // --- VMContext field offsets (i32 for Cranelift) ---
 

--- a/tidepool-codegen/src/layout.rs
+++ b/tidepool-codegen/src/layout.rs
@@ -1,0 +1,70 @@
+//! Canonical VMContext and HeapObject layout constants for codegen.
+//!
+//! These constants define the frozen layout of the VMContext struct and
+//! the various heap object types, ensuring consistency between the JIT
+//! and the runtime.
+
+// --- VMContext field offsets (i32 for Cranelift) ---
+
+/// Offset of alloc_ptr within VMContext.
+pub const VMCTX_ALLOC_PTR_OFFSET: i32 = 0;
+/// Offset of alloc_limit within VMContext.
+pub const VMCTX_ALLOC_LIMIT_OFFSET: i32 = 8;
+/// Offset of gc_trigger within VMContext.
+pub const VMCTX_GC_TRIGGER_OFFSET: i32 = 16;
+/// Offset of tail_callee within VMContext.
+pub const VMCTX_TAIL_CALLEE_OFFSET: i32 = 24;
+/// Offset of tail_arg within VMContext.
+pub const VMCTX_TAIL_ARG_OFFSET: i32 = 32;
+
+// --- Heap object tags (u8) ---
+
+pub const TAG_CLOSURE: u8 = 0;
+pub const TAG_THUNK: u8 = 1;
+pub const TAG_CON: u8 = 2;
+pub const TAG_LIT: u8 = 3;
+pub const TAG_FORWARDED: u8 = 0xFF;
+
+// --- Thunk state tags (u8) ---
+
+pub const THUNK_UNEVALUATED: u8 = 0;
+pub const THUNK_BLACKHOLE: u8 = 1;
+pub const THUNK_EVALUATED: u8 = 2;
+
+// --- HeapObject layout constants (i32/u64 for Cranelift and Rust) ---
+
+pub const HEAP_HEADER_SIZE: u64 = 8;
+
+// Closure layout
+pub const CLOSURE_CODE_PTR_OFFSET: i32 = 8;
+pub const CLOSURE_NUM_CAPTURED_OFFSET: i32 = 16;
+pub const CLOSURE_CAPTURED_OFFSET: i32 = 24;
+
+// Con layout
+pub const CON_TAG_OFFSET: i32 = 8;
+pub const CON_NUM_FIELDS_OFFSET: i32 = 16;
+pub const CON_FIELDS_OFFSET: i32 = 24;
+
+// Lit layout
+pub const LIT_TAG_OFFSET: i32 = 8;
+pub const LIT_VALUE_OFFSET: i32 = 16;
+pub const LIT_TOTAL_SIZE: u64 = 24;
+
+// Lit tags (i64 for builder.ins().iconst)
+pub const LIT_TAG_INT: i64 = 0;
+pub const LIT_TAG_WORD: i64 = 1;
+pub const LIT_TAG_CHAR: i64 = 2;
+pub const LIT_TAG_FLOAT: i64 = 3;
+pub const LIT_TAG_DOUBLE: i64 = 4;
+pub const LIT_TAG_STRING: i64 = 5;
+pub const LIT_TAG_ADDR: i64 = 6;
+pub const LIT_TAG_BYTEARRAY: i64 = 7;
+pub const LIT_TAG_SMALLARRAY: i64 = 8;
+pub const LIT_TAG_ARRAY: i64 = 9;
+
+// Thunk layout
+pub const THUNK_STATE_OFFSET: i32 = 8;
+pub const THUNK_CODE_PTR_OFFSET: i32 = 16;
+pub const THUNK_CAPTURED_OFFSET: i32 = 24;
+pub const THUNK_MIN_SIZE: u64 = 24;
+pub const THUNK_INDIRECTION_OFFSET: i32 = 16;

--- a/tidepool-codegen/src/lib.rs
+++ b/tidepool-codegen/src/lib.rs
@@ -13,6 +13,7 @@ pub mod gc;
 pub mod heap_bridge;
 pub mod host_fns;
 pub mod jit_machine;
+pub(crate) mod layout;
 pub mod nursery;
 pub mod pipeline;
 pub mod signal_safety;


### PR DESCRIPTION
This PR centralizes all VMContext and HeapObject layout constants into a new `tidepool-codegen/src/layout.rs` module.

Scattered constant definitions in `alloc.rs`, `emit/mod.rs`, and others have been removed and replaced with imports from the new centralized module. This ensures consistency between the JIT-emitted code and the runtime components within `tidepool-codegen`.

Key changes:
- Created `tidepool-codegen/src/layout.rs` with `VMCTX_*`, `TAG_*`, `CON_*`, `CLOSURE_*`, `LIT_*`, and `THUNK_*` layout constants.
- Updated `alloc.rs`, `context.rs`, `emit/mod.rs`, `emit/expr.rs`, `emit/case.rs`, `heap_bridge.rs`, `host_fns.rs`, `effect_machine.rs`, and `debug.rs` to use these centralized constants.
- Added necessary `as usize` casts where these `i32` offsets are used in Rust pointer arithmetic.
- Verified that no duplicate constant definitions remain in `tidepool-codegen`.
- All workspace tests passed.