### PR TITLE
refactor: make ConTags non-optional in JitEffectMachine

### DIFF
--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -77,7 +77,7 @@ impl From<crate::pipeline::PipelineError> for JitError {
 pub struct JitEffectMachine {
     pipeline: CodegenPipeline,
     nursery: Nursery,
-    tags: Option<ConTags>,
+    tags: ConTags,
     func_id: FuncId,
 }
 
@@ -105,7 +105,7 @@ impl JitEffectMachine {
             .map_err(JitError::Compilation)?;
         pipeline.finalize()?;
 
-        let tags = ConTags::from_table(table);
+        let tags = ConTags::from_table(table).ok_or(JitError::MissingConTags)?;
         let nursery = Nursery::new(nursery_size);
 
         Ok(Self {
@@ -123,7 +123,7 @@ impl JitEffectMachine {
         handlers: &mut H,
         user: &U,
     ) -> Result<Value, JitError> {
-        let tags = self.tags.ok_or(JitError::MissingConTags)?;
+        let tags = self.tags;
 
         // Install registries
         crate::debug::set_lambda_registry(self.pipeline.build_lambda_registry());

--- a/tidepool-codegen/tests/gc_frame_walker.rs
+++ b/tidepool-codegen/tests/gc_frame_walker.rs
@@ -27,6 +27,22 @@ fn make_table_with_con(id: DataConId, arity: u32) -> DataConTable {
         field_bangs: vec![],
         qualified_name: None,
     });
+    // Add required freer-simple tags for JitEffectMachine::compile
+    use tidepool_codegen::effect_machine::EffContKind;
+    for (i, kind) in EffContKind::ALL.iter().enumerate() {
+        table.insert(tidepool_repr::datacon::DataCon {
+            id: DataConId(1000 + i as u64),
+            name: kind.name().to_string(),
+            tag: (1000 + i) as u32,
+            rep_arity: if matches!(kind, EffContKind::Node | EffContKind::Union) {
+                2
+            } else {
+                1
+            },
+            field_bangs: vec![],
+            qualified_name: None,
+        });
+    }
     table
 }
 

--- a/tidepool-codegen/tests/tco.rs
+++ b/tidepool-codegen/tests/tco.rs
@@ -19,7 +19,24 @@ fn assert_lit_int(val: &Value, expected: i64) {
 }
 
 fn empty_table() -> DataConTable {
-    DataConTable::new()
+    let mut table = DataConTable::new();
+    // Add required freer-simple tags for JitEffectMachine::compile
+    use tidepool_codegen::effect_machine::EffContKind;
+    for (i, kind) in EffContKind::ALL.iter().enumerate() {
+        table.insert(tidepool_repr::datacon::DataCon {
+            id: DataConId(1000 + i as u64),
+            name: kind.name().to_string(),
+            tag: (1000 + i) as u32,
+            rep_arity: if matches!(kind, EffContKind::Node | EffContKind::Union) {
+                2
+            } else {
+                1
+            },
+            field_bangs: vec![],
+            qualified_name: None,
+        });
+    }
+    table
 }
 
 /// Build: `let go = \n -> case n ==# 0# of { 1# -> Lit(result); _ -> go (n -# 1#) } in go N`

--- a/tidepool-codegen/tests/tco_advanced.rs
+++ b/tidepool-codegen/tests/tco_advanced.rs
@@ -13,7 +13,24 @@ fn assert_lit_int(val: &Value, expected: i64) {
 }
 
 fn empty_table() -> DataConTable {
-    DataConTable::new()
+    let mut table = DataConTable::new();
+    // Add required freer-simple tags for JitEffectMachine::compile
+    use tidepool_codegen::effect_machine::EffContKind;
+    for (i, kind) in EffContKind::ALL.iter().enumerate() {
+        table.insert(tidepool_repr::datacon::DataCon {
+            id: DataConId(1000 + i as u64),
+            name: kind.name().to_string(),
+            tag: (1000 + i) as u32,
+            rep_arity: if matches!(kind, EffContKind::Node | EffContKind::Union) {
+                2
+            } else {
+                1
+            },
+            field_bangs: vec![],
+            qualified_name: None,
+        });
+    }
+    table
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Change `tags: Option<ConTags>` → `tags: ConTags` in `JitEffectMachine`
- Fail at compile time (`compile()`) if freer-simple constructors are missing, not at run time
- Parse-don't-validate: invalid state is now unrepresentable

## Verify
```
cargo test -p tidepool-codegen
cargo check --workspace
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)