### PR TITLE
test: add explicit test for lambda shadowing in substitution

### DIFF
--- a/tidepool-repr/src/subst.rs
+++ b/tidepool-repr/src/subst.rs
@@ -689,4 +689,34 @@ mod tests {
             panic!("Result should be Join");
         }
     }
+
+    #[test]
+    fn test_subst_lambda_shadow_exact() {
+        let x = VarId(1);
+        let y = VarId(2);
+        // \x -> x
+        let tree = RecursiveTree {
+            nodes: vec![
+                CoreFrame::Var(x),                     // 0
+                CoreFrame::Lam { binder: x, body: 0 }, // 1
+            ],
+        };
+        // Var(y)
+        let replacement = leaf(CoreFrame::Var(y));
+
+        let result = subst(&tree, x, &replacement);
+
+        // Result should be \x -> x (shadowed)
+        assert_eq!(result.nodes.len(), 2);
+        if let CoreFrame::Lam { binder, body } = &result.nodes[1] {
+            assert_eq!(*binder, x);
+            if let CoreFrame::Var(v) = &result.nodes[*body] {
+                assert_eq!(*v, x, "Shadowed variable should not be substituted");
+            } else {
+                panic!("Body should be Var(x)");
+            }
+        } else {
+            panic!("Result should be Lam");
+        }
+    }
 }


### PR DESCRIPTION
This PR addresses coverage gap #1 identified in `coverage-gaps.md`.

Added `test_subst_lambda_shadow_exact` to `tidepool-repr/src/subst.rs` to specifically verify that when a lambda binder equals the substitution target, substitution does NOT proceed into the body.

Verified that:
1. The new test passes on the current codebase.
2. The new test fails if the shadowing check at `tidepool-repr/src/subst.rs:97` is flipped (`==` to `!=`).

The test constructs `\x -> x` and attempts to substitute `x` with `y`. It asserts that the result is still `\x -> x` due to shadowing.