### PR TITLE
codegen-cleanup-unique-title-12345

### DIFF
--- a/tidepool-heap/src/arena.rs
+++ b/tidepool-heap/src/arena.rs
@@ -217,23 +217,20 @@ mod tests {
         assert_eq!(id1.0, 0);
         assert_eq!(id2.0, 1);
 
-        match heap.read(id1) {
-            ThunkState::Unevaluated(_, _) => (),
-            _ => panic!("Expected Unevaluated"),
-        }
+        let ThunkState::Unevaluated(_, _) = heap.read(id1) else {
+            panic!("Expected Unevaluated");
+        };
 
         heap.write(id1, ThunkState::BlackHole);
-        match heap.read(id1) {
-            ThunkState::BlackHole => (),
-            _ => panic!("Expected BlackHole"),
-        }
+        let ThunkState::BlackHole = heap.read(id1) else {
+            panic!("Expected BlackHole");
+        };
 
         let val = Value::Lit(Literal::LitInt(100));
         heap.write(id1, ThunkState::Evaluated(val));
-        match heap.read(id1) {
-            ThunkState::Evaluated(Value::Lit(Literal::LitInt(100))) => (),
-            _ => panic!("Expected Evaluated(100)"),
-        }
+        let ThunkState::Evaluated(Value::Lit(Literal::LitInt(100))) = heap.read(id1) else {
+            panic!("Expected Evaluated(100)");
+        };
     }
 
     #[test]
@@ -326,14 +323,12 @@ mod tests {
         assert_eq!(new_id2, ThunkId(1));
 
         // Both are readable
-        match heap.read(new_id0) {
-            ThunkState::Unevaluated(_, _) => (),
-            _ => panic!("Expected Unevaluated"),
-        }
-        match heap.read(new_id2) {
-            ThunkState::Unevaluated(_, _) => (),
-            _ => panic!("Expected Unevaluated"),
-        }
+        let ThunkState::Unevaluated(_, _) = heap.read(new_id0) else {
+            panic!("Expected Unevaluated");
+        };
+        let ThunkState::Unevaluated(_, _) = heap.read(new_id2) else {
+            panic!("Expected Unevaluated");
+        };
     }
 
     #[test]
@@ -355,17 +350,15 @@ mod tests {
 
         assert_eq!(heap.thunk_count(), 2);
         let new_id1 = table.lookup(id1).unwrap();
-        match heap.read(new_id1) {
-            ThunkState::Unevaluated(env, _) => {
-                // The ThunkRef should point to the NEW id for id0
-                let new_id0 = table.lookup(id0).unwrap();
-                match env.get(&VarId(42)).unwrap() {
-                    Value::ThunkRef(id) => assert_eq!(*id, new_id0),
-                    _ => panic!("Expected ThunkRef"),
-                }
-            }
-            _ => panic!("Expected Unevaluated"),
-        }
+        let ThunkState::Unevaluated(env, _) = heap.read(new_id1) else {
+            panic!("Expected Unevaluated");
+        };
+        // The ThunkRef should point to the NEW id for id0
+        let new_id0 = table.lookup(id0).unwrap();
+        let Value::ThunkRef(id) = env.get(&VarId(42)).unwrap() else {
+            panic!("Expected ThunkRef");
+        };
+        assert_eq!(*id, new_id0);
     }
 
     #[test]

