### PR TITLE
fix: remove incorrect wasm category from tidepool package

### DIFF
--- a/tidepool/Cargo.toml
+++ b/tidepool/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 description = "Compile Haskell effect stacks to Cranelift JIT, drive from Rust"
 readme = "../README.md"
 keywords = ["haskell", "jit", "cranelift", "effects", "compiler"]
-categories = ["compilers", "wasm"]
+categories = ["compilers"]
 
 [[bin]]
 name = "tidepool"


### PR DESCRIPTION
Corrected the categories field in tidepool/Cargo.toml to remove wasm, as this package is a compiler and not specifically a WASM component. Verified with cargo check -p tidepool.