### PR TITLE
test: add coverage for shift primops (IntShra, IntShrl, IntShl)

### DIFF
--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -2176,6 +2176,102 @@ mod tests {
     }
 
     #[test]
+    fn test_eval_primop_shifts() {
+        let mut heap = crate::heap::VecHeap::new();
+
+        // IntShra (Arithmetic Right Shift)
+        // 16 >> 2 = 4
+        {
+            let nodes = vec![
+                CoreFrame::Lit(Literal::LitInt(16)),
+                CoreFrame::Lit(Literal::LitInt(2)),
+                CoreFrame::PrimOp {
+                    op: PrimOpKind::IntShra,
+                    args: vec![0, 1],
+                },
+            ];
+            let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
+            if let Value::Lit(Literal::LitInt(n)) = res {
+                assert_eq!(n, 4);
+            } else {
+                panic!("Expected LitInt(4), got {:?}", res);
+            }
+        }
+        // -16 >> 2 = -4 (preserves sign)
+        {
+            let nodes = vec![
+                CoreFrame::Lit(Literal::LitInt(-16)),
+                CoreFrame::Lit(Literal::LitInt(2)),
+                CoreFrame::PrimOp {
+                    op: PrimOpKind::IntShra,
+                    args: vec![0, 1],
+                },
+            ];
+            let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
+            if let Value::Lit(Literal::LitInt(n)) = res {
+                assert_eq!(n, -4);
+            } else {
+                panic!("Expected LitInt(-4), got {:?}", res);
+            }
+        }
+        // 16 >> 0 = 16
+        {
+            let nodes = vec![
+                CoreFrame::Lit(Literal::LitInt(16)),
+                CoreFrame::Lit(Literal::LitInt(0)),
+                CoreFrame::PrimOp {
+                    op: PrimOpKind::IntShra,
+                    args: vec![0, 1],
+                },
+            ];
+            let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
+            if let Value::Lit(Literal::LitInt(n)) = res {
+                assert_eq!(n, 16);
+            } else {
+                panic!("Expected LitInt(16), got {:?}", res);
+            }
+        }
+
+        // IntShrl (Logical Right Shift)
+        // -16 shrl 2 = 4611686018427387900
+        {
+            let nodes = vec![
+                CoreFrame::Lit(Literal::LitInt(-16)),
+                CoreFrame::Lit(Literal::LitInt(2)),
+                CoreFrame::PrimOp {
+                    op: PrimOpKind::IntShrl,
+                    args: vec![0, 1],
+                },
+            ];
+            let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
+            if let Value::Lit(Literal::LitInt(n)) = res {
+                assert_eq!(n, 4611686018427387900);
+            } else {
+                panic!("Expected LitInt(4611686018427387900), got {:?}", res);
+            }
+        }
+
+        // IntShl (Logical Left Shift)
+        // 16 << 2 = 64
+        {
+            let nodes = vec![
+                CoreFrame::Lit(Literal::LitInt(16)),
+                CoreFrame::Lit(Literal::LitInt(2)),
+                CoreFrame::PrimOp {
+                    op: PrimOpKind::IntShl,
+                    args: vec![0, 1],
+                },
+            ];
+            let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
+            if let Value::Lit(Literal::LitInt(n)) = res {
+                assert_eq!(n, 64);
+            } else {
+                panic!("Expected LitInt(64), got {:?}", res);
+            }
+        }
+    }
+
+    #[test]
     fn test_eval_case_data() {
         let nodes = vec![
             CoreFrame::Lit(Literal::LitInt(42)),


### PR DESCRIPTION
This PR addresses Gap #5 from `coverage-gaps.md` by adding comprehensive test coverage for shift primops in `tidepool-eval/src/eval.rs`.

**Changes:**
- Added `test_eval_primop_shifts` which covers:
    - `IntShra` (Arithmetic Right Shift):
        - Positive operands: `16 >> 2 = 4`
        - Negative operands (sign-extending): `-16 >> 2 = -4`
        - Shift by zero: `16 >> 0 = 16`
    - `IntShrl` (Logical Right Shift):
        - Negative operands: `-16 shrl 2 = 4611686018427387900`
    - `IntShl` (Logical Left Shift):
        - `16 << 2 = 64`

Verified that the tests correctly detect a swap between `IntShra` and `IntShl`.
