### PR TITLE
docs: fix inconsistencies and update crate descriptions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Tidepool transforms `freer-simple` continuations into a state machine:
 ## Crate Responsibilities
 
 - **`tidepool-repr`**: Defines the Core IR, `Value` types, and handles CBOR serialization/deserialization.
-- **`tidepool-eval`**: A tree-walking interpreter used for constant folding and simple evaluation without the overhead of JIT.
+- **`tidepool-eval`**: A tree-walking interpreter for evaluating Core expressions without JIT overhead, used for testing and as a reference implementation.
 - **`tidepool-heap`**: Implements the manual memory layout (raw byte buffers) and the copying garbage collector used by the JIT runtime.
 - **`tidepool-optimize`**: Contains optimization passes like beta reduction, dead code elimination (DCE), inlining, and case reduction.
 - **`tidepool-codegen`**: The Cranelift-based compiler that generates native code and manages the `JitEffectMachine` lifecycle.
@@ -38,6 +38,7 @@ Tidepool transforms `freer-simple` continuations into a state machine:
 - **`tidepool-effect`**: Core traits and logic for effect dispatch and handling (`EffectHandler`, `DispatchEffect`).
 - **`tidepool-macro`**: Procedural macros for inlining Haskell code directly into Rust using `haskell_inline!`.
 - **`tidepool-bridge`**: Provides `FromCore` and `ToCore` traits for seamless data conversion between Rust types and Tidepool `Value`s.
+- **`tidepool-bridge-derive`**: Procedural macro crate providing `#[derive(FromCore)]` and `#[derive(ToCore)]`.
 - **`tidepool-testing`**: Internal utilities and property-based generators for testing the compiler and runtime.
 
 ## Data Flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,8 +131,6 @@ tidepool/
 │   └── tide/              ← Demo: REPL
 ├── haskell/               ← Haskell harness (tidepool-extract) + test suite + stdlib
 │   └── lib/Tidepool/      ← Haskell stdlib (auto-imported in MCP)
-├── tools/
-│   └── mcp-wrapper.py     ← MCP stdio proxy with __mcp_restart tool
 ├── flake.nix              ← Dev shell (Rust + GHC 9.12 with fat interfaces)
 └── CLAUDE.md              ← YOU ARE HERE
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,6 @@ cargo install --path tidepool
 tidepool # Communicates via JSON-RPC over stdio
 ```
 
-You can use the `tools/mcp-wrapper.py` script to add hot-restarting capabilities for your MCP client.
-
 ## Adding New Effects
 
 Adding an effect involves changes in both Haskell and Rust:
@@ -52,12 +50,12 @@ When adding or modifying functions in `haskell/lib/Tidepool/Prelude.hs`, keep th
 
 - **Monomorphization**: Polymorphic base functions that use typeclass dictionaries often crash when JIT-compiled because error branches in dictionaries are eagerly evaluated.
 - **Shadowing**: Shadow polymorphic base functions with monomorphic versions that use primops directly (e.g., use `rem` instead of the `Integral` typeclass version).
-- **Avoid Dictionary-Heavy Functions**: Avoid functions like `maximum` or `minimum` from `base`. Implement them manually using `foldl'` and direct comparison.
+- **Avoid Dictionary-Heavy Functions**: Functions like `sum`, `product`, `maximum`, and `minimum` now work via lazy poison closures.
 
 ## Testing Approach
 
 - **Rust Tests**: Use unit tests and integration tests in the `tests/` directory of each crate.
-- **Haskell Integration Tests**: Add test cases to `haskell/test/Suite.hs`. These tests are run by the `tidepool-harness` to ensure correctness across the Haskell/Rust boundary.
+- **Haskell Integration Tests**: Add test cases to `haskell/test/Suite.hs`. These tests are compiled to CBOR fixtures and verified by integration tests in `tidepool-eval/tests/haskell_suite.rs`.
 - **Property-Based Testing**: Use `proptest` for complex logic like the bridge conversion and the JIT machine state transitions.
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -52,19 +52,6 @@ The `tidepool` binary is an [MCP](https://modelcontextprotocol.io/) server that 
 }
 ```
 
-You can also use `mcp-wrapper.py` (from the repo) to add a `__mcp_restart` tool for hot-restarting the server:
-
-```json
-{
-  "mcpServers": {
-    "tidepool": {
-      "command": "python3",
-      "args": ["/path/to/tidepool/tools/mcp-wrapper.py", "tidepool"]
-    }
-  }
-}
-```
-
 **Environment variables:**
 - `TIDEPOOL_EXTRACT` — path to the `tidepool-extract` binary (falls back to `tidepool-extract` on `$PATH`)
 - `TIDEPOOL_PRELUDE_DIR` — override the Haskell stdlib location (normally embedded in the binary)


### PR DESCRIPTION
This PR addresses documentation inconsistencies and updates several descriptions:
- Removed references to the defunct `mcp-wrapper.py` and `tidepool-harness`.
- Updated `tidepool-eval` and `tidepool-bridge-derive` crate descriptions.
- Updated Haskell implementation guidelines regarding `maximum`/`minimum` and lazy poison closures.
- Updated testing section to reflect the use of CBOR fixtures and `tidepool-eval` integration tests.