--- a/tidepool-heap/tests/gc_unit.rs
+++ b/tidepool-heap/tests/gc_unit.rs
@@ -111,19 +111,18 @@ fn test_gc_thunkref_tracing() {
     let new_id_a = table.lookup(id_a).expect("Thunk A should be alive");
 
     // Check what id_a points to now
-    let new_id_b = match heap.read(new_id_a) {
-        ThunkState::Evaluated(Value::ThunkRef(id)) => *id,
-        _ => panic!("Expected Thunk A to be Evaluated(ThunkRef(_))"),
+    let ThunkState::Evaluated(Value::ThunkRef(new_id_b)) = heap.read(new_id_a) else {
+        panic!("Expected Thunk A to be Evaluated(ThunkRef(_))");
     };
+    let new_id_b = *new_id_b;
 
     // Assert id_b survived and has correct value
-    match heap.read(new_id_b) {
-        ThunkState::Evaluated(Value::Lit(Literal::LitInt(99))) => (),
-        other => panic!(
+    let ThunkState::Evaluated(Value::Lit(Literal::LitInt(99))) = heap.read(new_id_b) else {
+        panic!(
             "Expected Thunk B to be Evaluated(LitInt(99)), got {:?}",
-            other
-        ),
-    }
+            heap.read(new_id_b)
+        );
+    };
 
     // Also verify B is in the forwarding table
     assert!(

--- a/tidepool-heap/tests/proptest_heap.rs
+++ b/tidepool-heap/tests/proptest_heap.rs
@@ -124,10 +124,9 @@ proptest! {
             assert!(table.is_reachable(id));
             let new_id = table.lookup(id).unwrap();
             // Verify we can still read the thunk
-            match heap.read(new_id) {
-                ThunkState::Unevaluated(_, _) => (),
-                _ => panic!("Expected Unevaluated thunk state after GC"),
-            }
+            let ThunkState::Unevaluated(_, _) = heap.read(new_id) else {
+                panic!("Expected Unevaluated thunk state after GC");
+            };
         }
     }
 
@@ -193,20 +192,16 @@ proptest! {
         // Verify the chain structure is preserved
         let mut current_new_id = table.lookup(root).unwrap();
         for i in (1..chain_len).rev() {
-            match heap.read(current_new_id) {
-                ThunkState::Unevaluated(env, _) => {
-                    let prev_old_id = ids[i-1];
-                    let expected_new_id = table.lookup(prev_old_id).unwrap();
-                    match env.get(&VarId(i as u64)).expect("Value not found in env") {
-                        Value::ThunkRef(id) => {
-                            prop_assert_eq!(*id, expected_new_id, "Chain link broken at index {}", i);
-                            current_new_id = table.lookup(prev_old_id).unwrap();
-                        }
-                        _ => panic!("Expected ThunkRef"),
-                    }
-                }
-                _ => panic!("Expected Unevaluated thunk"),
-            }
+            let ThunkState::Unevaluated(env, _) = heap.read(current_new_id) else {
+                panic!("Expected Unevaluated thunk");
+            };
+            let prev_old_id = ids[i - 1];
+            let expected_new_id = table.lookup(prev_old_id).unwrap();
+            let Value::ThunkRef(id) = env.get(&VarId(i as u64)).expect("Value not found in env") else {
+                panic!("Expected ThunkRef");
+            };
+            prop_assert_eq!(*id, expected_new_id, "Chain link broken at index {}", i);
+            current_new_id = table.lookup(prev_old_id).unwrap();
         }
     }
 
@@ -242,10 +237,9 @@ proptest! {
 
             // Verify all roots are valid
             for &root in &roots {
-                match heap.read(root) {
-                    ThunkState::Unevaluated(_, _) => (),
-                    _ => panic!("Expected Unevaluated thunk after cycle {}", cycle),
-                }
+                let ThunkState::Unevaluated(_, _) = heap.read(root) else {
+                    panic!("Expected Unevaluated thunk after cycle {}", cycle);
+                };
             }
 
             prop_assert_eq!(heap.thunk_count(), roots.len(), "Heap should only contain roots");

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -391,14 +391,14 @@ pub fn build_preamble(effects: &[EffectDecl], user_library: bool) -> String {
     out.push('\n');
 
     for eff in effects {
-        for td in eff.type_defs {
+        eff.type_defs.iter().for_each(|td| {
             out.push_str(td);
             out.push('\n');
-        }
+        });
         out.push_str(&format!("data {} a where\n", eff.type_name));
-        for ctor in eff.constructors {
+        eff.constructors.iter().for_each(|ctor| {
             out.push_str(&format!("  {}\n", ctor));
-        }
+        });
         out.push('\n');
     }
 
@@ -865,9 +865,9 @@ fn build_eval_tool_description(effects: &[EffectDecl]) -> String {
 
     if !effects.is_empty() {
         desc.push_str("\nAvailable effects (use `send` to invoke):\n");
-        for eff in effects {
+        effects.iter().for_each(|eff| {
             desc.push_str(&format!("\n{}: {}\n", eff.type_name, eff.description));
-        }
+        });
 
         // List built-in helpers
         let has_console = effects.iter().any(|e| e.type_name == "Console");
@@ -877,14 +877,12 @@ fn build_eval_tool_description(effects: &[EffectDecl]) -> String {
             if has_console {
                 desc.push_str("  say :: Text -> M ()\n");
             }
-            for eff in effects {
-                for h in eff.helpers {
-                    // Extract just the type signature line
-                    if let Some(sig) = h.lines().next() {
-                        desc.push_str(&format!("  {}\n", sig));
-                    }
+            effects.iter().flat_map(|e| e.helpers).for_each(|h| {
+                // Extract just the type signature line
+                if let Some(sig) = h.lines().next() {
+                    desc.push_str(&format!("  {}\n", sig));
                 }
-            }
+            });
             desc.push_str(
                 "\nPrefer helpers over raw `send`: `say \"hi\"` not `send (Print \"hi\")`.\n",
             );
@@ -1218,28 +1216,34 @@ fn extract_ask_prompt(
 ) -> Result<String, String> {
     use tidepool_eval::value::Value;
 
-    if let Value::Con(_, fields) = request {
-        if let Some(prompt_val) = fields.first() {
-            // Try using FromCore (handles Text, LitString, [Char])
-            match String::from_value(prompt_val, table) {
-                Ok(s) => return Ok(s),
-                Err(e) => {
-                    // Provide diagnostic: the prompt text couldn't be extracted,
-                    // likely because the string-building expression crashed
-                    // (e.g., unresolved external, partial evaluation).
-                    return Err(format!(
-                        "ask prompt could not be evaluated to Text: {e}. \
-                         The expression passed to `ask` likely crashed during evaluation \
-                         (check for unresolved externals or runtime errors in the prompt string)."
-                    ));
-                }
-            }
+    let Value::Con(_, fields) = request else {
+        return Err(format!(
+            "ask received unexpected request shape (expected Con(Ask, [text])): {:?}",
+            request
+        ));
+    };
+
+    let Some(prompt_val) = fields.first() else {
+        return Err(format!(
+            "ask received unexpected request shape (expected Con(Ask, [text])): {:?}",
+            request
+        ));
+    };
+
+    // Try using FromCore (handles Text, LitString, [Char])
+    match String::from_value(prompt_val, table) {
+        Ok(s) => Ok(s),
+        Err(e) => {
+            // Provide diagnostic: the prompt text couldn't be extracted,
+            // likely because the string-building expression crashed
+            // (e.g., unresolved external, partial evaluation).
+            Err(format!(
+                "ask prompt could not be evaluated to Text: {e}. \
+                 The expression passed to `ask` likely crashed during evaluation \
+                 (check for unresolved externals or runtime errors in the prompt string)."
+            ))
         }
     }
-    Err(format!(
-        "ask received unexpected request shape (expected Con(Ask, [text])): {:?}",
-        request
-    ))
 }
 
 // ---------------------------------------------------------------------------

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -45,17 +45,22 @@ fn fingerprint_dir(dir: &Path, hasher: &mut blake3::Hasher) {
         let path = entry.path();
         if path.is_dir() {
             fingerprint_dir(&path, hasher);
-        } else if let Some(ext) = path.extension() {
-            if ext == "hs" || ext == "hs-boot" {
-                if let Ok(meta) = entry.metadata() {
-                    hasher.update(path.as_os_str().as_encoded_bytes());
-                    hasher.update(&meta.len().to_le_bytes());
-                    if let Ok(mtime) = meta.modified() {
-                        if let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH) {
-                            hasher.update(&dur.as_nanos().to_le_bytes());
-                        }
-                    }
-                }
+            continue;
+        }
+        let Some(ext) = path.extension() else {
+            continue;
+        };
+        if ext != "hs" && ext != "hs-boot" {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        hasher.update(path.as_os_str().as_encoded_bytes());
+        hasher.update(&meta.len().to_le_bytes());
+        if let Ok(mtime) = meta.modified() {
+            if let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH) {
+                hasher.update(&dur.as_nanos().to_le_bytes());
             }
         }
     }

--- a/tidepool-runtime/src/render.rs
+++ b/tidepool-runtime/src/render.rs
@@ -21,7 +21,7 @@ impl EvalResult {
 
     /// Render the result as structured JSON.
     pub fn to_json(&self) -> serde_json::Value {
-        value_to_json(&self.value, &self.table, 0)
+        self.into()
     }
 
     /// Pretty-print the JSON representation.
@@ -57,6 +57,18 @@ impl EvalResult {
     /// Borrow the DataConTable.
     pub fn table(&self) -> &DataConTable {
         &self.table
+    }
+}
+
+impl From<&EvalResult> for serde_json::Value {
+    fn from(result: &EvalResult) -> Self {
+        value_to_json(&result.value, &result.table, 0)
+    }
+}
+
+impl From<EvalResult> for serde_json::Value {
+    fn from(result: EvalResult) -> Self {
+        (&result).into()
     }
 }
 


### PR DESCRIPTION
Applied idiomatic Rust refactors to the `tidepool-codegen` crate:
- Replaced `match-on-Result` with `.map_err()?` in `jit_machine.rs`.
- Replaced for-loops with iterator chains in `heap_bridge.rs`.
- Replaced push loops with `.extend()` in `datacon_env.rs` (added `TreeBuilder::extend` in `tidepool-repr`).
- Implemented `TryFrom<&DataConTable>` for `ConTags` in `effect_machine.rs`.
- Refactored alt classification to iterator chains and used `let-else` in `emit/case.rs`.
- Converted `if-let`/`else-panic` to `let-else` across multiple test modules.

Verified with `cargo test`, `cargo clippy`, and `cargo fmt`.