### PR TITLE
refactor: delete dead-code EnvGuard struct and impls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Tidepool transforms `freer-simple` continuations into a state machine:
 ## Crate Responsibilities
 
 - **`tidepool-repr`**: Defines the Core IR, `Value` types, and handles CBOR serialization/deserialization.
-- **`tidepool-eval`**: A tree-walking interpreter used for constant folding and simple evaluation without the overhead of JIT.
+- **`tidepool-eval`**: A tree-walking interpreter for evaluating Core expressions without JIT overhead, used for testing and as a reference implementation.
 - **`tidepool-heap`**: Implements the manual memory layout (raw byte buffers) and the copying garbage collector used by the JIT runtime.
 - **`tidepool-optimize`**: Contains optimization passes like beta reduction, dead code elimination (DCE), inlining, and case reduction.
 - **`tidepool-codegen`**: The Cranelift-based compiler that generates native code and manages the `JitEffectMachine` lifecycle.
@@ -38,6 +38,7 @@ Tidepool transforms `freer-simple` continuations into a state machine:
 - **`tidepool-effect`**: Core traits and logic for effect dispatch and handling (`EffectHandler`, `DispatchEffect`).
 - **`tidepool-macro`**: Procedural macros for inlining Haskell code directly into Rust using `haskell_inline!`.
 - **`tidepool-bridge`**: Provides `FromCore` and `ToCore` traits for seamless data conversion between Rust types and Tidepool `Value`s.
+- **`tidepool-bridge-derive`**: Procedural macro crate providing `#[derive(FromCore)]` and `#[derive(ToCore)]`.
 - **`tidepool-testing`**: Internal utilities and property-based generators for testing the compiler and runtime.
 
 ## Data Flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,8 +131,6 @@ tidepool/
 │   └── tide/              ← Demo: REPL
 ├── haskell/               ← Haskell harness (tidepool-extract) + test suite + stdlib
 │   └── lib/Tidepool/      ← Haskell stdlib (auto-imported in MCP)
-├── tools/
-│   └── mcp-wrapper.py     ← MCP stdio proxy with __mcp_restart tool
 ├── flake.nix              ← Dev shell (Rust + GHC 9.12 with fat interfaces)
 └── CLAUDE.md              ← YOU ARE HERE
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,6 @@ cargo install --path tidepool
 tidepool # Communicates via JSON-RPC over stdio
 ```
 
-You can use the `tools/mcp-wrapper.py` script to add hot-restarting capabilities for your MCP client.
-
 ## Adding New Effects
 
 Adding an effect involves changes in both Haskell and Rust:
@@ -52,12 +50,12 @@ When adding or modifying functions in `haskell/lib/Tidepool/Prelude.hs`, keep th
 
 - **Monomorphization**: Polymorphic base functions that use typeclass dictionaries often crash when JIT-compiled because error branches in dictionaries are eagerly evaluated.
 - **Shadowing**: Shadow polymorphic base functions with monomorphic versions that use primops directly (e.g., use `rem` instead of the `Integral` typeclass version).
-- **Avoid Dictionary-Heavy Functions**: Avoid functions like `maximum` or `minimum` from `base`. Implement them manually using `foldl'` and direct comparison.
+- **Avoid Dictionary-Heavy Functions**: Functions like `sum`, `product`, `maximum`, and `minimum` now work via lazy poison closures.
 
 ## Testing Approach
 
 - **Rust Tests**: Use unit tests and integration tests in the `tests/` directory of each crate.
