### PR TITLE
test: add boundary condition test for SubWordCCarry

### DIFF
--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -2176,6 +2176,34 @@ mod tests {
     }
 
     #[test]
+    fn test_eval_prim_sub_word_c_carry() {
+        let cases = vec![
+            (3u64, 5u64, 1), // a < b => 1 (borrow)
+            (5u64, 5u64, 0), // a == b => 0 (no borrow) - the boundary case
+            (7u64, 5u64, 0), // a > b => 0 (no borrow)
+        ];
+
+        for (a, b, expected) in cases {
+            let nodes = vec![
+                CoreFrame::Lit(Literal::LitWord(a)),
+                CoreFrame::Lit(Literal::LitWord(b)),
+                CoreFrame::PrimOp {
+                    op: PrimOpKind::SubWordCCarry,
+                    args: vec![0, 1],
+                },
+            ];
+            let expr = CoreExpr { nodes };
+            let mut heap = crate::heap::VecHeap::new();
+            let res = eval(&expr, &Env::new(), &mut heap).expect(&format!("eval failed for a={}, b={}", a, b));
+            if let Value::Lit(Literal::LitInt(n)) = res {
+                assert_eq!(n, expected, "Failed for a={}, b={}", a, b);
+            } else {
+                panic!("Expected LitInt({}), got {:?}", expected, res);
+            }
+        }
+    }
+
+    #[test]
     fn test_eval_case_data() {
         let nodes = vec![
             CoreFrame::Lit(Literal::LitInt(42)),


### PR DESCRIPTION
This PR adds a new test case `test_eval_prim_sub_word_c_carry` to `tidepool-eval/src/eval.rs` to address coverage gap #6 from `coverage-gaps.md`.

The test verifies the boundary condition for the `SubWordCCarry` primop, specifically ensuring that when `a == b`, the borrow bit is reported as `0` (not `1`).

Cases covered:
1. `a < b` → carry = 1
2. `a == b` → carry = 0 (boundary case)
3. `a > b` → carry = 0

Verified that this test fails if the logic is mutated from `<` to `<=`.