### PR TITLE
test: verify nursery growth threshold (gap #9)

### DIFF
--- a/tidepool-heap/src/arena.rs
+++ b/tidepool-heap/src/arena.rs
@@ -389,6 +389,49 @@ mod tests {
     }
 
     #[test]
+    fn test_nursery_growth_threshold() {
+        let mut heap = ArenaHeap::with_capacity(1024 * 1024); // 1MB
+        let env = Env::new();
+        let expr = RecursiveTree {
+            nodes: vec![CoreFrame::Var(VarId(0))],
+        };
+        let thunk_size = std::mem::size_of::<ThunkState>();
+
+        // 1. Fill to ~60% (between 50% and 75% threshold).
+        // If the threshold was mutated to 50%, this would grow.
+        let count_60pct = (1024 * 1024 * 6 / 10) / thunk_size;
+        let mut roots = Vec::new();
+        for _ in 0..count_60pct {
+            roots.push(heap.alloc(env.clone(), expr.clone()));
+        }
+
+        heap.collect_garbage(&roots);
+
+        // Should NOT have grown (75% threshold not reached).
+        assert_eq!(
+            heap.nursery_limit(),
+            1024 * 1024,
+            "Nursery should not grow at 60% utilization (threshold is 75%)"
+        );
+
+        // 2. Fill past 75% (e.g. to 80%).
+        let count_80pct = (1024 * 1024 * 8 / 10) / thunk_size;
+        // We already have count_60pct roots, add more to reach 80%.
+        for _ in 0..(count_80pct - count_60pct) {
+            roots.push(heap.alloc(env.clone(), expr.clone()));
+        }
+
+        heap.collect_garbage(&roots);
+
+        // SHOULD have grown to 2MB.
+        assert_eq!(
+            heap.nursery_limit(),
+            2 * 1024 * 1024,
+            "Nursery should grow at 80% utilization"
+        );
+    }
+
+    #[test]
     fn test_nursery_cap() {
         let mut heap = ArenaHeap::with_capacity(MAX_NURSERY_SIZE - 1024);
 


### PR DESCRIPTION
This PR adds a test case to `tidepool-heap/src/arena.rs` to verify the nursery growth heuristic, specifically addressing coverage gap #9 (misidentified as #8 in the file but #9 in the request).

The test `test_nursery_growth_threshold`:
1. Fills the nursery to ~60% (between 50% and 75%).
2. Verifies it does NOT grow (catching the mutation where threshold is lowered to 1/2).
3. Fills it to ~80%.
4. Verifies it DOES grow.

Verified that the test fails if the threshold is mutated to `1/2` and passes with the current `3/4`.