-- **Haskell Integration Tests**: Add test cases to `haskell/test/Suite.hs`. These tests are run by the `tidepool-harness` to ensure correctness across the Haskell/Rust boundary.
+- **Haskell Integration Tests**: Add test cases to `haskell/test/Suite.hs`. These tests are compiled to CBOR fixtures and verified by integration tests in `tidepool-eval/tests/haskell_suite.rs`.
 - **Property-Based Testing**: Use `proptest` for complex logic like the bridge conversion and the JIT machine state transitions.
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -52,19 +52,6 @@ The `tidepool` binary is an [MCP](https://modelcontextprotocol.io/) server that 
 }
 ```
 
-You can also use `mcp-wrapper.py` (from the repo) to add a `__mcp_restart` tool for hot-restarting the server:
-
-```json
-{
-  "mcpServers": {
-    "tidepool": {
-      "command": "python3",
-      "args": ["/path/to/tidepool/tools/mcp-wrapper.py", "tidepool"]
-    }
-  }
-}
-```
-
 **Environment variables:**
 - `TIDEPOOL_EXTRACT` — path to the `tidepool-extract` binary (falls back to `tidepool-extract` on `$PATH`)
 - `TIDEPOOL_PRELUDE_DIR` — override the Haskell stdlib location (normally embedded in the binary)

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -85,6 +85,30 @@ pub struct CompiledEffectMachine {
 unsafe impl Send for CompiledEffectMachine {}
 
 impl CompiledEffectMachine {
+    /// Read the constructor tag from a Con heap object.
+    ///
+    /// # Safety
+    /// `ptr` must point to a valid Con heap object (tag byte == TAG_CON).
+    unsafe fn read_con_tag(ptr: *const u8) -> u64 {
+        *(ptr.add(layout::CON_TAG_OFFSET as usize) as *const u64)
+    }
+
+    /// Read the number of fields from a Con heap object.
+    ///
+    /// # Safety
+    /// `ptr` must point to a valid Con heap object.
+    unsafe fn read_con_num_fields(ptr: *const u8) -> u16 {
+        *(ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16)
+    }
+
+    /// Read a field pointer from a Con heap object by index.
+    ///
+    /// # Safety
+    /// `ptr` must point to a valid Con heap object with at least `index + 1` fields.
+    unsafe fn read_con_field(ptr: *const u8, index: usize) -> *mut u8 {
+        *(ptr.add(layout::CON_FIELDS_OFFSET as usize + 8 * index) as *const *mut u8)
+    }
+
     pub fn new(
         func_ptr: unsafe extern "C" fn(*mut VMContext) -> *mut u8,
         vmctx: VMContext,
@@ -151,31 +175,26 @@ impl CompiledEffectMachine {
             return Yield::Error(YieldError::UnexpectedTag(tag));
         }
 
-        let con_tag = unsafe { *(result.add(layout::CON_TAG_OFFSET as usize) as *const u64) };
+        let con_tag = unsafe { Self::read_con_tag(result) };
 
         if con_tag == self.tags.val {
             // Val(value) — extract value from fields[0]
-            let num_fields =
-                unsafe { *(result.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) };
+            let num_fields = unsafe { Self::read_con_num_fields(result) };
             if num_fields < 1 {
                 return Yield::Error(YieldError::BadValFields(num_fields));
             }
-            let value =
-                unsafe { *(result.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) };
+            let value = unsafe { Self::read_con_field(result, 0) };
             // Force value field — it may be a thunk
             let value = self.force_ptr(value);
             Yield::Done(value)
         } else if con_tag == self.tags.e {
             // E(union, continuation) — extract Union and k
-            let num_fields =
-                unsafe { *(result.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) };
+            let num_fields = unsafe { Self::read_con_num_fields(result) };
             if num_fields != 2 {
                 return Yield::Error(YieldError::BadEFields(num_fields));
             }
-            let mut union_ptr =
-                unsafe { *(result.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) };
-            let mut continuation =
-                unsafe { *(result.add(layout::CON_FIELDS_OFFSET as usize + 8) as *const *mut u8) };
+            let mut union_ptr = unsafe { Self::read_con_field(result, 0) };
+            let mut continuation = unsafe { Self::read_con_field(result, 1) };
 
             // Force all field pointers — they may be thunks from lazy Con fields
             union_ptr = self.force_ptr(union_ptr);
@@ -192,14 +211,12 @@ impl CompiledEffectMachine {
                 return Yield::Error(YieldError::UnexpectedTag(union_tag));
             }
 
-            let union_num_fields =
-                unsafe { *(union_ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *const u16) };
+            let union_num_fields = unsafe { Self::read_con_num_fields(union_ptr) };
             if union_num_fields != 2 {
                 return Yield::Error(YieldError::BadUnionFields(union_num_fields));
             }
 
-            let tag_ptr =
-                unsafe { *(union_ptr.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8) };
+            let tag_ptr = unsafe { Self::read_con_field(union_ptr, 0) };
             let tag_ptr = self.force_ptr(tag_ptr);
             if tag_ptr.is_null() {
                 return Yield::Error(YieldError::NullPointer);
@@ -208,9 +225,7 @@ impl CompiledEffectMachine {
             let tag_ptr_tag = unsafe { *tag_ptr };
             let effect_tag =
                 unsafe { *(tag_ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const u64) };
-            let mut request = unsafe {
-                *(union_ptr.add(layout::CON_FIELDS_OFFSET as usize + 8) as *const *mut u8)
-            };
+            let mut request = unsafe { Self::read_con_field(union_ptr, 1) };
             request = self.force_ptr(request);
 
             if std::env::var("TIDEPOOL_TRACE_EFFECTS").is_ok() {
@@ -218,7 +233,7 @@ impl CompiledEffectMachine {
                     "[effect_machine] effect_tag={} tag_ptr_tag={} union_con_tag={} request_tag={}",
                     effect_tag,
                     tag_ptr_tag,
-                    unsafe { *(union_ptr.add(layout::CON_TAG_OFFSET as usize) as *const u64) },
+                    unsafe { Self::read_con_tag(union_ptr) },
                     if request.is_null() {
                         255
                     } else {
@@ -283,22 +298,16 @@ impl CompiledEffectMachine {
         let tag = *k;
         match tag {
             t if t == layout::TAG_CON => {
-                let con_tag = unsafe { *(k.add(layout::CON_TAG_OFFSET as usize) as *const u64) };
+                let con_tag = unsafe { Self::read_con_tag(k) };
 
                 if con_tag == self.tags.leaf {
                     // Leaf(f) — extract closure f at field[0], call f(arg)
-                    let f = self.force_ptr(unsafe {
-                        *(k.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8)
-                    });
+                    let f = self.force_ptr(unsafe { Self::read_con_field(k, 0) });
                     self.call_closure(f, arg)
                 } else if con_tag == self.tags.node {
                     // Node(k1, k2) — apply k1 to arg, then compose with k2
-                    let k1 = self.force_ptr(unsafe {
-                        *(k.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8)
-                    });
-                    let k2 = self.force_ptr(unsafe {
-                        *(k.add(layout::CON_FIELDS_OFFSET as usize + 8) as *const *mut u8)
-                    });
+                    let k1 = self.force_ptr(unsafe { Self::read_con_field(k, 0) });
+                    let k2 = self.force_ptr(unsafe { Self::read_con_field(k, 1) });
 
                     let result = self.apply_cont_heap(k1, arg);
                     if result.is_null() {
@@ -317,23 +326,16 @@ impl CompiledEffectMachine {
                         return std::ptr::null_mut();
                     }
 
-                    let result_con_tag =
-                        unsafe { *(result.add(layout::CON_TAG_OFFSET as usize) as *const u64) };
+                    let result_con_tag = unsafe { Self::read_con_tag(result) };
 
                     if result_con_tag == self.tags.val {
                         // Val(y) — extract y, apply k2(y)
-                        let y = self.force_ptr(unsafe {
-                            *(result.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8)
-                        });
+                        let y = self.force_ptr(unsafe { Self::read_con_field(result, 0) });
                         self.apply_cont_heap(k2, y)
                     } else if result_con_tag == self.tags.e {
                         // E(union, k') — compose: E(union, Node(k', k2))
-                        let union_val = self.force_ptr(unsafe {
-                            *(result.add(layout::CON_FIELDS_OFFSET as usize) as *const *mut u8)
-                        });
-                        let k_prime = self.force_ptr(unsafe {
-                            *(result.add(layout::CON_FIELDS_OFFSET as usize + 8) as *const *mut u8)
-                        });
+                        let union_val = self.force_ptr(unsafe { Self::read_con_field(result, 0) });
+                        let k_prime = self.force_ptr(unsafe { Self::read_con_field(result, 1) });
 
                         // Allocate Node(k', k2)
                         let new_node = self.alloc_con(self.tags.node, &[k_prime, k2]);

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -4,6 +4,38 @@ use crate::layout;
 use crate::yield_type::{Yield, YieldError};
 use tidepool_heap::layout as heap_layout;
 
+/// The five freer-simple continuation constructors that the effect machine must resolve.
+#[derive(Debug, Clone, Copy)]
+pub enum EffContKind {
+    Val,
+    E,
+    Union,
+    Leaf,
+    Node,
+}
+
+impl EffContKind {
+    /// The constructor name as it appears in the DataConTable.
+    pub fn name(self) -> &'static str {
+        match self {
+            EffContKind::Val => "Val",
+            EffContKind::E => "E",
+            EffContKind::Union => "Union",
+            EffContKind::Leaf => "Leaf",
+            EffContKind::Node => "Node",
+        }
+    }
+
+    /// All variants in registration order.
+    pub const ALL: [EffContKind; 5] = [
+        EffContKind::Val,
+        EffContKind::E,
+        EffContKind::Union,
+        EffContKind::Leaf,
+        EffContKind::Node,
+    ];
+}
+
 /// Constructor tags for the freer-simple Eff type.
 ///
 /// These identify which DataCon a heap-allocated constructor represents,
@@ -24,14 +56,13 @@ pub struct ConTags {
 }
 
 impl ConTags {
-    /// Resolve freer-simple constructor tags from a DataConTable.
     pub fn from_table(table: &tidepool_repr::DataConTable) -> Option<Self> {
         Some(ConTags {
-            val: table.get_by_name("Val")?.0,
-            e: table.get_by_name("E")?.0,
-            union: table.get_by_name("Union")?.0,
-            leaf: table.get_by_name("Leaf")?.0,
-            node: table.get_by_name("Node")?.0,
+            val: table.get_by_name(EffContKind::Val.name())?.0,
+            e: table.get_by_name(EffContKind::E.name())?.0,
+            union: table.get_by_name(EffContKind::Union.name())?.0,
+            leaf: table.get_by_name(EffContKind::Leaf.name())?.0,
+            node: table.get_by_name(EffContKind::Node.name())?.0,
         })
     }
 }

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -128,39 +128,6 @@ impl Default for EnvScope {
     }
 }
 
-/// RAII guard that automatically restores environment bindings when dropped.
-///
-/// Note: Due to borrow checker constraints, this cannot be used where the
-/// parent `EmitContext` needs to be used (e.g., in `emit_node` calls) since it
-/// mutably borrows `ctx.env`. It is primarily for use in future refactorings
-/// that split `EmitContext` or in simple leaf functions.
-#[allow(dead_code)]
-pub(crate) struct EnvGuard<'a> {
-    env: &'a mut ScopedEnv,
-    scope: EnvScope,
-}
-
-#[allow(dead_code)]
-impl<'a> EnvGuard<'a> {
-    pub fn new(env: &'a mut ScopedEnv) -> Self {
-        Self {
-            env,
-            scope: EnvScope::new(),
-        }
-    }
-
-    pub fn insert(&mut self, var: VarId, val: SsaVal) {
-        self.env.insert_scoped(&mut self.scope, var, val);
-    }
-}
-
-impl<'a> Drop for EnvGuard<'a> {
-    fn drop(&mut self) {
-        let scope = std::mem::take(&mut self.scope);
-        self.env.restore_scope(scope);
-    }
-}
-
 /// Emission context — bundles state during IR generation for one function.
 pub struct EmitContext {
     pub env: ScopedEnv,

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -77,7 +77,7 @@ impl From<crate::pipeline::PipelineError> for JitError {
 pub struct JitEffectMachine {
     pipeline: CodegenPipeline,
     nursery: Nursery,
-    tags: Option<ConTags>,
+    tags: ConTags,
     func_id: FuncId,
 }
 
@@ -105,7 +105,7 @@ impl JitEffectMachine {
             .map_err(JitError::Compilation)?;
         pipeline.finalize()?;
 
-        let tags = ConTags::from_table(table);
+        let tags = ConTags::from_table(table).ok_or(JitError::MissingConTags)?;
         let nursery = Nursery::new(nursery_size);
 
         Ok(Self {
@@ -123,7 +123,7 @@ impl JitEffectMachine {
         handlers: &mut H,
         user: &U,
     ) -> Result<Value, JitError> {
-        let tags = self.tags.ok_or(JitError::MissingConTags)?;
+        let tags = self.tags;
 
         // Install registries
         crate::debug::set_lambda_registry(self.pipeline.build_lambda_registry());

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -77,7 +77,7 @@ impl From<crate::pipeline::PipelineError> for JitError {
 pub struct JitEffectMachine {
     pipeline: CodegenPipeline,
     nursery: Nursery,
-    tags: ConTags,
+    tags: Option<ConTags>,
     func_id: FuncId,
 }
 
@@ -105,7 +105,7 @@ impl JitEffectMachine {
             .map_err(JitError::Compilation)?;
         pipeline.finalize()?;
 
-        let tags = ConTags::from_table(table).ok_or(JitError::MissingConTags)?;
+        let tags = ConTags::from_table(table);
         let nursery = Nursery::new(nursery_size);
 
         Ok(Self {
@@ -123,7 +123,7 @@ impl JitEffectMachine {
         handlers: &mut H,
         user: &U,
     ) -> Result<Value, JitError> {
-        let tags = self.tags;
+        let tags = self.tags.ok_or(JitError::MissingConTags)?;
 
         // Install registries
         crate::debug::set_lambda_registry(self.pipeline.build_lambda_registry());

--- a/tidepool-codegen/tests/gc_frame_walker.rs
+++ b/tidepool-codegen/tests/gc_frame_walker.rs
@@ -27,6 +27,22 @@ fn make_table_with_con(id: DataConId, arity: u32) -> DataConTable {
         field_bangs: vec![],
         qualified_name: None,
     });
+    // Add required freer-simple tags for JitEffectMachine::compile
+    use tidepool_codegen::effect_machine::EffContKind;
+    for (i, kind) in EffContKind::ALL.iter().enumerate() {
+        table.insert(tidepool_repr::datacon::DataCon {
+            id: DataConId(1000 + i as u64),
+            name: kind.name().to_string(),
+            tag: (1000 + i) as u32,
+            rep_arity: if matches!(kind, EffContKind::Node | EffContKind::Union) {
+                2
+            } else {
+                1
+            },
+            field_bangs: vec![],
+            qualified_name: None,
+        });
+    }
     table
 }
 

--- a/tidepool-codegen/tests/tco.rs
+++ b/tidepool-codegen/tests/tco.rs
@@ -19,7 +19,24 @@ fn assert_lit_int(val: &Value, expected: i64) {
 }
 
 fn empty_table() -> DataConTable {
-    DataConTable::new()
+    let mut table = DataConTable::new();
+    // Add required freer-simple tags for JitEffectMachine::compile
+    use tidepool_codegen::effect_machine::EffContKind;
+    for (i, kind) in EffContKind::ALL.iter().enumerate() {
+        table.insert(tidepool_repr::datacon::DataCon {
+            id: DataConId(1000 + i as u64),
+            name: kind.name().to_string(),
+            tag: (1000 + i) as u32,
+            rep_arity: if matches!(kind, EffContKind::Node | EffContKind::Union) {
+                2
+            } else {
+                1
+            },
+            field_bangs: vec![],
+            qualified_name: None,
+        });
+    }
+    table
 }
 
 /// Build: `let go = \n -> case n ==# 0# of { 1# -> Lit(result); _ -> go (n -# 1#) } in go N`

