### PR TITLE
fix: remove incorrect wasm category from Cargo.toml

### DIFF
--- a/tidepool/Cargo.toml
+++ b/tidepool/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 description = "Compile Haskell effect stacks to Cranelift JIT, drive from Rust"
 readme = "../README.md"
 keywords = ["haskell", "jit", "cranelift", "effects", "compiler"]
-categories = ["compilers", "wasm"]
+categories = ["compilers"]
 
 [[bin]]
 name = "tidepool"


### PR DESCRIPTION
## Summary
- Remove `wasm` from `categories` in `tidepool/Cargo.toml` — tidepool is not a wasm project

## Verify
```
cargo check -p tidepool
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)