### PR TITLE
refactor: add apply_cont_heap diagnostics and deduplicate tail-call resolution

### DIFF
--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -326,6 +326,10 @@ impl CompiledEffectMachine {
                     // Check if result is Val or E
                     let result_tag = unsafe { *result };
                     if result_tag != layout::TAG_CON {
+                        crate::host_fns::push_diagnostic(format!(
+                            "apply_cont_heap: Node(k1,k2) result has unexpected tag {} (expected TAG_CON)",
+                            result_tag
+                        ));
                         return std::ptr::null_mut();
                     }
 
@@ -348,10 +352,18 @@ impl CompiledEffectMachine {
                         // Allocate E(union, new_node)
                         self.alloc_con(self.tags.e, &[union_val, new_node])
                     } else {
+                        crate::host_fns::push_diagnostic(format!(
+                            "apply_cont_heap: Node result con_tag {} is neither Val nor E",
+                            result_con_tag
+                        ));
                         std::ptr::null_mut()
                     }
                 } else {
                     // Unknown Con tag in continuation position — error
+                    crate::host_fns::push_diagnostic(format!(
+                        "apply_cont_heap: unexpected continuation con_tag {} (expected Leaf or Node)",
+                        con_tag
+                    ));
                     std::ptr::null_mut()
                 }
             }
@@ -359,11 +371,13 @@ impl CompiledEffectMachine {
                 // Raw closure (degenerate continuation fallback)
                 self.call_closure(k, arg)
             }
-            t if t == layout::TAG_THUNK => {
-                // Thunk in continuation position — already forced above, shouldn't happen
+            _ => {
+                crate::host_fns::push_diagnostic(format!(
+                    "apply_cont_heap: unexpected heap tag {} in continuation position",
+                    tag
+                ));
                 std::ptr::null_mut()
             }
-            _ => std::ptr::null_mut(),
         }
     }
 

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -257,32 +257,7 @@ impl JitEffectMachine {
         // SAFETY: Resolving pending tail calls. vmctx.tail_callee/tail_arg are valid
         // heap pointers set by JIT tail-call sites. Code pointers in closures point to
         // finalized JIT functions. Signal protection guards each call.
-        let result_ptr = unsafe {
-            let mut ptr = result_ptr;
-            while ptr.is_null() && !vmctx.tail_callee.is_null() {
-                let callee = vmctx.tail_callee;
-                let arg = vmctx.tail_arg;
-                vmctx.tail_callee = std::ptr::null_mut();
-                vmctx.tail_arg = std::ptr::null_mut();
-                crate::host_fns::reset_call_depth();
-                let code_ptr =
-                    *(callee.add(crate::layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
-                let func: unsafe extern "C" fn(
-                    *mut crate::context::VMContext,
-                    *mut u8,
-                    *mut u8,
-                ) -> *mut u8 = std::mem::transmute(code_ptr);
-                ptr = match crate::signal_safety::with_signal_protection(|| {
-                    func(&mut vmctx, callee, arg)
-                }) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        return Err(JitError::Yield(runtime_error_or_signal(e.0)));
-                    }
-                };
-            }
-            ptr
-        };
+        let result_ptr = unsafe { resolve_tail_calls_protected(&mut vmctx, result_ptr)? };
 
         // Check for runtime error FIRST — runtime_error now returns a poison
         // object instead of null, so we can't rely on null-check alone.
@@ -303,6 +278,31 @@ impl JitEffectMachine {
             .map_err(JitError::HeapBridge)
         }
     }
+}
+
+/// Resolve pending tail calls with signal protection.
+///
+/// # Safety
+/// vmctx must have valid tail_callee/tail_arg if non-null.
+unsafe fn resolve_tail_calls_protected(
+    vmctx: &mut VMContext,
+    result: *mut u8,
+) -> Result<*mut u8, JitError> {
+    let mut ptr = result;
+    while ptr.is_null() && !vmctx.tail_callee.is_null() {
+        let callee = vmctx.tail_callee;
+        let arg = vmctx.tail_arg;
+        vmctx.tail_callee = std::ptr::null_mut();
+        vmctx.tail_arg = std::ptr::null_mut();
+        crate::host_fns::reset_call_depth();
+        let code_ptr =
+            *(callee.add(crate::layout::CLOSURE_CODE_PTR_OFFSET as usize) as *const usize);
+        let func: unsafe extern "C" fn(*mut VMContext, *mut u8, *mut u8) -> *mut u8 =
+            std::mem::transmute(code_ptr);
+        ptr = crate::signal_safety::with_signal_protection(|| func(vmctx, callee, arg))
+            .map_err(|e| JitError::Yield(runtime_error_or_signal(e.0)))?;
+    }
+    Ok(ptr)
 }
 
 /// Check for a pending RuntimeError (more specific) before falling back to the


### PR DESCRIPTION
## Summary
- Add `push_diagnostic` calls before silent `null_mut()` returns in `apply_cont_heap` — unexpected tags now report what went wrong
- Extract `resolve_tail_calls_protected` free function, replacing the duplicated inline loop in `run_pure()`

## Verify
```
cargo test -p tidepool-codegen
cargo test --workspace
cargo clippy -p tidepool-codegen
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)