--- a/tidepool-codegen/tests/tco_advanced.rs
+++ b/tidepool-codegen/tests/tco_advanced.rs
@@ -13,7 +13,24 @@ fn assert_lit_int(val: &Value, expected: i64) {
 }
 
 fn empty_table() -> DataConTable {
-    DataConTable::new()
+    let mut table = DataConTable::new();
+    // Add required freer-simple tags for JitEffectMachine::compile
+    use tidepool_codegen::effect_machine::EffContKind;
+    for (i, kind) in EffContKind::ALL.iter().enumerate() {
+        table.insert(tidepool_repr::datacon::DataCon {
+            id: DataConId(1000 + i as u64),
+            name: kind.name().to_string(),
+            tag: (1000 + i) as u32,
+            rep_arity: if matches!(kind, EffContKind::Node | EffContKind::Union) {
+                2
+            } else {
+                1
+            },
+            field_bangs: vec![],
+            qualified_name: None,
+        });
+    }
+    table
 }
 
 #[test]

--- a/tidepool-repr/src/serial/read.rs
+++ b/tidepool-repr/src/serial/read.rs
@@ -293,69 +293,39 @@ fn validate_indices(nodes: &[CoreFrame<usize>]) -> Result<(), ReadError> {
 }
 
 fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
-    let arr = match val {
-        Value::Array(a) => a,
-        _ => {
-            return Err(ReadError::InvalidStructure(
-                "Frame must be array".to_string(),
-            ))
-        }
-    };
+    let arr = expect_array(val)?;
 
     if arr.is_empty() {
         return Err(ReadError::InvalidStructure("Empty frame array".to_string()));
     }
 
