### PR TITLE
feat: add Heap::children_of and test for ThunkRef tracing (Gap #8)

### DIFF
--- a/tidepool-eval/src/heap.rs
+++ b/tidepool-eval/src/heap.rs
@@ -24,6 +24,9 @@ pub trait Heap {
 
     /// Write a new state to a thunk (for force protocol and LetRec back-patching).
     fn write(&mut self, id: ThunkId, state: ThunkState);
+
+    /// Return all ThunkIds directly referenced by this thunk.
+    fn children_of(&self, id: ThunkId) -> Vec<ThunkId>;
 }
 
 /// Simple Vec-backed heap for the interpreter. No GC.
@@ -35,6 +38,18 @@ pub struct VecHeap {
 impl VecHeap {
     pub fn new() -> Self {
         Self { thunks: Vec::new() }
+    }
+
+    fn collect_thunk_refs(val: &Value) -> Vec<ThunkId> {
+        match val {
+            Value::ThunkRef(id) => vec![*id],
+            Value::Con(_, fields) => fields.iter().flat_map(Self::collect_thunk_refs).collect(),
+            Value::ConFun(_, _, args) => args.iter().flat_map(Self::collect_thunk_refs).collect(),
+            Value::Closure(env, _, _) => env.values().flat_map(Self::collect_thunk_refs).collect(),
+            Value::JoinCont(_, _, env) => env.values().flat_map(Self::collect_thunk_refs).collect(),
+            Value::Lit(_) => vec![],
+            Value::ByteArray(_) => vec![],
+        }
     }
 }
 
@@ -51,6 +66,16 @@ impl Heap for VecHeap {
 
     fn write(&mut self, id: ThunkId, state: ThunkState) {
         self.thunks[id.0 as usize] = state;
+    }
+
+    fn children_of(&self, id: ThunkId) -> Vec<ThunkId> {
+        match self.read(id) {
+            ThunkState::Unevaluated(env, _) => {
+                env.values().flat_map(Self::collect_thunk_refs).collect()
+            }
+            ThunkState::BlackHole => vec![],
+            ThunkState::Evaluated(val) => Self::collect_thunk_refs(val),
+        }
     }
 }
 

--- a/tidepool-heap/src/arena.rs
+++ b/tidepool-heap/src/arena.rs
@@ -150,17 +150,6 @@ impl ArenaHeap {
         }
     }
 
-    /// Return all ThunkIds directly referenced by this thunk.
-    pub fn children_of(&self, id: ThunkId) -> Vec<ThunkId> {
-        match self.read(id) {
-            ThunkState::Unevaluated(env, _) => {
-                env.values().flat_map(Self::collect_thunk_refs).collect()
-            }
-            ThunkState::BlackHole => vec![],
-            ThunkState::Evaluated(val) => Self::collect_thunk_refs(val),
-        }
-    }
-
     fn collect_thunk_refs(val: &Value) -> Vec<ThunkId> {
         match val {
             Value::ThunkRef(id) => vec![*id],
@@ -193,6 +182,16 @@ impl Heap for ArenaHeap {
 
     fn write(&mut self, id: ThunkId, state: ThunkState) {
         self.thunks[id.0 as usize] = state;
+    }
+
+    fn children_of(&self, id: ThunkId) -> Vec<ThunkId> {
+        match self.read(id) {
+            ThunkState::Unevaluated(env, _) => {
+                env.values().flat_map(Self::collect_thunk_refs).collect()
+            }
+            ThunkState::BlackHole => vec![],
+            ThunkState::Evaluated(val) => Self::collect_thunk_refs(val),
+        }
     }
 }
 

--- a/tidepool-heap/src/gc/trace.rs
+++ b/tidepool-heap/src/gc/trace.rs
@@ -1,9 +1,8 @@
 use std::collections::VecDeque;
 use std::error::Error;
 use std::fmt;
-use tidepool_eval::env::Env;
-use tidepool_eval::heap::{Heap, ThunkState};
-use tidepool_eval::value::{ThunkId, Value};
+use tidepool_eval::heap::Heap;
+use tidepool_eval::value::ThunkId;
 
 /// Error during garbage collection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,9 +64,6 @@ pub fn trace(roots: &[ThunkId], heap: &dyn Heap) -> ForwardingTable {
             continue;
         }
 
-        // Validate the ID before potentially large resize to prevent OOM/DoS
-        let state = heap.read(old_id);
-
         if idx >= mapping.len() {
             mapping.resize(idx + 1, None);
         }
@@ -75,56 +71,20 @@ pub fn trace(roots: &[ThunkId], heap: &dyn Heap) -> ForwardingTable {
         mapping[idx] = Some(ThunkId(next_new_id));
         next_new_id += 1;
 
-        match state {
-            ThunkState::Unevaluated(env, _) => {
-                scan_env(env, &mut queue);
-            }
-            ThunkState::BlackHole => {}
-            ThunkState::Evaluated(val) => {
-                scan_value(val, &mut queue);
-            }
+        for child_id in heap.children_of(old_id) {
+            queue.push_back(child_id);
         }
     }
 
     ForwardingTable { mapping }
 }
 
-fn scan_value(val: &Value, queue: &mut VecDeque<ThunkId>) {
-    match val {
-        Value::Lit(_) => {}
-        Value::Con(_, fields) => {
-            for field in fields {
-                scan_value(field, queue);
-            }
-        }
-        Value::ConFun(_, _, args) => {
-            for arg in args {
-                scan_value(arg, queue);
-            }
-        }
-        Value::Closure(env, _, _) => {
-            scan_env(env, queue);
-        }
-        Value::ThunkRef(id) => {
-            queue.push_back(*id);
-        }
-        Value::JoinCont(_, _, env) => {
-            scan_env(env, queue);
-        }
-        Value::ByteArray(_) => {}
-    }
-}
-
-fn scan_env(env: &Env, queue: &mut VecDeque<ThunkId>) {
-    for val in env.values() {
-        scan_value(val, queue);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tidepool_eval::heap::VecHeap;
+    use tidepool_eval::env::Env;
+    use tidepool_eval::heap::{ThunkState, VecHeap};
+    use tidepool_eval::value::Value;
     use tidepool_repr::{CoreFrame, DataConId, Literal, RecursiveTree, VarId};
 
     fn empty_expr() -> tidepool_repr::CoreExpr {

--- a/tidepool-heap/tests/gc_unit.rs
+++ b/tidepool-heap/tests/gc_unit.rs
@@ -81,3 +81,48 @@ fn test_thunk_state_machine() {
         assert_eq!(*(ptr.add(THUNK_STATE_OFFSET)), THUNK_EVALUATED);
     }
 }
+
+#[test]
+fn test_gc_thunkref_tracing() {
+    use tidepool_heap::ArenaHeap;
+    use tidepool_eval::{Heap, ThunkState};
+    use tidepool_eval::value::Value;
+    use tidepool_repr::{CoreFrame, Literal, RecursiveTree, VarId};
+    use tidepool_eval::env::Env;
+
+    let mut heap = ArenaHeap::new();
+    let env = Env::new();
+    let expr = RecursiveTree {
+        nodes: vec![CoreFrame::Var(VarId(0))],
+    };
+
+    // 1. Allocate thunk B, evaluate it to Value::Lit(LitInt(99))
+    let id_b = heap.alloc(env.clone(), expr.clone());
+    heap.write(id_b, ThunkState::Evaluated(Value::Lit(Literal::LitInt(99))));
+
+    // 2. Allocate thunk A, evaluate it to Value::ThunkRef(B) — A's value points to B
+    let id_a = heap.alloc(env.clone(), expr.clone());
+    heap.write(id_a, ThunkState::Evaluated(Value::ThunkRef(id_b)));
+
+    // 3. Keep only thunk A as a GC root (do NOT keep B as a direct root)
+    let table = heap.collect_garbage(&[id_a]);
+
+    // 4. After GC, assert that B is still alive (can be read) and contains Evaluated(LitInt(99))
+    let new_id_a = table.lookup(id_a).expect("Thunk A should be alive");
+    
+    // Check what id_a points to now
+    let new_id_b = match heap.read(new_id_a) {
+        ThunkState::Evaluated(Value::ThunkRef(id)) => *id,
+        _ => panic!("Expected Thunk A to be Evaluated(ThunkRef(_))"),
+    };
+
+    // Assert id_b survived and has correct value
+    match heap.read(new_id_b) {
+        ThunkState::Evaluated(Value::Lit(Literal::LitInt(99))) => (),
+        other => panic!("Expected Thunk B to be Evaluated(LitInt(99)), got {:?}", other),
+    }
+
+    // Also verify B is in the forwarding table
+    assert!(table.lookup(id_b).is_ok(), "Thunk B should be in forwarding table");
+    assert_eq!(table.lookup(id_b).unwrap(), new_id_b);
+}


### PR DESCRIPTION
This PR addresses Gap #8: "GC drops ThunkRef tracing — arena.rs:166" in `tidepool-heap`.

Changes:
1.  **Refactored GC Tracing**: Added `children_of` method to the `Heap` trait in `tidepool-eval` and implemented it for `VecHeap` and `ArenaHeap`.
2.  **Deduplicated Logic**: Refactored `trace::trace` in `tidepool-heap` to use `heap.children_of(id)`, removing the duplicated `scan_value`/`scan_env` logic.
3.  **Added Unit Test**: Added `test_gc_thunkref_tracing` to `tidepool-heap/tests/gc_unit.rs` which verifies that a thunk reachable only through another thunk's evaluated value survives GC.

The test was verified to fail when the `ThunkRef` tracing logic was intentionally broken.
All existing tests in `tidepool-heap` pass.