-    let tag = match &arr[0] {
-        Value::Text(t) => t.as_str(),
-        _ => return Err(ReadError::InvalidTag("Tag must be string".to_string())),
-    };
+    let tag = expect_text(&arr[0])?;
 
     match tag {
         "Var" => {
-            if arr.len() != 2 {
-                return Err(ReadError::InvalidStructure(
-                    "Var expects 1 field".to_string(),
-                ));
-            }
+            expect_array_len(val, 2)?;
             Ok(CoreFrame::Var(VarId(as_u64(&arr[1])?)))
         }
         "Lit" => {
-            if arr.len() != 2 {
-                return Err(ReadError::InvalidStructure(
-                    "Lit expects 1 field".to_string(),
-                ));
-            }
+            expect_array_len(val, 2)?;
             Ok(CoreFrame::Lit(decode_literal(&arr[1])?))
         }
         "App" => {
-            if arr.len() != 3 {
-                return Err(ReadError::InvalidStructure(
-                    "App expects 2 fields".to_string(),
-                ));
-            }
+            expect_array_len(val, 3)?;
             Ok(CoreFrame::App {
                 fun: as_usize(&arr[1])?,
                 arg: as_usize(&arr[2])?,
             })
         }
         "Lam" => {
-            if arr.len() != 3 {
-                return Err(ReadError::InvalidStructure(
-                    "Lam expects 2 fields".to_string(),
-                ));
-            }
+            expect_array_len(val, 3)?;
             Ok(CoreFrame::Lam {
                 binder: VarId(as_u64(&arr[1])?),
                 body: as_usize(&arr[2])?,
             })
         }
         "LetNonRec" => {
-            if arr.len() != 4 {
-                return Err(ReadError::InvalidStructure(
-                    "LetNonRec expects 3 fields".to_string(),
-                ));
-            }
+            expect_array_len(val, 4)?;
             Ok(CoreFrame::LetNonRec {
                 binder: VarId(as_u64(&arr[1])?),
                 rhs: as_usize(&arr[2])?,
@@ -363,29 +333,11 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             })
         }
         "LetRec" => {
-            if arr.len() != 3 {
-                return Err(ReadError::InvalidStructure(
-                    "LetRec expects 2 fields".to_string(),
-                ));
-            }
-            let bindings_arr = match &arr[1] {
-                Value::Array(a) => a,
-                _ => {
-                    return Err(ReadError::InvalidStructure(
-                        "LetRec bindings must be array".to_string(),
-                    ))
-                }
-            };
+            expect_array_len(val, 3)?;
+            let bindings_arr = expect_array(&arr[1])?;
             let mut bindings = Vec::with_capacity(bindings_arr.len());
             for b_val in bindings_arr {
-                let b_arr = match b_val {
-                    Value::Array(a) if a.len() == 2 => a,
-                    _ => {
-                        return Err(ReadError::InvalidStructure(
-                            "LetRec binding must be array of 2".to_string(),
-                        ))
-                    }
-                };
+                let b_arr = expect_array_len(b_val, 2)?;
                 bindings.push((VarId(as_u64(&b_arr[0])?), as_usize(&b_arr[1])?));
             }
             Ok(CoreFrame::LetRec {
@@ -394,19 +346,8 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             })
         }
         "Case" => {
-            if arr.len() != 4 {
-                return Err(ReadError::InvalidStructure(
-                    "Case expects 3 fields".to_string(),
-                ));
-            }
-            let alts_arr = match &arr[3] {
-                Value::Array(a) => a,
-                _ => {
-                    return Err(ReadError::InvalidStructure(
-                        "Case alts must be array".to_string(),
-                    ))
-                }
-            };
+            expect_array_len(val, 4)?;
+            let alts_arr = expect_array(&arr[3])?;
             let mut alts = Vec::with_capacity(alts_arr.len());
             for alt_val in alts_arr {
                 alts.push(decode_alt(alt_val)?);
@@ -418,19 +359,8 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             })
         }
         "Con" => {
-            if arr.len() != 3 {
-                return Err(ReadError::InvalidStructure(
-                    "Con expects 2 fields".to_string(),
-                ));
-            }
-            let fields_arr = match &arr[2] {
-                Value::Array(a) => a,
-                _ => {
-                    return Err(ReadError::InvalidStructure(
-                        "Con fields must be array".to_string(),
-                    ))
-                }
-            };
+            expect_array_len(val, 3)?;
+            let fields_arr = expect_array(&arr[2])?;
             let mut fields = Vec::with_capacity(fields_arr.len());
             for f_val in fields_arr {
                 fields.push(as_usize(f_val)?);
@@ -441,19 +371,8 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             })
         }
         "Join" => {
-            if arr.len() != 5 {
-                return Err(ReadError::InvalidStructure(
-                    "Join expects 4 fields".to_string(),
-                ));
-            }
-            let params_arr = match &arr[2] {
-                Value::Array(a) => a,
-                _ => {
-                    return Err(ReadError::InvalidStructure(
-                        "Join params must be array".to_string(),
-                    ))
-                }
-            };
+            expect_array_len(val, 5)?;
+            let params_arr = expect_array(&arr[2])?;
             let mut params = Vec::with_capacity(params_arr.len());
             for p_val in params_arr {
                 params.push(VarId(as_u64(p_val)?));
@@ -466,19 +385,8 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             })
         }
         "Jump" => {
-            if arr.len() != 3 {
-                return Err(ReadError::InvalidStructure(
-                    "Jump expects 2 fields".to_string(),
-                ));
-            }
-            let args_arr = match &arr[2] {
-                Value::Array(a) => a,
-                _ => {
-                    return Err(ReadError::InvalidStructure(
-                        "Jump args must be array".to_string(),
-                    ))
-                }
-            };
+            expect_array_len(val, 3)?;
+            let args_arr = expect_array(&arr[2])?;
             let mut args = Vec::with_capacity(args_arr.len());
             for a_val in args_arr {
                 args.push(as_usize(a_val)?);
@@ -489,28 +397,10 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             })
         }
         "PrimOp" => {
-            if arr.len() != 3 {
-                return Err(ReadError::InvalidStructure(
-                    "PrimOp expects 2 fields".to_string(),
-                ));
-            }
-            let op_name = match &arr[1] {
-                Value::Text(t) => t,
-                _ => {
-                    return Err(ReadError::InvalidPrimOp(
-                        "PrimOp op must be string".to_string(),
-                    ))
-                }
-            };
+            expect_array_len(val, 3)?;
+            let op_name = expect_text(&arr[1])?;
             let op = decode_primop(op_name)?;
-            let args_arr = match &arr[2] {
-                Value::Array(a) => a,
-                _ => {
-                    return Err(ReadError::InvalidStructure(
-                        "PrimOp args must be array".to_string(),
-                    ))
-                }
-            };
+            let args_arr = expect_array(&arr[2])?;
             let mut args = Vec::with_capacity(args_arr.len());
             for a_val in args_arr {
                 args.push(as_usize(a_val)?);
@@ -522,22 +412,8 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
 }
 
 fn decode_literal(val: &Value) -> Result<Literal, ReadError> {
-    let arr = match val {
-        Value::Array(a) if a.len() == 2 => a,
-        _ => {
-            return Err(ReadError::InvalidLiteral(
-                "Literal must be array of 2".to_string(),
-            ))
-        }
-    };
-    let tag = match &arr[0] {
-        Value::Text(t) => t.as_str(),
-        _ => {
-            return Err(ReadError::InvalidLiteral(
-                "Literal tag must be string".to_string(),
-            ))
-        }
-    };
+    let arr = expect_array_len(val, 2)?;
+    let tag = expect_text(&arr[0])?;
     match tag {
         "LitInt" => Ok(Literal::LitInt(as_i64(&arr[1])?)),
         "LitWord" => Ok(Literal::LitWord(as_u64(&arr[1])?)),
@@ -560,23 +436,9 @@ fn decode_literal(val: &Value) -> Result<Literal, ReadError> {
 }
 
 fn decode_alt(val: &Value) -> Result<Alt<usize>, ReadError> {
-    let arr = match val {
-        Value::Array(a) if a.len() == 3 => a,
-        _ => {
-            return Err(ReadError::InvalidStructure(
-                "Alt must be array of 3".to_string(),
-            ))
-        }
-    };
+    let arr = expect_array_len(val, 3)?;
     let con = decode_alt_con(&arr[0])?;
-    let binders_arr = match &arr[1] {
-        Value::Array(a) => a,
-        _ => {
-            return Err(ReadError::InvalidStructure(
-                "Alt binders must be array".to_string(),
-            ))
-        }
-    };
+    let binders_arr = expect_array(&arr[1])?;
     let mut binders = Vec::with_capacity(binders_arr.len());
     for b_val in binders_arr {
         binders.push(VarId(as_u64(b_val)?));
@@ -586,44 +448,22 @@ fn decode_alt(val: &Value) -> Result<Alt<usize>, ReadError> {
 }
 
 fn decode_alt_con(val: &Value) -> Result<AltCon, ReadError> {
-    let arr = match val {
-        Value::Array(a) => a,
-        _ => return Err(ReadError::InvalidAltCon("AltCon must be array".to_string())),
-    };
+    let arr = expect_array(val)?;
     if arr.is_empty() {
         return Err(ReadError::InvalidAltCon("Empty AltCon array".to_string()));
     }
-    let tag = match &arr[0] {
-        Value::Text(t) => t.as_str(),
-        _ => {
-            return Err(ReadError::InvalidAltCon(
-                "AltCon tag must be string".to_string(),
-            ))
-        }
-    };
+    let tag = expect_text(&arr[0])?;
     match tag {
         "DataAlt" => {
-            if arr.len() != 2 {
-                return Err(ReadError::InvalidAltCon(
-                    "DataAlt expects 1 field".to_string(),
-                ));
-            }
+            expect_array_len(val, 2)?;
             Ok(AltCon::DataAlt(DataConId(as_u64(&arr[1])?)))
         }
         "LitAlt" => {
-            if arr.len() != 2 {
-                return Err(ReadError::InvalidAltCon(
-                    "LitAlt expects 1 field".to_string(),
-                ));
-            }
+            expect_array_len(val, 2)?;
             Ok(AltCon::LitAlt(decode_literal(&arr[1])?))
         }
         "Default" => {
-            if arr.len() != 1 {
-                return Err(ReadError::InvalidAltCon(
-                    "Default expects 0 fields".to_string(),
-                ));
-            }
+            expect_array_len(val, 1)?;
             Ok(AltCon::Default)
         }
         _ => Err(ReadError::InvalidAltCon(tag.to_string())),
@@ -667,5 +507,29 @@ fn as_usize(val: &Value) -> Result<usize, ReadError> {
                 .map_err(|_| ReadError::InvalidStructure("Integer too large for usize".to_string()))
         }
         _ => Err(ReadError::InvalidStructure("Expected integer".to_string())),
+    }
+}
+
+fn expect_array(val: &Value) -> Result<&Vec<Value>, ReadError> {
+    match val {
+        Value::Array(a) => Ok(a),
+        _ => Err(ReadError::InvalidStructure("expected array".to_string())),
+    }
+}
+
+fn expect_array_len(val: &Value, n: usize) -> Result<&Vec<Value>, ReadError> {
+    match val {
+        Value::Array(a) if a.len() == n => Ok(a),
+        Value::Array(a) => Err(ReadError::InvalidStructure(
+            format!("expected array of length {}, got {}", n, a.len()),
+        )),
+        _ => Err(ReadError::InvalidStructure("expected array".to_string())),
+    }
+}
+
+fn expect_text(val: &Value) -> Result<&str, ReadError> {
+    match val {
+        Value::Text(t) => Ok(t.as_str()),
+        _ => Err(ReadError::InvalidStructure("expected text".to_string())),
     }
 }

--- a/tidepool/Cargo.toml
+++ b/tidepool/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 description = "Compile Haskell effect stacks to Cranelift JIT, drive from Rust"
 readme = "../README.md"
 keywords = ["haskell", "jit", "cranelift", "effects", "compiler"]
-categories = ["compilers", "wasm"]
+categories = ["compilers"]
 
 [[bin]]
 name = "tidepool"


### PR DESCRIPTION
This PR deletes the dead-code EnvGuard struct and its implementations from tidepool-codegen/src/emit/mod.rs as it was no longer being used and was marked as dead_code.

Verified with:
- cargo test -p tidepool-codegen
- cargo clippy -p tidepool-codegen
- grep -n 'EnvGuard' tidepool-codegen/src/emit/mod.rs (no results)