### PR TITLE
refactor: idiomatic Rust cleanup across workspace

### DIFF
--- a/tidepool-codegen/src/datacon_env.rs
+++ b/tidepool-codegen/src/datacon_env.rs
@@ -15,9 +15,7 @@ pub fn wrap_with_datacon_env(expr: &CoreExpr, table: &DataConTable) -> CoreExpr 
 
     // First, push all nodes from the original expression
     let mut src = TreeBuilder::new();
-    for node in &expr.nodes {
-        src.push(node.clone());
-    }
+    src.extend(expr.nodes.iter().cloned());
     let base = b.push_tree(src);
     let root = base + expr.nodes.len() - 1;
 

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -55,8 +55,10 @@ pub struct ConTags {
     pub node: u64,
 }
 
-impl ConTags {
-    pub fn from_table(table: &tidepool_repr::DataConTable) -> Result<Self, EffContKind> {
+impl TryFrom<&tidepool_repr::DataConTable> for ConTags {
+    type Error = EffContKind;
+
+    fn try_from(table: &tidepool_repr::DataConTable) -> Result<Self, Self::Error> {
         let resolve = |kind: EffContKind| -> Result<u64, EffContKind> {
             table.get_by_name(kind.name()).map(|t| t.0).ok_or(kind)
         };
@@ -67,6 +69,12 @@ impl ConTags {
             leaf: resolve(EffContKind::Leaf)?,
             node: resolve(EffContKind::Node)?,
         })
+    }
+}
+
+impl ConTags {
+    pub fn from_table(table: &tidepool_repr::DataConTable) -> Result<Self, EffContKind> {
+        Self::try_from(table)
     }
 }
 

--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -27,17 +27,15 @@ pub fn emit_case(
     let old_case_binder = ctx.env.insert(*binder, scrut);
 
     // 3. Classify alts
-    let mut data_alts = Vec::new();
-    let mut lit_alts = Vec::new();
-    let mut default_alt = None;
-
-    for alt in alts {
-        match &alt.con {
-            AltCon::DataAlt(_) => data_alts.push(alt),
-            AltCon::LitAlt(_) => lit_alts.push(alt),
-            AltCon::Default => default_alt = Some(alt),
-        }
-    }
+    let data_alts: Vec<_> = alts
+        .iter()
+        .filter(|alt| matches!(alt.con, AltCon::DataAlt(_)))
+        .collect();
+    let lit_alts: Vec<_> = alts
+        .iter()
+        .filter(|alt| matches!(alt.con, AltCon::LitAlt(_)))
+        .collect();
+    let default_alt = alts.iter().find(|alt| matches!(alt.con, AltCon::Default));
 
     // 4. Create merge block
     let merge_block = builder.create_block();
@@ -165,63 +163,63 @@ fn emit_data_dispatch(
     // Use comparison chain instead of jump table because DataConIds are large
     // GHC Uniques (arbitrary u64 values), not small sequential integers.
     for &alt in data_alts {
-        if let AltCon::DataAlt(tag) = &alt.con {
-            let alt_block = builder.create_block();
-            let next_check_block = builder.create_block();
+        let AltCon::DataAlt(tag) = &alt.con else {
+            continue;
+        };
 
-            let tag_val = builder.ins().iconst(types::I64, tag.0 as i64);
-            let eq = builder.ins().icmp(IntCC::Equal, con_tag, tag_val);
-            builder
+        let alt_block = builder.create_block();
+        let next_check_block = builder.create_block();
+
+        let tag_val = builder.ins().iconst(types::I64, tag.0 as i64);
+        let eq = builder.ins().icmp(IntCC::Equal, con_tag, tag_val);
+        builder
+            .ins()
+            .brif(eq, alt_block, &[], next_check_block, &[]);
+
+        // Emit alt body
+        builder.switch_to_block(alt_block);
+        builder.seal_block(alt_block);
+        ctx.declare_env(builder);
+
+        // Bind pattern variables — do NOT force thunked fields.
+        // In Haskell, case alt binders are lazy. Thunked Con fields
+        // remain as thunks until used in a strict context (case scrutiny,
+        // primop args, etc.). Forcing here causes infinite loops for
+        // self-referencing structures like `xs = 1 : map (+1) xs`.
+        //
+        // INVARIANT: All strict consumers must force thunked values before
+        // reading heap layout. The forcing points are:
+        //   - emit_lit_dispatch: force_thunk_ssaval on scrutinee
+        //   - emit_data_dispatch: tag < 2 check → heap_force on scrutinee
+        //   - PrimOp collapse: force_thunk_ssaval on all args
+        //   - App collapse: tag check → heap_force on fun position
+        //   - unbox_int/unbox_double/unbox_float: defensive trap on TAG_THUNK
+        // See force_thunk_ssaval in expr.rs.
+        let mut scope = EnvScope::new();
+        // NOTE: EnvGuard cannot be used here because it would borrow ctx.env
+        // mutably, preventing the use of ctx in emit_node.
+        for (i, &binder) in alt.binders.iter().enumerate() {
+            let offset = CON_FIELDS_OFFSET + (8 * i as i32);
+            let field_val = builder
                 .ins()
-                .brif(eq, alt_block, &[], next_check_block, &[]);
-
-            // Emit alt body
-            builder.switch_to_block(alt_block);
-            builder.seal_block(alt_block);
-            ctx.declare_env(builder);
-
-            // Bind pattern variables — do NOT force thunked fields.
-            // In Haskell, case alt binders are lazy. Thunked Con fields
-            // remain as thunks until used in a strict context (case scrutiny,
-            // primop args, etc.). Forcing here causes infinite loops for
-            // self-referencing structures like `xs = 1 : map (+1) xs`.
-            //
-            // INVARIANT: All strict consumers must force thunked values before
-            // reading heap layout. The forcing points are:
-            //   - emit_lit_dispatch: force_thunk_ssaval on scrutinee
-            //   - emit_data_dispatch: tag < 2 check → heap_force on scrutinee
-            //   - PrimOp collapse: force_thunk_ssaval on all args
-            //   - App collapse: tag check → heap_force on fun position
-            //   - unbox_int/unbox_double/unbox_float: defensive trap on TAG_THUNK
-            // See force_thunk_ssaval in expr.rs.
-            let mut scope = EnvScope::new();
-            // NOTE: EnvGuard cannot be used here because it would borrow ctx.env
-            // mutably, preventing the use of ctx in emit_node.
-            for (i, &binder) in alt.binders.iter().enumerate() {
-                let offset = CON_FIELDS_OFFSET + (8 * i as i32);
-                let field_val =
-                    builder
-                        .ins()
-                        .load(types::I64, MemFlags::trusted(), scrut_ptr, offset);
-                builder.declare_value_needs_stack_map(field_val);
-                ctx.env
-                    .insert_scoped(&mut scope, binder, SsaVal::HeapPtr(field_val));
-            }
-
-            let result = ctx.emit_node(sess, builder, alt.body, tail)?;
-            let result_ptr =
-                ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, result);
-            builder
-                .ins()
-                .jump(merge_block, &[BlockArg::Value(result_ptr)]);
-
-            // Restore pattern variable bindings
-            ctx.env.restore_scope(scope);
-
-            // Continue to next check
-            builder.switch_to_block(next_check_block);
-            builder.seal_block(next_check_block);
+                .load(types::I64, MemFlags::trusted(), scrut_ptr, offset);
+            builder.declare_value_needs_stack_map(field_val);
+            ctx.env
+                .insert_scoped(&mut scope, binder, SsaVal::HeapPtr(field_val));
         }
+
+        let result = ctx.emit_node(sess, builder, alt.body, tail)?;
+        let result_ptr = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, result);
+        builder
+            .ins()
+            .jump(merge_block, &[BlockArg::Value(result_ptr)]);
+
+        // Restore pattern variable bindings
+        ctx.env.restore_scope(scope);
+
+        // Continue to next check
+        builder.switch_to_block(next_check_block);
+        builder.seal_block(next_check_block);
     }
 
     // Default or trap

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -149,11 +149,12 @@ unsafe fn heap_to_value_inner(
                     if len > MAX_DATA_SIZE {
                         return Err(BridgeError::DataTooLarge { len });
                     }
-                    let mut elems = Vec::with_capacity(len);
-                    for i in 0..len {
-                        let elem_ptr = *(arr_ptr.add(8 + 8 * i) as *const *const u8);
-                        elems.push(heap_to_value_inner(elem_ptr, depth + 1, vmctx)?);
-                    }
+                    let elems: Vec<_> = (0..len)
+                        .map(|i| {
+                            let elem_ptr = *(arr_ptr.add(8 + 8 * i) as *const *const u8);
+                            heap_to_value_inner(elem_ptr, depth + 1, vmctx)
+                        })
+                        .collect::<Result<_, _>>()?;
                     // Return as a generic Con with fields — the renderer will
                     // see the constructor names from the wrapping Con objects
                     // (e.g., Vector's Array constructor wraps this)
@@ -169,12 +170,13 @@ unsafe fn heap_to_value_inner(
             if num_fields > MAX_FIELDS {
                 return Err(BridgeError::TooManyFields { count: num_fields });
             }
-            let mut fields = Vec::with_capacity(num_fields);
-            for i in 0..num_fields {
-                let field_ptr =
-                    *(ptr.add(layout::CON_FIELDS_OFFSET as usize + 8 * i) as *const *const u8);
-                fields.push(heap_to_value_inner(field_ptr, depth + 1, vmctx)?);
-            }
+            let fields: Vec<_> = (0..num_fields)
+                .map(|i| {
+                    let field_ptr =
+                        *(ptr.add(layout::CON_FIELDS_OFFSET as usize + 8 * i) as *const *const u8);
+                    heap_to_value_inner(field_ptr, depth + 1, vmctx)
+                })
+                .collect::<Result<_, _>>()?;
             Ok(Value::Con(DataConId(con_tag), fields))
         }
         t if t == layout::TAG_THUNK => {
@@ -371,11 +373,10 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::Lit(Literal::LitInt(n)) = back {
-                assert_eq!(n, 42);
-            } else {
+            let Value::Lit(Literal::LitInt(n)) = back else {
                 panic!("Expected LitInt, got {:?}", back);
-            }
+            };
+            assert_eq!(n, 42);
         }
     }
 
@@ -386,11 +387,10 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::Lit(Literal::LitWord(n)) = back {
-                assert_eq!(n, 123);
-            } else {
+            let Value::Lit(Literal::LitWord(n)) = back else {
                 panic!("Expected LitWord, got {:?}", back);
-            }
+            };
+            assert_eq!(n, 123);
         }
     }
 
@@ -401,11 +401,10 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::Lit(Literal::LitChar(c)) = back {
-                assert_eq!(c, 'λ');
-            } else {
+            let Value::Lit(Literal::LitChar(c)) = back else {
                 panic!("Expected LitChar, got {:?}", back);
-            }
+            };
+            assert_eq!(c, 'λ');
         }
     }
 
@@ -416,11 +415,10 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::Lit(Literal::LitDouble(bits)) = back {
-                assert_eq!(f64::from_bits(bits), 1.2345678);
-            } else {
+            let Value::Lit(Literal::LitDouble(bits)) = back else {
                 panic!("Expected LitDouble, got {:?}", back);
-            }
+            };
+            assert_eq!(f64::from_bits(bits), 1.2345678);
         }
     }
 
@@ -432,11 +430,10 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::Lit(Literal::LitString(b)) = back {
-                assert_eq!(b, bytes);
-            } else {
+            let Value::Lit(Literal::LitString(b)) = back else {
                 panic!("Expected LitString, got {:?}", back);
-            }
+            };
+            assert_eq!(b, bytes);
         }
     }
 
@@ -447,12 +444,11 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::Con(id, fields) = back {
-                assert_eq!(id.0, 42);
-                assert!(fields.is_empty());
-            } else {
+            let Value::Con(id, fields) = back else {
                 panic!("Expected Con, got {:?}", back);
-            }
+            };
+            assert_eq!(id.0, 42);
+            assert!(fields.is_empty());
         }
     }
 
@@ -469,15 +465,14 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::Con(id, fields) = back {
-                assert_eq!(id.0, 1);
-                assert_eq!(fields.len(), 2);
-                match (&fields[0], &fields[1]) {
-                    (Value::Lit(Literal::LitInt(10)), Value::Lit(Literal::LitChar('a'))) => (),
-                    _ => panic!("Expected [LitInt(10), LitChar('a')], got {:?}", fields),
-                }
-            } else {
+            let Value::Con(id, fields) = back else {
                 panic!("Expected Con, got {:?}", back);
+            };
+            assert_eq!(id.0, 1);
+            assert_eq!(fields.len(), 2);
+            match (&fields[0], &fields[1]) {
+                (Value::Lit(Literal::LitInt(10)), Value::Lit(Literal::LitChar('a'))) => (),
+                _ => panic!("Expected [LitInt(10), LitChar('a')], got {:?}", fields),
             }
         }
     }
@@ -492,23 +487,20 @@ mod tests {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
 
-            if let Value::Con(id, fields) = back {
-                assert_eq!(id.0, 1);
-                assert_eq!(fields.len(), 1);
-                if let Value::Con(id2, fields2) = &fields[0] {
-                    assert_eq!(id2.0, 2);
-                    assert_eq!(fields2.len(), 1);
-                    if let Value::Lit(Literal::LitInt(n)) = &fields2[0] {
-                        assert_eq!(*n, 42);
-                    } else {
-                        panic!("Expected LitInt");
-                    }
-                } else {
-                    panic!("Expected nested Con");
-                }
-            } else {
+            let Value::Con(id, fields) = back else {
                 panic!("Expected Con");
-            }
+            };
+            assert_eq!(id.0, 1);
+            assert_eq!(fields.len(), 1);
+            let Value::Con(id2, fields2) = &fields[0] else {
+                panic!("Expected nested Con");
+            };
+            assert_eq!(id2.0, 2);
+            assert_eq!(fields2.len(), 1);
+            let Value::Lit(Literal::LitInt(n)) = &fields2[0] else {
+                panic!("Expected LitInt");
+            };
+            assert_eq!(*n, 42);
         }
     }
 
@@ -520,11 +512,10 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::ByteArray(ba) = back {
-                assert_eq!(*ba.lock().unwrap(), data);
-            } else {
+            let Value::ByteArray(ba) = back else {
                 panic!("Expected ByteArray, got {:?}", back);
-            }
+            };
+            assert_eq!(*ba.lock().unwrap(), data);
         }
     }
 
@@ -561,11 +552,10 @@ mod tests {
         unsafe {
             let ptr = value_to_heap(&val, &mut vmctx).expect("value_to_heap failed");
             let back = heap_to_value(ptr).expect("heap_to_value failed");
-            if let Value::Lit(Literal::LitFloat(b)) = back {
-                assert_eq!(b, bits);
-            } else {
+            let Value::Lit(Literal::LitFloat(b)) = back else {
                 panic!("Expected LitFloat, got {:?}", back);
-            }
+            };
+            assert_eq!(b, bits);
         }
     }
 

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -249,14 +249,9 @@ impl JitEffectMachine {
         crate::host_fns::set_exec_context("running pure computation");
         // SAFETY: Calling the JIT function through a valid function pointer with signal
         // protection for crash recovery. vmctx is freshly created from the nursery.
-        let result_ptr: *mut u8 = match unsafe {
-            crate::signal_safety::with_signal_protection(|| func_ptr(&mut vmctx))
-        } {
-            Ok(ptr) => ptr,
-            Err(e) => {
-                return Err(JitError::Yield(runtime_error_or_signal(e.0)));
-            }
-        };
+        let result_ptr: *mut u8 =
+            unsafe { crate::signal_safety::with_signal_protection(|| func_ptr(&mut vmctx)) }
+                .map_err(|e| JitError::Yield(runtime_error_or_signal(e.0)))?;
 
         // SAFETY: Resolving pending tail calls. vmctx.tail_callee/tail_arg are valid
         // heap pointers set by JIT tail-call sites. Code pointers in closures point to

--- a/tidepool-codegen/tests/effect_machine.rs
+++ b/tidepool-codegen/tests/effect_machine.rs
@@ -235,16 +235,14 @@ fn test_yield_done_val() {
     );
     let result = machine.step();
 
-    match result {
-        Yield::Done(val_ptr) => {
-            // val_ptr should point to the Lit(42) object
-            let tag = unsafe { *val_ptr };
-            assert_eq!(tag, TAG_LIT);
-            let val = unsafe { *(val_ptr.add(16) as *const i64) };
-            assert_eq!(val, 42);
-        }
-        _ => panic!("Expected Yield::Done, got {:?}", result),
-    }
+    let Yield::Done(val_ptr) = result else {
+        panic!("Expected Yield::Done, got {:?}", result);
+    };
+    // val_ptr should point to the Lit(42) object
+    let tag = unsafe { *val_ptr };
+    assert_eq!(tag, TAG_LIT);
+    let val = unsafe { *(val_ptr.add(16) as *const i64) };
+    assert_eq!(val, 42);
 }
 
 /// Test 2: Yield::Request from E result.
@@ -290,25 +288,24 @@ fn test_yield_request_e() {
     );
     let result = machine.step();
 
-    match result {
-        Yield::Request {
-            tag,
-            request,
-            continuation,
-        } => {
-            assert_eq!(tag, 7);
+    let Yield::Request {
+        tag,
+        request,
+        continuation,
+    } = result
+    else {
+        panic!("Expected Yield::Request, got {:?}", result);
+    };
+    assert_eq!(tag, 7);
 
-            // Verify request is Lit(99)
-            let req_tag = unsafe { *request };
-            assert_eq!(req_tag, TAG_LIT);
-            let req_val = unsafe { *(request.add(16) as *const i64) };
-            assert_eq!(req_val, 99);
+    // Verify request is Lit(99)
+    let req_tag = unsafe { *request };
+    assert_eq!(req_tag, TAG_LIT);
+    let req_val = unsafe { *(request.add(16) as *const i64) };
+    assert_eq!(req_val, 99);
 
-            // Verify continuation is there
-            assert!(!continuation.is_null());
-        }
-        _ => panic!("Expected Yield::Request, got {:?}", result),
-    }
+    // Verify continuation is there
+    assert!(!continuation.is_null());
 }
 
 /// Test 3: CompiledEffectMachine is Send.
@@ -613,17 +610,14 @@ fn test_resume_leaf_identity() {
 
     let result = unsafe { machine.resume(leaf_ptr, lit_ptr) };
 
-    match result {
-        Yield::Done(res_ptr) => {
-            assert_eq!(res_ptr, lit_ptr);
+    let Yield::Done(res_ptr) = result else {
+        panic!("Expected Yield::Done, got {:?}", result);
+    };
+    assert_eq!(res_ptr, lit_ptr);
 
-            let val = unsafe { *(res_ptr.add(16) as *const i64) };
+    let val = unsafe { *(res_ptr.add(16) as *const i64) };
 
-            assert_eq!(val, 42);
-        }
-
-        _ => panic!("Expected Yield::Done, got {:?}", result),
-    }
+    assert_eq!(val, 42);
 }
 
 /// Test 10: resume(Node(Leaf(f), Leaf(g)), x) -> g(f(x))
@@ -697,17 +691,14 @@ fn test_resume_node_identity() {
 
     let result = unsafe { machine.resume(node_ptr, lit_ptr) };
 
-    match result {
-        Yield::Done(res_ptr) => {
-            assert_eq!(res_ptr, lit_ptr);
+    let Yield::Done(res_ptr) = result else {
+        panic!("Expected Yield::Done, got {:?}", result);
+    };
+    assert_eq!(res_ptr, lit_ptr);
 
-            let val = unsafe { *(res_ptr.add(16) as *const i64) };
+    let val = unsafe { *(res_ptr.add(16) as *const i64) };
 
-            assert_eq!(val, 100);
-        }
-
-        _ => panic!("Expected Yield::Done, got {:?}", result),
-    }
+    assert_eq!(val, 100);
 }
 
 /// Test 11: resume(null, x) -> Error(NullPointer)
@@ -881,37 +872,33 @@ fn test_resume_node_with_effect_result() {
 
     let result = unsafe { machine.resume(node_ptr, lit_ptr) };
 
-    match result {
-        Yield::Request {
-            tag,
-            request,
-            continuation,
-        } => {
-            assert_eq!(tag, 7);
+    let Yield::Request {
+        tag,
+        request,
+        continuation,
+    } = result
+    else {
+        panic!("Expected Yield::Request, got {:?}", result);
+    };
+    assert_eq!(tag, 7);
 
-            assert_eq!(request, lit_ptr);
+    assert_eq!(request, lit_ptr);
 
-            // continuation should be Node(k_prime, leaf_g)
+    // continuation should be Node(k_prime, leaf_g)
 
-            let tag = unsafe { *continuation };
+    let tag = unsafe { *continuation };
 
-            assert_eq!(tag, layout::TAG_CON);
+    assert_eq!(tag, layout::TAG_CON);
 
-            let con_tag = unsafe { *(continuation.add(layout::CON_TAG_OFFSET) as *const u64) };
+    let con_tag = unsafe { *(continuation.add(layout::CON_TAG_OFFSET) as *const u64) };
 
-            assert_eq!(con_tag, NODE_CON_TAG);
+    assert_eq!(con_tag, NODE_CON_TAG);
 
-            let k_prime =
-                unsafe { *(continuation.add(layout::CON_FIELDS_OFFSET) as *const *mut u8) };
+    let k_prime = unsafe { *(continuation.add(layout::CON_FIELDS_OFFSET) as *const *mut u8) };
 
-            let k2 =
-                unsafe { *(continuation.add(layout::CON_FIELDS_OFFSET + 8) as *const *mut u8) };
+    let k2 = unsafe { *(continuation.add(layout::CON_FIELDS_OFFSET + 8) as *const *mut u8) };
 
-            assert_eq!(k2, leaf_g);
+    assert_eq!(k2, leaf_g);
 
-            assert!(!k_prime.is_null());
-        }
-
-        _ => panic!("Expected Yield::Request, got {:?}", result),
-    }
+    assert!(!k_prime.is_null());
 }

--- a/tidepool-codegen/tests/gc_frame_walker.rs
+++ b/tidepool-codegen/tests/gc_frame_walker.rs
@@ -150,17 +150,15 @@ fn test_gc_preserves_values() {
             let mut machine = JitEffectMachine::compile(&expr, &table, 2048).unwrap();
             let result = machine.run_pure().unwrap();
 
-            match result {
-                Value::Con(tag, fields) => {
-                    assert_eq!(tag, DataConId(1));
-                    assert_eq!(fields.len(), 1);
-                    match &fields[0] {
-                        Value::Lit(lit) => assert_eq!(*lit, Literal::LitInt(42)),
-                        other => panic!("Expected Lit(42), got {:?}", other),
-                    }
-                }
-                other => panic!("Expected Con, got {:?}", other),
-            }
+            let Value::Con(tag, fields) = result else {
+                panic!("Expected Con, got {:?}", result);
+            };
+            assert_eq!(tag, DataConId(1));
+            assert_eq!(fields.len(), 1);
+            let Value::Lit(lit) = &fields[0] else {
+                panic!("Expected Lit(42), got {:?}", fields[0]);
+            };
+            assert_eq!(*lit, Literal::LitInt(42));
         })
         .unwrap()
         .join()
@@ -180,35 +178,30 @@ fn test_multiple_gc_cycles() {
             let mut machine = JitEffectMachine::compile(&expr, &table, 2048).unwrap();
             let result = machine.run_pure();
 
-            match result {
-                Ok(val) => {
-                    // Verify the result is a nested Con chain ending in Lit(42)
-                    let mut current = &val;
-                    for _ in 0..60 {
-                        match current {
-                            Value::Con(_, fields) => {
-                                assert_eq!(fields.len(), 1);
-                                current = &fields[0];
-                            }
-                            other => panic!("Expected Con in chain, got {:?}", other),
-                        }
-                    }
-                    match current {
-                        Value::Lit(Literal::LitInt(42)) => {}
-                        other => panic!("Expected Lit(42) at leaf, got {:?}", other),
-                    }
-                    // Should have multiple GC cycles
-                    let gc_count = host_fns::gc_trigger_call_count();
-                    assert!(
-                        gc_count > 1,
-                        "Expected multiple GC cycles, got {}",
-                        gc_count
-                    );
+            if let Ok(val) = result {
+                // Verify the result is a nested Con chain ending in Lit(42)
+                let mut current = &val;
+                for _ in 0..60 {
+                    let Value::Con(_, fields) = current else {
+                        panic!("Expected Con in chain, got {:?}", current);
+                    };
+                    assert_eq!(fields.len(), 1);
+                    current = &fields[0];
                 }
-                Err(JitError::Yield(YieldError::HeapOverflow)) => {
-                    // HeapOverflow is acceptable for small nursery
-                }
-                Err(e) => panic!("Expected HeapOverflow but got: {}", e),
+                let Value::Lit(Literal::LitInt(42)) = current else {
+                    panic!("Expected Lit(42) at leaf, got {:?}", current);
+                };
+                // Should have multiple GC cycles
+                let gc_count = host_fns::gc_trigger_call_count();
+                assert!(
+                    gc_count > 1,
+                    "Expected multiple GC cycles, got {}",
+                    gc_count
+                );
+            } else if let Err(JitError::Yield(YieldError::HeapOverflow)) = result {
+                // HeapOverflow is acceptable for small nursery
+            } else if let Err(e) = result {
+                panic!("Expected HeapOverflow but got: {}", e);
             }
         })
         .unwrap()

--- a/tidepool-codegen/tests/heap_bridge_tests.rs
+++ b/tidepool-codegen/tests/heap_bridge_tests.rs
@@ -16,11 +16,10 @@ fn test_heap_to_value_lit_int() {
         *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut i64) = 42;
 
         let res = heap_to_value(ptr).expect("heap_to_value failed");
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
+        let Value::Lit(Literal::LitInt(n)) = res else {
             panic!("Expected LitInt, got {:?}", res);
-        }
+        };
+        assert_eq!(n, 42);
     }
 }
 
@@ -50,14 +49,13 @@ fn test_heap_to_value_con_pair() {
         *(con.add(layout::CON_FIELDS_OFFSET + 8) as *mut *const u8) = lit2;
 
         let res = heap_to_value(con).expect("heap_to_value failed");
-        if let Value::Con(DataConId(1), fields) = res {
-            assert_eq!(fields.len(), 2);
-            match (&fields[0], &fields[1]) {
-                (Value::Lit(Literal::LitInt(10)), Value::Lit(Literal::LitInt(20))) => (),
-                _ => panic!("Expected [LitInt(10), LitInt(20)], got {:?}", fields),
-            }
-        } else {
+        let Value::Con(DataConId(1), fields) = res else {
             panic!("Expected Con, got {:?}", res);
+        };
+        assert_eq!(fields.len(), 2);
+        match (&fields[0], &fields[1]) {
+            (Value::Lit(Literal::LitInt(10)), Value::Lit(Literal::LitInt(20))) => (),
+            _ => panic!("Expected [LitInt(10), LitInt(20)], got {:?}", fields),
         }
     }
 }
@@ -100,10 +98,8 @@ fn test_heap_to_value_deeply_nested_cons() {
             v = fields[0].clone();
         }
         assert_eq!(depth, 100);
-        if let Value::Lit(Literal::LitInt(0)) = v {
-            // OK
-        } else {
+        let Value::Lit(Literal::LitInt(0)) = v else {
             panic!("Expected terminal LitInt(0), got {:?}", v);
-        }
+        };
     }
 }

--- a/tidepool-codegen/tests/signal_safety.rs
+++ b/tidepool-codegen/tests/signal_safety.rs
@@ -29,13 +29,11 @@ fn test_sigill_returns_signal_error() {
         })
     };
 
-    match result {
-        Err(e) => {
-            assert_eq!(e.0, libc::SIGILL, "expected SIGILL, got signal {}", e.0);
-            eprintln!("Signal caught correctly: {}", e);
-        }
-        Ok(()) => panic!("expected SignalError, got Ok"),
-    }
+    let Err(e) = result else {
+        panic!("expected SignalError, got Ok");
+    };
+    assert_eq!(e.0, libc::SIGILL, "expected SIGILL, got signal {}", e.0);
+    eprintln!("Signal caught correctly: {}", e);
 }
 
 #[test]

--- a/tidepool-codegen/tests/tco.rs
+++ b/tidepool-codegen/tests/tco.rs
@@ -12,10 +12,10 @@ use tidepool_repr::types::*;
 use tidepool_repr::{CoreExpr, Literal, TreeBuilder};
 
 fn assert_lit_int(val: &Value, expected: i64) {
-    match val {
-        Value::Lit(Literal::LitInt(n)) => assert_eq!(*n, expected),
-        other => panic!("expected Lit(Int({})), got {:?}", expected, other),
-    }
+    let Value::Lit(Literal::LitInt(n)) = val else {
+        panic!("expected Lit(Int({})), got {:?}", expected, val);
+    };
+    assert_eq!(*n, expected);
 }
 
 fn empty_table() -> DataConTable {

--- a/tidepool-codegen/tests/tco_advanced.rs
+++ b/tidepool-codegen/tests/tco_advanced.rs
@@ -6,10 +6,10 @@ use tidepool_repr::types::*;
 use tidepool_repr::{Literal, TreeBuilder};
 
 fn assert_lit_int(val: &Value, expected: i64) {
-    match val {
-        Value::Lit(Literal::LitInt(n)) => assert_eq!(*n, expected),
-        other => panic!("expected Lit(Int({})), got {:?}", expected, other),
-    }
+    let Value::Lit(Literal::LitInt(n)) = val else {
+        panic!("expected Lit(Int({})), got {:?}", expected, val);
+    };
+    assert_eq!(*n, expected);
 }
 
 fn empty_table() -> DataConTable {

--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -11,17 +11,19 @@ use tidepool_repr::{
 /// bound to its worker VarId, so that `Var` references to constructors
 /// in the expression tree resolve correctly.
 pub fn env_from_datacon_table(table: &DataConTable) -> Env {
-    let mut env = Env::new();
-    for dc in table.iter() {
-        let var = VarId(dc.id.0);
-        if dc.rep_arity == 0 {
-            // Nullary constructor: just a Con value
-            env.insert(var, Value::Con(dc.id, vec![]));
-        } else {
-            env.insert(var, Value::ConFun(dc.id, dc.rep_arity as usize, vec![]));
-        }
-    }
-    env
+    table
+        .iter()
+        .map(|dc| {
+            let var = VarId(dc.id.0);
+            let val = if dc.rep_arity == 0 {
+                // Nullary constructor: just a Con value
+                Value::Con(dc.id, vec![])
+            } else {
+                Value::ConFun(dc.id, dc.rep_arity as usize, vec![])
+            };
+            (var, val)
+        })
+        .collect()
 }
 
 /// Evaluate a CoreExpr to a Value.
@@ -221,28 +223,28 @@ fn eval_at(
             eval_at(expr, *body, &new_env, heap)
         }
         CoreFrame::Con { tag, fields } => {
-            let mut field_vals = Vec::with_capacity(fields.len());
-            for &f in fields {
-                // Thunkify non-trivial fields to enable lazy evaluation.
-                // Var and Lit are cheap lookups; everything else (App, Case,
-                // Let, PrimOp, nested Con) gets wrapped in a thunk so that
-                // infinite structures like `cycle` and `zipWith ... [0..]`
-                // don't diverge at construction time.
-                match &expr.nodes[f] {
-                    CoreFrame::Var(_)
-                    | CoreFrame::Lit(_)
-                    | CoreFrame::Con { .. }
-                    | CoreFrame::Lam { .. }
-                    | CoreFrame::PrimOp { .. } => {
-                        field_vals.push(eval_at(expr, f, env, heap)?);
+            let field_vals = fields
+                .iter()
+                .map(|&f| {
+                    // Thunkify non-trivial fields to enable lazy evaluation.
+                    // Var and Lit are cheap lookups; everything else (App, Case,
+                    // Let, PrimOp, nested Con) gets wrapped in a thunk so that
+                    // infinite structures like `cycle` and `zipWith ... [0..]`
+                    // don't diverge at construction time.
+                    match &expr.nodes[f] {
+                        CoreFrame::Var(_)
+                        | CoreFrame::Lit(_)
+                        | CoreFrame::Con { .. }
+                        | CoreFrame::Lam { .. }
+                        | CoreFrame::PrimOp { .. } => eval_at(expr, f, env, heap),
+                        _ => {
+                            let subtree = expr.extract_subtree(f);
+                            let thunk_id = heap.alloc(env.clone(), subtree);
+                            Ok(Value::ThunkRef(thunk_id))
+                        }
                     }
-                    _ => {
-                        let subtree = expr.extract_subtree(f);
-                        let thunk_id = heap.alloc(env.clone(), subtree);
-                        field_vals.push(Value::ThunkRef(thunk_id));
-                    }
-                }
-            }
+                })
+                .collect::<Result<Vec<_>, _>>()?;
             Ok(Value::Con(*tag, field_vals))
         }
         CoreFrame::Case {
@@ -294,11 +296,10 @@ fn eval_at(
             Err(EvalError::NoMatchingAlt)
         }
         CoreFrame::PrimOp { op, args } => {
-            let mut arg_vals = Vec::with_capacity(args.len());
-            for &arg in args {
-                let val = force(eval_at(expr, arg, env, heap)?, heap)?;
-                arg_vals.push(val);
-            }
+            let arg_vals: Vec<Value> = args
+                .iter()
+                .map(|&arg| force(eval_at(expr, arg, env, heap)?, heap))
+                .collect::<Result<_, _>>()?;
             // Handle primops that need heap access for deep forcing
             match op {
                 PrimOpKind::ShowDoubleAddr => {
@@ -2100,21 +2101,19 @@ mod tests {
         let f_state = heap.read(ThunkId(0));
         let g_state = heap.read(ThunkId(1));
 
-        match f_state {
-            ThunkState::Evaluated(Value::Closure(..)) => (),
-            _ => panic!(
+        let ThunkState::Evaluated(Value::Closure(..)) = f_state else {
+            panic!(
                 "Expected f to be eagerly evaluated to a Closure, got {:?}",
                 f_state
-            ),
-        }
+            );
+        };
 
-        match g_state {
-            ThunkState::Evaluated(Value::Closure(..)) => (),
-            _ => panic!(
+        let ThunkState::Evaluated(Value::Closure(..)) = g_state else {
+            panic!(
                 "Expected g to be eagerly evaluated to a Closure, got {:?}",
                 g_state
-            ),
-        }
+            );
+        };
 
         // Now also verify correctness by evaluating f 5.
         // letrec { f = \n -> g n; g = \n -> n + 1 } in f 5
@@ -2159,11 +2158,10 @@ mod tests {
         };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
+        let Value::Lit(Literal::LitInt(n)) = res else {
             panic!("Expected LitInt(42), got {:?}", res);
-        }
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2175,11 +2173,10 @@ mod tests {
         env.insert(VarId(1), Value::Lit(Literal::LitInt(42)));
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &env, &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
+        let Value::Lit(Literal::LitInt(n)) = res else {
             panic!("Expected LitInt(42), got {:?}", res);
-        }
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2206,11 +2203,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
+        let Value::Lit(Literal::LitInt(n)) = res else {
             panic!("Expected LitInt(42), got {:?}", res);
-        }
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2227,11 +2223,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 1);
-        } else {
+        let Value::Lit(Literal::LitInt(n)) = res else {
             panic!("Expected LitInt(1), got {:?}", res);
-        }
+        };
+        assert_eq!(n, 1);
     }
 
     #[test]
@@ -2246,17 +2241,15 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Con(tag, fields) = res {
-            assert_eq!(tag.0, 1);
-            assert_eq!(fields.len(), 1);
-            if let Value::Lit(Literal::LitInt(n)) = fields[0] {
-                assert_eq!(n, 42);
-            } else {
-                panic!("Expected LitInt(42)");
-            }
-        } else {
-            panic!("Expected Con");
-        }
+        let Value::Con(tag, fields) = res else {
+            panic!("Expected Con, got {:?}", res);
+        };
+        assert_eq!(tag.0, 1);
+        assert_eq!(fields.len(), 1);
+        let Value::Lit(Literal::LitInt(n)) = fields[0] else {
+            panic!("Expected LitInt(42), got {:?}", fields[0]);
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2272,11 +2265,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 3);
-        } else {
-            panic!("Expected LitInt(3)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(3), got {:?}", res);
+        };
+        assert_eq!(n, 3);
     }
 
     #[test]
@@ -2295,11 +2287,10 @@ mod tests {
                 },
             ];
             let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
-            if let Value::Lit(Literal::LitInt(n)) = res {
-                assert_eq!(n, 4);
-            } else {
+            let Value::Lit(Literal::LitInt(n)) = res else {
                 panic!("Expected LitInt(4), got {:?}", res);
-            }
+            };
+            assert_eq!(n, 4);
         }
         // -16 >> 2 = -4 (preserves sign)
         {
@@ -2312,11 +2303,10 @@ mod tests {
                 },
             ];
             let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
-            if let Value::Lit(Literal::LitInt(n)) = res {
-                assert_eq!(n, -4);
-            } else {
+            let Value::Lit(Literal::LitInt(n)) = res else {
                 panic!("Expected LitInt(-4), got {:?}", res);
-            }
+            };
+            assert_eq!(n, -4);
         }
         // 16 >> 0 = 16
         {
@@ -2329,11 +2319,10 @@ mod tests {
                 },
             ];
             let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
-            if let Value::Lit(Literal::LitInt(n)) = res {
-                assert_eq!(n, 16);
-            } else {
+            let Value::Lit(Literal::LitInt(n)) = res else {
                 panic!("Expected LitInt(16), got {:?}", res);
-            }
+            };
+            assert_eq!(n, 16);
         }
 
         // IntShrl (Logical Right Shift)
@@ -2348,11 +2337,10 @@ mod tests {
                 },
             ];
             let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
-            if let Value::Lit(Literal::LitInt(n)) = res {
-                assert_eq!(n, 4611686018427387900);
-            } else {
+            let Value::Lit(Literal::LitInt(n)) = res else {
                 panic!("Expected LitInt(4611686018427387900), got {:?}", res);
-            }
+            };
+            assert_eq!(n, 4611686018427387900);
         }
 
         // IntShl (Logical Left Shift)
@@ -2367,11 +2355,10 @@ mod tests {
                 },
             ];
             let res = eval(&CoreExpr { nodes }, &Env::new(), &mut heap).unwrap();
-            if let Value::Lit(Literal::LitInt(n)) = res {
-                assert_eq!(n, 64);
-            } else {
+            let Value::Lit(Literal::LitInt(n)) = res else {
                 panic!("Expected LitInt(64), got {:?}", res);
-            }
+            };
+            assert_eq!(n, 64);
         }
     }
 
@@ -2396,11 +2383,10 @@ mod tests {
             let mut heap = crate::heap::VecHeap::new();
             let res = eval(&expr, &Env::new(), &mut heap)
                 .unwrap_or_else(|_| panic!("eval failed for a={}, b={}", a, b));
-            if let Value::Lit(Literal::LitInt(n)) = res {
-                assert_eq!(n, expected, "Failed for a={}, b={}", a, b);
-            } else {
+            let Value::Lit(Literal::LitInt(n)) = res else {
                 panic!("Expected LitInt({}), got {:?}", expected, res);
-            }
+            };
+            assert_eq!(n, expected, "Failed for a={}, b={}", a, b);
         }
     }
 
@@ -2426,11 +2412,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
-            panic!("Expected LitInt(42)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(42), got {:?}", res);
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2455,11 +2440,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Con(tag, _) = res {
-            assert_eq!(tag.0, 1);
-        } else {
-            panic!("Expected Con");
-        }
+        let Value::Con(tag, _) = res else {
+            panic!("Expected Con, got {:?}", res);
+        };
+        assert_eq!(tag.0, 1);
     }
 
     #[test]
@@ -2494,11 +2478,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 30);
-        } else {
-            panic!("Expected LitInt(30)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(30), got {:?}", res);
+        };
+        assert_eq!(n, 30);
     }
 
     #[test]
@@ -2516,11 +2499,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 5);
-        } else {
-            panic!("Expected LitInt(5)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(5), got {:?}", res);
+        };
+        assert_eq!(n, 5);
     }
 
     #[test]
@@ -2538,11 +2520,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 1);
-        } else {
-            panic!("Expected LitInt(1)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(1), got {:?}", res);
+        };
+        assert_eq!(n, 1);
     }
 
     #[test]
@@ -2565,11 +2546,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
+        let Value::Lit(Literal::LitInt(n)) = res else {
             panic!("Expected LitInt(42), got {:?}", res);
-        }
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2598,11 +2578,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 3);
-        } else {
-            panic!("Expected LitInt(3)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(3), got {:?}", res);
+        };
+        assert_eq!(n, 3);
     }
 
     #[test]
@@ -2632,11 +2611,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
-            panic!("Expected LitInt(42)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(42), got {:?}", res);
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2662,11 +2640,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 4);
-        } else {
-            panic!("Expected LitInt(4)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(4), got {:?}", res);
+        };
+        assert_eq!(n, 4);
     }
 
     #[test]
@@ -2712,11 +2689,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
-            panic!("Expected LitInt(42)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(42), got {:?}", res);
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2760,11 +2736,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 101);
-        } else {
-            panic!("Expected LitInt(101)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(101), got {:?}", res);
+        };
+        assert_eq!(n, 101);
     }
 
     #[test]
@@ -2934,11 +2909,10 @@ mod tests {
         let mut heap = crate::heap::VecHeap::new();
         let val = Value::Lit(Literal::LitInt(42));
         let res = force(val, &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
-            panic!("Expected LitInt(42)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(42), got {:?}", res);
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -2958,24 +2932,20 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        match res {
-            Value::Con(tag, fields) => {
-                assert_eq!(tag.0, 2);
-                assert_eq!(fields.len(), 1);
-                match &fields[0] {
-                    Value::Con(tag2, fields2) => {
-                        assert_eq!(tag2.0, 1);
-                        assert_eq!(fields2.len(), 1);
-                        match &fields2[0] {
-                            Value::Lit(Literal::LitInt(n)) => assert_eq!(*n, 42),
-                            _ => panic!("Expected LitInt(42)"),
-                        }
-                    }
-                    _ => panic!("Expected inner Con"),
-                }
-            }
-            _ => panic!("Expected outer Con"),
-        }
+        let Value::Con(tag, fields) = res else {
+            panic!("Expected outer Con, got {:?}", res);
+        };
+        assert_eq!(tag.0, 2);
+        assert_eq!(fields.len(), 1);
+        let Value::Con(tag2, fields2) = &fields[0] else {
+            panic!("Expected inner Con, got {:?}", fields[0]);
+        };
+        assert_eq!(tag2.0, 1);
+        assert_eq!(fields2.len(), 1);
+        let Value::Lit(Literal::LitInt(n)) = &fields2[0] else {
+            panic!("Expected LitInt(42), got {:?}", fields2[0]);
+        };
+        assert_eq!(*n, 42);
     }
 
     #[test]
@@ -2997,11 +2967,10 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
-            panic!("Expected LitInt(42)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(42), got {:?}", res);
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]
@@ -3013,12 +2982,11 @@ mod tests {
         let expr = CoreExpr { nodes };
         let mut heap = crate::heap::VecHeap::new();
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Con(tag, fields) = res {
-            assert_eq!(tag.0, 1);
-            assert!(fields.is_empty());
-        } else {
-            panic!("Expected empty Con");
-        }
+        let Value::Con(tag, fields) = res else {
+            panic!("Expected empty Con, got {:?}", res);
+        };
+        assert_eq!(tag.0, 1);
+        assert!(fields.is_empty());
     }
 
     #[test]
@@ -3043,11 +3011,10 @@ mod tests {
         let mut heap = crate::heap::VecHeap::new();
         // Since y is not forced, this should SUCCEED and return 1
         let res = eval(&expr, &Env::new(), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 1);
-        } else {
-            panic!("Expected LitInt(1)");
-        }
+        let Value::Lit(Literal::LitInt(n)) = res else {
+            panic!("Expected LitInt(1), got {:?}", res);
+        };
+        assert_eq!(n, 1);
     }
 
     #[test]
@@ -3096,26 +3063,27 @@ mod tests {
         // it would return ThunkRef(id_b) instead of 42.
         let res = force(Value::ThunkRef(id_a), &mut heap).unwrap();
 
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
+        let Value::Lit(Literal::LitInt(n)) = res else {
             panic!("Expected LitInt(42), got {:?}", res);
-        }
+        };
+        assert_eq!(n, 42);
 
         // Verify that B was also forced on the heap.
-        match heap.read(id_b) {
-            ThunkState::Evaluated(Value::Lit(Literal::LitInt(n))) => assert_eq!(*n, 42),
-            other => panic!("Expected id_b to be Evaluated(42), got {:?}", other),
-        }
+        let ThunkState::Evaluated(Value::Lit(Literal::LitInt(n_b))) = heap.read(id_b) else {
+            panic!(
+                "Expected id_b to be Evaluated(42), got {:?}",
+                heap.read(id_b)
+            );
+        };
+        assert_eq!(*n_b, 42);
 
         // Forcing A again. It should still return 42.
         // This time it hits: Evaluated(A) -> force(ThunkRef B) -> Evaluated(B) -> 42.
         let res2 = force(Value::ThunkRef(id_a), &mut heap).unwrap();
-        if let Value::Lit(Literal::LitInt(n)) = res2 {
-            assert_eq!(n, 42);
-        } else {
+        let Value::Lit(Literal::LitInt(n2)) = res2 else {
             panic!("Expected LitInt(42), got {:?}", res2);
-        }
+        };
+        assert_eq!(n2, 42);
     }
 
     #[test]
@@ -3145,16 +3113,18 @@ mod tests {
         // x gets updated to Evaluated(42).
         let res = force(Value::ThunkRef(id_x), &mut heap).unwrap();
 
-        if let Value::Lit(Literal::LitInt(n)) = res {
-            assert_eq!(n, 42);
-        } else {
+        let Value::Lit(Literal::LitInt(n)) = res else {
             panic!("Expected LitInt(42), got {:?}", res);
-        }
+        };
+        assert_eq!(n, 42);
 
         // In this case, x DOES get compressed because eval() forces.
-        match heap.read(id_x) {
-            ThunkState::Evaluated(Value::Lit(Literal::LitInt(n))) => assert_eq!(*n, 42),
-            other => panic!("Expected id_x to be Evaluated(42), got {:?}", other),
-        }
+        let ThunkState::Evaluated(Value::Lit(Literal::LitInt(n_x))) = heap.read(id_x) else {
+            panic!(
+                "Expected id_x to be Evaluated(42), got {:?}",
+                heap.read(id_x)
+            );
+        };
+        assert_eq!(*n_x, 42);
     }
 }

--- a/tidepool-heap/src/arena.rs
+++ b/tidepool-heap/src/arena.rs
@@ -217,23 +217,20 @@ mod tests {
         assert_eq!(id1.0, 0);
         assert_eq!(id2.0, 1);
 
-        match heap.read(id1) {
-            ThunkState::Unevaluated(_, _) => (),
-            _ => panic!("Expected Unevaluated"),
-        }
+        let ThunkState::Unevaluated(_, _) = heap.read(id1) else {
+            panic!("Expected Unevaluated");
+        };
 
         heap.write(id1, ThunkState::BlackHole);
-        match heap.read(id1) {
-            ThunkState::BlackHole => (),
-            _ => panic!("Expected BlackHole"),
-        }
+        let ThunkState::BlackHole = heap.read(id1) else {
+            panic!("Expected BlackHole");
+        };
 
         let val = Value::Lit(Literal::LitInt(100));
         heap.write(id1, ThunkState::Evaluated(val));
-        match heap.read(id1) {
-            ThunkState::Evaluated(Value::Lit(Literal::LitInt(100))) => (),
-            _ => panic!("Expected Evaluated(100)"),
-        }
+        let ThunkState::Evaluated(Value::Lit(Literal::LitInt(100))) = heap.read(id1) else {
+            panic!("Expected Evaluated(100)");
+        };
     }
 
     #[test]
@@ -326,14 +323,12 @@ mod tests {
         assert_eq!(new_id2, ThunkId(1));
 
         // Both are readable
-        match heap.read(new_id0) {
-            ThunkState::Unevaluated(_, _) => (),
-            _ => panic!("Expected Unevaluated"),
-        }
-        match heap.read(new_id2) {
-            ThunkState::Unevaluated(_, _) => (),
-            _ => panic!("Expected Unevaluated"),
-        }
+        let ThunkState::Unevaluated(_, _) = heap.read(new_id0) else {
+            panic!("Expected Unevaluated");
+        };
+        let ThunkState::Unevaluated(_, _) = heap.read(new_id2) else {
+            panic!("Expected Unevaluated");
+        };
     }
 
     #[test]
@@ -355,17 +350,15 @@ mod tests {
 
         assert_eq!(heap.thunk_count(), 2);
         let new_id1 = table.lookup(id1).unwrap();
-        match heap.read(new_id1) {
-            ThunkState::Unevaluated(env, _) => {
-                // The ThunkRef should point to the NEW id for id0
-                let new_id0 = table.lookup(id0).unwrap();
-                match env.get(&VarId(42)).unwrap() {
-                    Value::ThunkRef(id) => assert_eq!(*id, new_id0),
-                    _ => panic!("Expected ThunkRef"),
-                }
-            }
-            _ => panic!("Expected Unevaluated"),
-        }
+        let ThunkState::Unevaluated(env, _) = heap.read(new_id1) else {
+            panic!("Expected Unevaluated");
+        };
+        // The ThunkRef should point to the NEW id for id0
+        let new_id0 = table.lookup(id0).unwrap();
+        let Value::ThunkRef(id) = env.get(&VarId(42)).unwrap() else {
+            panic!("Expected ThunkRef");
+        };
+        assert_eq!(*id, new_id0);
     }
 
     #[test]

--- a/tidepool-heap/tests/gc_unit.rs
+++ b/tidepool-heap/tests/gc_unit.rs
@@ -111,19 +111,18 @@ fn test_gc_thunkref_tracing() {
     let new_id_a = table.lookup(id_a).expect("Thunk A should be alive");
 
     // Check what id_a points to now
-    let new_id_b = match heap.read(new_id_a) {
-        ThunkState::Evaluated(Value::ThunkRef(id)) => *id,
-        _ => panic!("Expected Thunk A to be Evaluated(ThunkRef(_))"),
+    let ThunkState::Evaluated(Value::ThunkRef(new_id_b)) = heap.read(new_id_a) else {
+        panic!("Expected Thunk A to be Evaluated(ThunkRef(_))");
     };
+    let new_id_b = *new_id_b;
 
     // Assert id_b survived and has correct value
-    match heap.read(new_id_b) {
-        ThunkState::Evaluated(Value::Lit(Literal::LitInt(99))) => (),
-        other => panic!(
+    let ThunkState::Evaluated(Value::Lit(Literal::LitInt(99))) = heap.read(new_id_b) else {
+        panic!(
             "Expected Thunk B to be Evaluated(LitInt(99)), got {:?}",
-            other
-        ),
-    }
+            heap.read(new_id_b)
+        );
+    };
 
     // Also verify B is in the forwarding table
     assert!(

--- a/tidepool-heap/tests/proptest_heap.rs
+++ b/tidepool-heap/tests/proptest_heap.rs
@@ -124,10 +124,9 @@ proptest! {
             assert!(table.is_reachable(id));
             let new_id = table.lookup(id).unwrap();
             // Verify we can still read the thunk
-            match heap.read(new_id) {
-                ThunkState::Unevaluated(_, _) => (),
-                _ => panic!("Expected Unevaluated thunk state after GC"),
-            }
+            let ThunkState::Unevaluated(_, _) = heap.read(new_id) else {
+                panic!("Expected Unevaluated thunk state after GC");
+            };
         }
     }
 
@@ -193,20 +192,16 @@ proptest! {
         // Verify the chain structure is preserved
         let mut current_new_id = table.lookup(root).unwrap();
         for i in (1..chain_len).rev() {
-            match heap.read(current_new_id) {
-                ThunkState::Unevaluated(env, _) => {
-                    let prev_old_id = ids[i-1];
-                    let expected_new_id = table.lookup(prev_old_id).unwrap();
-                    match env.get(&VarId(i as u64)).expect("Value not found in env") {
-                        Value::ThunkRef(id) => {
-                            prop_assert_eq!(*id, expected_new_id, "Chain link broken at index {}", i);
-                            current_new_id = table.lookup(prev_old_id).unwrap();
-                        }
-                        _ => panic!("Expected ThunkRef"),
-                    }
-                }
-                _ => panic!("Expected Unevaluated thunk"),
-            }
+            let ThunkState::Unevaluated(env, _) = heap.read(current_new_id) else {
+                panic!("Expected Unevaluated thunk");
+            };
+            let prev_old_id = ids[i - 1];
+            let expected_new_id = table.lookup(prev_old_id).unwrap();
+            let Value::ThunkRef(id) = env.get(&VarId(i as u64)).expect("Value not found in env") else {
+                panic!("Expected ThunkRef");
+            };
+            prop_assert_eq!(*id, expected_new_id, "Chain link broken at index {}", i);
+            current_new_id = table.lookup(prev_old_id).unwrap();
         }
     }
 
@@ -242,10 +237,9 @@ proptest! {
 
             // Verify all roots are valid
             for &root in &roots {
-                match heap.read(root) {
-                    ThunkState::Unevaluated(_, _) => (),
-                    _ => panic!("Expected Unevaluated thunk after cycle {}", cycle),
-                }
+                let ThunkState::Unevaluated(_, _) = heap.read(root) else {
+                    panic!("Expected Unevaluated thunk after cycle {}", cycle);
+                };
             }
 
             prop_assert_eq!(heap.thunk_count(), roots.len(), "Heap should only contain roots");

--- a/tidepool-mcp/src/lib.rs
+++ b/tidepool-mcp/src/lib.rs
@@ -391,14 +391,14 @@ pub fn build_preamble(effects: &[EffectDecl], user_library: bool) -> String {
     out.push('\n');
 
     for eff in effects {
-        for td in eff.type_defs {
+        eff.type_defs.iter().for_each(|td| {
             out.push_str(td);
             out.push('\n');
-        }
+        });
         out.push_str(&format!("data {} a where\n", eff.type_name));
-        for ctor in eff.constructors {
+        eff.constructors.iter().for_each(|ctor| {
             out.push_str(&format!("  {}\n", ctor));
-        }
+        });
         out.push('\n');
     }
 
@@ -865,9 +865,9 @@ fn build_eval_tool_description(effects: &[EffectDecl]) -> String {
 
     if !effects.is_empty() {
         desc.push_str("\nAvailable effects (use `send` to invoke):\n");
-        for eff in effects {
+        effects.iter().for_each(|eff| {
             desc.push_str(&format!("\n{}: {}\n", eff.type_name, eff.description));
-        }
+        });
 
         // List built-in helpers
         let has_console = effects.iter().any(|e| e.type_name == "Console");
@@ -877,14 +877,12 @@ fn build_eval_tool_description(effects: &[EffectDecl]) -> String {
             if has_console {
                 desc.push_str("  say :: Text -> M ()\n");
             }
-            for eff in effects {
-                for h in eff.helpers {
-                    // Extract just the type signature line
-                    if let Some(sig) = h.lines().next() {
-                        desc.push_str(&format!("  {}\n", sig));
-                    }
+            effects.iter().flat_map(|e| e.helpers).for_each(|h| {
+                // Extract just the type signature line
+                if let Some(sig) = h.lines().next() {
+                    desc.push_str(&format!("  {}\n", sig));
                 }
-            }
+            });
             desc.push_str(
                 "\nPrefer helpers over raw `send`: `say \"hi\"` not `send (Print \"hi\")`.\n",
             );
@@ -1218,28 +1216,34 @@ fn extract_ask_prompt(
 ) -> Result<String, String> {
     use tidepool_eval::value::Value;
 
-    if let Value::Con(_, fields) = request {
-        if let Some(prompt_val) = fields.first() {
-            // Try using FromCore (handles Text, LitString, [Char])
-            match String::from_value(prompt_val, table) {
-                Ok(s) => return Ok(s),
-                Err(e) => {
-                    // Provide diagnostic: the prompt text couldn't be extracted,
-                    // likely because the string-building expression crashed
-                    // (e.g., unresolved external, partial evaluation).
-                    return Err(format!(
-                        "ask prompt could not be evaluated to Text: {e}. \
-                         The expression passed to `ask` likely crashed during evaluation \
-                         (check for unresolved externals or runtime errors in the prompt string)."
-                    ));
-                }
-            }
+    let Value::Con(_, fields) = request else {
+        return Err(format!(
+            "ask received unexpected request shape (expected Con(Ask, [text])): {:?}",
+            request
+        ));
+    };
+
+    let Some(prompt_val) = fields.first() else {
+        return Err(format!(
+            "ask received unexpected request shape (expected Con(Ask, [text])): {:?}",
+            request
+        ));
+    };
+
+    // Try using FromCore (handles Text, LitString, [Char])
+    match String::from_value(prompt_val, table) {
+        Ok(s) => Ok(s),
+        Err(e) => {
+            // Provide diagnostic: the prompt text couldn't be extracted,
+            // likely because the string-building expression crashed
+            // (e.g., unresolved external, partial evaluation).
+            Err(format!(
+                "ask prompt could not be evaluated to Text: {e}. \
+                 The expression passed to `ask` likely crashed during evaluation \
+                 (check for unresolved externals or runtime errors in the prompt string)."
+            ))
         }
     }
-    Err(format!(
-        "ask received unexpected request shape (expected Con(Ask, [text])): {:?}",
-        request
-    ))
 }
 
 // ---------------------------------------------------------------------------

--- a/tidepool-optimize/src/beta.rs
+++ b/tidepool-optimize/src/beta.rs
@@ -33,89 +33,44 @@ fn try_beta_at(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
     match &expr.nodes[idx] {
         CoreFrame::App { fun, arg } => {
             // Check if fun is a Lam
-            if let CoreFrame::Lam { binder, body } = &expr.nodes[*fun] {
-                // Found a manifest beta redex!
-                let body_tree = expr.extract_subtree(*body);
-                let arg_tree = expr.extract_subtree(*arg);
-                let substituted = tidepool_repr::subst::subst(&body_tree, *binder, &arg_tree);
-                Some(replace_subtree(expr, idx, &substituted))
-            } else {
+            let CoreFrame::Lam { binder, body } = &expr.nodes[*fun] else {
                 // Try to find redex in children
-                try_beta_at(expr, *fun).or_else(|| try_beta_at(expr, *arg))
-            }
+                return try_beta_at(expr, *fun).or_else(|| try_beta_at(expr, *arg));
+            };
+            // Found a manifest beta redex!
+            let body_tree = expr.extract_subtree(*body);
+            let arg_tree = expr.extract_subtree(*arg);
+            let substituted = tidepool_repr::subst::subst(&body_tree, *binder, &arg_tree);
+            Some(replace_subtree(expr, idx, &substituted))
         }
         // For other nodes, try each child
-        other => {
-            let mut result = None;
-            // We need to visit children. Since map_layer is for remapping indices,
-            // we can use it to "visit" indices if we are careful.
-            // But it's easier to just match on the frame and visit children.
-            match other {
-                CoreFrame::Var(_) | CoreFrame::Lit(_) => {}
-                CoreFrame::App { .. } => {
-                    // App nodes are handled in the outer match — this arm should never fire.
-                    return None;
-                }
-                CoreFrame::Lam { body, .. } => {
-                    result = try_beta_at(expr, *body);
-                }
-                CoreFrame::LetNonRec { rhs, body, .. } => {
-                    result = try_beta_at(expr, *rhs).or_else(|| try_beta_at(expr, *body));
-                }
-                CoreFrame::LetRec { bindings, body } => {
-                    for (_, rhs) in bindings {
-                        result = try_beta_at(expr, *rhs);
-                        if result.is_some() {
-                            break;
-                        }
-                    }
-                    if result.is_none() {
-                        result = try_beta_at(expr, *body);
-                    }
-                }
-                CoreFrame::Case {
-                    scrutinee, alts, ..
-                } => {
-                    result = try_beta_at(expr, *scrutinee);
-                    if result.is_none() {
-                        for alt in alts {
-                            result = try_beta_at(expr, alt.body);
-                            if result.is_some() {
-                                break;
-                            }
-                        }
-                    }
-                }
-                CoreFrame::Con { fields, .. } => {
-                    for field in fields {
-                        result = try_beta_at(expr, *field);
-                        if result.is_some() {
-                            break;
-                        }
-                    }
-                }
-                CoreFrame::Join { rhs, body, .. } => {
-                    result = try_beta_at(expr, *rhs).or_else(|| try_beta_at(expr, *body));
-                }
-                CoreFrame::Jump { args, .. } => {
-                    for arg in args {
-                        result = try_beta_at(expr, *arg);
-                        if result.is_some() {
-                            break;
-                        }
-                    }
-                }
-                CoreFrame::PrimOp { args, .. } => {
-                    for arg in args {
-                        result = try_beta_at(expr, *arg);
-                        if result.is_some() {
-                            break;
-                        }
-                    }
-                }
+        other => match other {
+            CoreFrame::Var(_) | CoreFrame::Lit(_) => None,
+            CoreFrame::App { .. } => {
+                // App nodes are handled in the outer match — this arm should never fire.
+                None
             }
-            result
-        }
+            CoreFrame::Lam { body, .. } => try_beta_at(expr, *body),
+            CoreFrame::LetNonRec { rhs, body, .. } => {
+                try_beta_at(expr, *rhs).or_else(|| try_beta_at(expr, *body))
+            }
+            CoreFrame::LetRec { bindings, body } => bindings
+                .iter()
+                .find_map(|(_, rhs)| try_beta_at(expr, *rhs))
+                .or_else(|| try_beta_at(expr, *body)),
+            CoreFrame::Case {
+                scrutinee, alts, ..
+            } => try_beta_at(expr, *scrutinee)
+                .or_else(|| alts.iter().find_map(|alt| try_beta_at(expr, alt.body))),
+            CoreFrame::Con { fields, .. } => {
+                fields.iter().find_map(|field| try_beta_at(expr, *field))
+            }
+            CoreFrame::Join { rhs, body, .. } => {
+                try_beta_at(expr, *rhs).or_else(|| try_beta_at(expr, *body))
+            }
+            CoreFrame::Jump { args, .. } => args.iter().find_map(|arg| try_beta_at(expr, *arg)),
+            CoreFrame::PrimOp { args, .. } => args.iter().find_map(|arg| try_beta_at(expr, *arg)),
+        },
     }
 }
 
@@ -163,16 +118,13 @@ mod tests {
         assert!(changed);
         // Result should be λy.1
         let root = expr.nodes.len() - 1;
-        if let CoreFrame::Lam { binder, body } = &expr.nodes[root] {
-            assert_eq!(*binder, y);
-            if let CoreFrame::Lit(Literal::LitInt(1)) = &expr.nodes[*body] {
-                // OK
-            } else {
-                panic!("Body should be 1, got {:?}", expr.nodes[*body]);
-            }
-        } else {
+        let CoreFrame::Lam { binder, body } = &expr.nodes[root] else {
             panic!("Result should be Lam, got {:?}", expr.nodes[root]);
-        }
+        };
+        assert_eq!(*binder, y);
+        let CoreFrame::Lit(Literal::LitInt(1)) = &expr.nodes[*body] else {
+            panic!("Body should be 1, got {:?}", expr.nodes[*body]);
+        };
     }
 
     #[test]
@@ -207,16 +159,14 @@ mod tests {
 
         assert!(changed);
         let root = expr.nodes.len() - 1;
-        if let CoreFrame::Lam { binder, body } = &expr.nodes[root] {
-            assert_ne!(*binder, y); // Should be renamed
-            if let CoreFrame::Var(v) = &expr.nodes[*body] {
-                assert_eq!(*v, y); // Should refer to the free y
-            } else {
-                panic!("Body should be Var(y)");
-            }
-        } else {
+        let CoreFrame::Lam { binder, body } = &expr.nodes[root] else {
             panic!("Result should be Lam");
-        }
+        };
+        assert_ne!(*binder, y); // Should be renamed
+        let CoreFrame::Var(v) = &expr.nodes[*body] else {
+            panic!("Body should be Var(y)");
+        };
+        assert_eq!(*v, y); // Should refer to the free y
     }
 
     #[test]
@@ -244,22 +194,20 @@ mod tests {
         let val_orig = eval(&expr_orig, &env, &mut heap).expect("Original eval failed");
         let val_reduced = eval(&expr_reduced, &env, &mut heap).expect("Reduced eval failed");
 
-        if let (tidepool_eval::Value::Lit(l1), tidepool_eval::Value::Lit(l2)) =
+        let (tidepool_eval::Value::Lit(l1), tidepool_eval::Value::Lit(l2)) =
             (&val_orig, &val_reduced)
-        {
-            assert_eq!(l1, l2);
-        } else {
+        else {
             panic!(
                 "Expected literal results, got {:?} and {:?}",
                 val_orig, val_reduced
             );
-        }
+        };
+        assert_eq!(l1, l2);
 
-        if let tidepool_eval::Value::Lit(Literal::LitInt(n)) = val_orig {
-            assert_eq!(n, 42);
-        } else {
+        let tidepool_eval::Value::Lit(Literal::LitInt(n)) = val_orig else {
             panic!("Expected 42");
-        }
+        };
+        assert_eq!(n, 42);
     }
 
     #[test]

--- a/tidepool-optimize/src/case_reduce.rs
+++ b/tidepool-optimize/src/case_reduce.rs
@@ -42,31 +42,31 @@ fn try_case_reduce_at(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
                         .find(|a| matches!(&a.con, AltCon::DataAlt(t) if t == tag))
                         .or_else(|| alts.iter().find(|a| matches!(&a.con, AltCon::Default)));
 
-                    if let Some(alt) = alt {
-                        // Arity check for DataAlt: binders must match fields.
-                        // If mismatch, skip this reduction (malformed IR).
-                        if let AltCon::DataAlt(_) = &alt.con {
-                            if alt.binders.len() != fields.len() {
-                                return try_children(expr, idx);
-                            }
-                        }
-
-                        let mut body = expr.extract_subtree(alt.body);
-                        // Bind fields to alt binders
-                        if let AltCon::DataAlt(_) = &alt.con {
-                            for (alt_binder, field_idx) in alt.binders.iter().zip(fields.iter()) {
-                                let field_tree = expr.extract_subtree(*field_idx);
-                                body = tidepool_repr::subst::subst(&body, *alt_binder, &field_tree);
-                            }
-                        }
-                        // Substitute case binder with scrutinee
-                        let scrut_tree = expr.extract_subtree(*scrutinee);
-                        body = tidepool_repr::subst::subst(&body, *binder, &scrut_tree);
-                        Some(replace_subtree(expr, idx, &body))
-                    } else {
+                    let Some(alt) = alt else {
                         // No matching alt — try children
-                        try_children(expr, idx)
+                        return try_children(expr, idx);
+                    };
+
+                    // Arity check for DataAlt: binders must match fields.
+                    // If mismatch, skip this reduction (malformed IR).
+                    if let AltCon::DataAlt(_) = &alt.con {
+                        if alt.binders.len() != fields.len() {
+                            return try_children(expr, idx);
+                        }
                     }
+
+                    let mut body = expr.extract_subtree(alt.body);
+                    // Bind fields to alt binders
+                    if let AltCon::DataAlt(_) = &alt.con {
+                        for (alt_binder, field_idx) in alt.binders.iter().zip(fields.iter()) {
+                            let field_tree = expr.extract_subtree(*field_idx);
+                            body = tidepool_repr::subst::subst(&body, *alt_binder, &field_tree);
+                        }
+                    }
+                    // Substitute case binder with scrutinee
+                    let scrut_tree = expr.extract_subtree(*scrutinee);
+                    body = tidepool_repr::subst::subst(&body, *binder, &scrut_tree);
+                    Some(replace_subtree(expr, idx, &body))
                 }
                 CoreFrame::Lit(lit) => {
                     let alt = alts
@@ -74,15 +74,15 @@ fn try_case_reduce_at(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
                         .find(|a| matches!(&a.con, AltCon::LitAlt(l) if l == lit))
                         .or_else(|| alts.iter().find(|a| matches!(&a.con, AltCon::Default)));
 
-                    if let Some(alt) = alt {
-                        let mut body = expr.extract_subtree(alt.body);
-                        // Substitute case binder with scrutinee literal
-                        let scrut_tree = expr.extract_subtree(*scrutinee);
-                        body = tidepool_repr::subst::subst(&body, *binder, &scrut_tree);
-                        Some(replace_subtree(expr, idx, &body))
-                    } else {
-                        try_children(expr, idx)
-                    }
+                    let Some(alt) = alt else {
+                        return try_children(expr, idx);
+                    };
+
+                    let mut body = expr.extract_subtree(alt.body);
+                    // Substitute case binder with scrutinee literal
+                    let scrut_tree = expr.extract_subtree(*scrutinee);
+                    body = tidepool_repr::subst::subst(&body, *binder, &scrut_tree);
+                    Some(replace_subtree(expr, idx, &body))
                 }
                 _ => try_children(expr, idx),
             }
@@ -92,13 +92,9 @@ fn try_case_reduce_at(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
 }
 
 fn try_children(expr: &CoreExpr, idx: usize) -> Option<CoreExpr> {
-    let children = get_children(&expr.nodes[idx]);
-    for child in children {
-        if let Some(result) = try_case_reduce_at(expr, child) {
-            return Some(result);
-        }
-    }
-    None
+    get_children(&expr.nodes[idx])
+        .into_iter()
+        .find_map(|child| try_case_reduce_at(expr, child))
 }
 
 #[cfg(test)]
@@ -176,17 +172,13 @@ mod tests {
         let mut heap2 = VecHeap::new();
         let val_after = tidepool_eval::eval(&expr, &Env::new(), &mut heap2).unwrap();
 
-        match (val_before, val_after) {
-            (Value::Lit(l1), Value::Lit(l2)) => {
-                assert_eq!(l1, l2);
-                if let Literal::LitInt(3) = l1 {
-                    // OK
-                } else {
-                    panic!("Expected 3, got {:?}", l1);
-                }
-            }
-            (v1, v2) => panic!("Value mismatch or not Lit: {:?}, {:?}", v1, v2),
-        }
+        let (Value::Lit(l1), Value::Lit(l2)) = (val_before, val_after) else {
+            panic!("Value mismatch or not Lit");
+        };
+        assert_eq!(l1, l2);
+        let Literal::LitInt(3) = l1 else {
+            panic!("Expected 3, got {:?}", l1);
+        };
     }
 
     #[test]
@@ -312,17 +304,14 @@ mod tests {
         let changed = pass.run(&mut expr);
         assert!(changed);
         // Result should be Con(tag=1, [42])
-        if let CoreFrame::Con { tag, fields } = &expr.nodes[expr.nodes.len() - 1] {
-            assert_eq!(tag.0, 1);
-            assert_eq!(fields.len(), 1);
-            if let CoreFrame::Lit(Literal::LitInt(42)) = &expr.nodes[fields[0]] {
-                // OK
-            } else {
-                panic!("Expected field to be 42");
-            }
-        } else {
+        let CoreFrame::Con { tag, fields } = &expr.nodes[expr.nodes.len() - 1] else {
             panic!("Expected Con, got {:?}", expr.nodes[expr.nodes.len() - 1]);
-        }
+        };
+        assert_eq!(tag.0, 1);
+        assert_eq!(fields.len(), 1);
+        let CoreFrame::Lit(Literal::LitInt(42)) = &expr.nodes[fields[0]] else {
+            panic!("Expected field to be 42");
+        };
     }
 
     #[test]
@@ -377,9 +366,10 @@ mod tests {
                 assert_eq!(f1.len(), f2.len());
                 // Simple check for literals in fields
                 for (v1, v2) in f1.iter().zip(f2.iter()) {
-                    if let (Value::Lit(ll1), Value::Lit(ll2)) = (v1, v2) {
-                        assert_eq!(ll1, ll2);
-                    }
+                    let (Value::Lit(ll1), Value::Lit(ll2)) = (v1, v2) else {
+                        continue;
+                    };
+                    assert_eq!(ll1, ll2);
                 }
             }
             (v1, v2) => panic!(

--- a/tidepool-optimize/src/dce.rs
+++ b/tidepool-optimize/src/dce.rs
@@ -59,13 +59,9 @@ fn try_dce_at(expr: &CoreExpr, idx: usize, occ_map: &crate::occ::OccMap) -> Opti
 }
 
 fn try_children(expr: &CoreExpr, idx: usize, occ_map: &crate::occ::OccMap) -> Option<CoreExpr> {
-    let children = get_children(&expr.nodes[idx]);
-    for child in children {
-        if let Some(result) = try_dce_at(expr, child, occ_map) {
-            return Some(result);
-        }
-    }
-    None
+    get_children(&expr.nodes[idx])
+        .into_iter()
+        .find_map(|child| try_dce_at(expr, child, occ_map))
 }
 
 #[cfg(test)]
@@ -188,14 +184,13 @@ mod tests {
         assert_eq!(dce_expr.nodes.len(), 3);
         // The root should be a LetNonRec for x
         let root_idx = dce_expr.nodes.len() - 1;
-        if let CoreFrame::LetNonRec { binder, .. } = &dce_expr.nodes[root_idx] {
-            assert_eq!(*binder, x);
-        } else {
+        let CoreFrame::LetNonRec { binder, .. } = &dce_expr.nodes[root_idx] else {
             panic!(
                 "Root should be LetNonRec for x, got {:?}",
                 dce_expr.nodes[root_idx]
             );
-        }
+        };
+        assert_eq!(*binder, x);
     }
 
     // 6. test_dce_preserves_eval: let x = 42 in let y = 99 in x -> eval before/after, verify match.
@@ -260,11 +255,10 @@ mod tests {
 
         // 1. Original evaluates to 100
         let val_orig = eval(&expr, &env, &mut heap).expect("Original eval failed");
-        if let tidepool_eval::Value::Lit(Literal::LitInt(n)) = val_orig {
-            assert_eq!(n, 100);
-        } else {
+        let tidepool_eval::Value::Lit(Literal::LitInt(n)) = val_orig else {
             panic!("Original should eval to 100, got {:?}", val_orig);
-        }
+        };
+        assert_eq!(n, 100);
 
         // 2. DCE should NOT drop the group because f is live
         let changed = Dce.run(&mut dce_expr);
@@ -276,13 +270,12 @@ mod tests {
 
         // 3. Evaluates correctly after (no-op) DCE
         let val_dce = eval(&dce_expr, &env, &mut heap).expect("DCE eval failed");
-        if let tidepool_eval::Value::Lit(Literal::LitInt(n)) = val_dce {
-            assert_eq!(n, 100);
-        } else {
+        let tidepool_eval::Value::Lit(Literal::LitInt(n2)) = val_dce else {
             panic!(
                 "Result after DCE should still eval to 100, got {:?}",
                 val_dce
             );
-        }
+        };
+        assert_eq!(n2, 100);
     }
 }

--- a/tidepool-optimize/src/inline.rs
+++ b/tidepool-optimize/src/inline.rs
@@ -49,13 +49,9 @@ fn try_inline_at(expr: &CoreExpr, idx: usize, occ_map: &crate::occ::OccMap) -> O
 }
 
 fn try_children(expr: &CoreExpr, idx: usize, occ_map: &crate::occ::OccMap) -> Option<CoreExpr> {
-    let children = get_children(&expr.nodes[idx]);
-    for child in children {
-        if let Some(result) = try_inline_at(expr, child, occ_map) {
-            return Some(result);
-        }
-    }
-    None
+    get_children(&expr.nodes[idx])
+        .into_iter()
+        .find_map(|child| try_inline_at(expr, child, occ_map))
 }
 
 #[cfg(test)]
@@ -198,16 +194,14 @@ mod tests {
 
         // Result should be \y'. y
         let root = expr.nodes.len() - 1;
-        if let CoreFrame::Lam { binder, body } = &expr.nodes[root] {
-            assert_ne!(*binder, y);
-            if let CoreFrame::Var(v) = &expr.nodes[*body] {
-                assert_eq!(*v, y);
-            } else {
-                panic!("Body should be Var(y)");
-            }
-        } else {
+        let CoreFrame::Lam { binder, body } = &expr.nodes[root] else {
             panic!("Result should be Lam");
-        }
+        };
+        assert_ne!(*binder, y);
+        let CoreFrame::Var(v) = &expr.nodes[*body] else {
+            panic!("Body should be Var(y)");
+        };
+        assert_eq!(*v, y);
     }
 
     // 7. test_inline_preserves_eval: Build let x = 21 in x + x (Many, no inline) and let x = 21 in x (Once, inline). Eval before/after, verify match.

--- a/tidepool-optimize/src/partial.rs
+++ b/tidepool-optimize/src/partial.rs
@@ -76,13 +76,10 @@ fn partial_eval_at(
             (ni, PartialValue::Known(KnownValue::Lit(lit.clone())))
         }
         CoreFrame::Con { tag, fields } => {
-            let mut fi = Vec::new();
-            let mut fv = Vec::new();
-            for &f in fields {
-                let (i, v) = partial_eval_at(expr, f, env, new_nodes);
-                fi.push(i);
-                fv.push(v);
-            }
+            let (fi, fv): (Vec<_>, Vec<_>) = fields
+                .iter()
+                .map(|&f| partial_eval_at(expr, f, env, new_nodes))
+                .unzip();
             let ni = new_nodes.len();
             new_nodes.push(CoreFrame::Con {
                 tag: *tag,
@@ -121,11 +118,13 @@ fn partial_eval_at(
             for (b, _) in bindings {
                 new_env.insert(*b, PartialValue::Unknown);
             }
-            let mut nb = Vec::new();
-            for (b, r) in bindings {
-                let (ri, _) = partial_eval_at(expr, *r, &new_env, new_nodes);
-                nb.push((*b, ri));
-            }
+            let nb: Vec<_> = bindings
+                .iter()
+                .map(|(b, r)| {
+                    let (ri, _) = partial_eval_at(expr, *r, &new_env, new_nodes);
+                    (*b, ri)
+                })
+                .collect();
             let (bi, bv) = partial_eval_at(expr, *body, &new_env, new_nodes);
             let ni = new_nodes.len();
             new_nodes.push(CoreFrame::LetRec {
@@ -176,13 +175,10 @@ fn partial_eval_at(
             }
         }
         CoreFrame::PrimOp { op, args } => {
-            let mut ai = Vec::new();
-            let mut av = Vec::new();
-            for &a in args {
-                let (i, v) = partial_eval_at(expr, a, env, new_nodes);
-                ai.push(i);
-                av.push(v);
-            }
+            let (ai, av): (Vec<_>, Vec<_>) = args
+                .iter()
+                .map(|&a| partial_eval_at(expr, a, env, new_nodes))
+                .unzip();
             if let Some(result) = try_eval_primop(*op, &av) {
                 let ni = new_nodes.len();
                 new_nodes.push(CoreFrame::Lit(result.clone()));
@@ -227,11 +223,10 @@ fn partial_eval_at(
             (ni, bv)
         }
         CoreFrame::Jump { label, args } => {
-            let mut ai = Vec::new();
-            for &a in args {
-                let (i, _) = partial_eval_at(expr, a, env, new_nodes);
-                ai.push(i);
-            }
+            let ai: Vec<_> = args
+                .iter()
+                .map(|&a| partial_eval_at(expr, a, env, new_nodes).0)
+                .collect();
             let ni = new_nodes.len();
             new_nodes.push(CoreFrame::Jump {
                 label: *label,
@@ -273,19 +268,21 @@ fn emit_residual_case(
 ) -> (usize, PartialValue) {
     let mut new_env = env.clone();
     new_env.insert(*binder, PartialValue::Unknown);
-    let mut new_alts = Vec::new();
-    for alt in alts {
-        let mut alt_env = new_env.clone();
-        for b in &alt.binders {
-            alt_env.insert(*b, PartialValue::Unknown);
-        }
-        let (bi, _) = partial_eval_at(expr, alt.body, &alt_env, new_nodes);
-        new_alts.push(Alt {
-            con: alt.con.clone(),
-            binders: alt.binders.clone(),
-            body: bi,
-        });
-    }
+    let new_alts: Vec<_> = alts
+        .iter()
+        .map(|alt| {
+            let mut alt_env = new_env.clone();
+            for b in &alt.binders {
+                alt_env.insert(*b, PartialValue::Unknown);
+            }
+            let (bi, _) = partial_eval_at(expr, alt.body, &alt_env, new_nodes);
+            Alt {
+                con: alt.con.clone(),
+                binders: alt.binders.clone(),
+                body: bi,
+            }
+        })
+        .collect();
     let ni = new_nodes.len();
     new_nodes.push(CoreFrame::Case {
         scrutinee: scrut_idx,
@@ -546,14 +543,13 @@ mod tests {
         let mut heap_after = VecHeap::new();
         let val_after = eval(&expr, &Env::new(), &mut heap_after).unwrap();
 
-        if let (Value::Lit(Literal::LitInt(n1)), Value::Lit(Literal::LitInt(n2))) =
+        let (Value::Lit(Literal::LitInt(n1)), Value::Lit(Literal::LitInt(n2))) =
             (val_before, val_after)
-        {
-            assert_eq!(n1, 30);
-            assert_eq!(n2, 30);
-        } else {
+        else {
             panic!("Expected LitInt(30)");
-        }
+        };
+        assert_eq!(n1, 30);
+        assert_eq!(n2, 30);
     }
 
     #[test]

--- a/tidepool-repr/src/builder.rs
+++ b/tidepool-repr/src/builder.rs
@@ -44,6 +44,18 @@ impl TreeBuilder {
         offset
     }
 
+    /// Add multiple nodes, return the index of the last added node (or 0 if empty).
+    pub fn extend<I>(&mut self, iter: I) -> usize
+    where
+        I: IntoIterator<Item = CoreFrame<usize>>,
+    {
+        let mut last_idx = self.nodes.len().saturating_sub(1);
+        for frame in iter {
+            last_idx = self.push(frame);
+        }
+        last_idx
+    }
+
     /// Finish building, return the tree.
     pub fn build(self) -> RecursiveTree<CoreFrame<usize>> {
         RecursiveTree { nodes: self.nodes }

--- a/tidepool-repr/src/frame.rs
+++ b/tidepool-repr/src/frame.rs
@@ -47,3 +47,75 @@ pub enum CoreFrame<A> {
         args: Vec<A>,
     },
 }
+
+impl<A: std::fmt::Display> std::fmt::Display for CoreFrame<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CoreFrame::Var(id) => write!(f, "Var({})", id),
+            CoreFrame::Lit(lit) => write!(f, "Lit({})", lit),
+            CoreFrame::App { fun, arg } => write!(f, "App({}, {})", fun, arg),
+            CoreFrame::Lam { binder, body } => write!(f, "Lam({}, {})", binder, body),
+            CoreFrame::LetNonRec { binder, rhs, body } => {
+                write!(f, "LetNonRec({}, {}, {})", binder, rhs, body)
+            }
+            CoreFrame::LetRec { bindings, body } => {
+                write!(f, "LetRec([")?;
+                for (i, (b, r)) in bindings.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "({}, {})", b, r)?;
+                }
+                write!(f, "], {})", body)
+            }
+            CoreFrame::Case {
+                scrutinee,
+                binder,
+                alts,
+            } => write!(f, "Case({}, {}, {} alts)", scrutinee, binder, alts.len()),
+            CoreFrame::Con { tag, fields } => {
+                write!(f, "Con({}, [", tag)?;
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", field)?;
+                }
+                write!(f, "])")
+            }
+            CoreFrame::Join {
+                label,
+                params,
+                rhs,
+                body,
+            } => write!(
+                f,
+                "Join({}, {} params, {}, {})",
+                label,
+                params.len(),
+                rhs,
+                body
+            ),
+            CoreFrame::Jump { label, args } => {
+                write!(f, "Jump({}, [", label)?;
+                for (i, a) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", a)?;
+                }
+                write!(f, "])")
+            }
+            CoreFrame::PrimOp { op, args } => {
+                write!(f, "PrimOp({}, [", op)?;
+                for (i, a) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", a)?;
+                }
+                write!(f, "])")
+            }
+        }
+    }
+}

--- a/tidepool-repr/src/pretty.rs
+++ b/tidepool-repr/src/pretty.rs
@@ -8,6 +8,12 @@ pub fn pretty_print(expr: &CoreExpr) -> String {
     pp_at(expr, expr.nodes.len() - 1)
 }
 
+impl std::fmt::Display for crate::tree::RecursiveTree<CoreFrame<usize>> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", pretty_print(self))
+    }
+}
+
 fn pp_at(expr: &CoreExpr, idx: usize) -> String {
     match &expr.nodes[idx] {
         CoreFrame::Var(id) => format_var(id),

--- a/tidepool-repr/src/serial/read.rs
+++ b/tidepool-repr/src/serial/read.rs
@@ -42,10 +42,10 @@ pub fn read_cbor(bytes: &[u8]) -> Result<RecursiveTree<CoreFrame<usize>>, ReadEr
         )));
     }
 
-    let mut nodes = Vec::with_capacity(nodes_array.len());
-    for node_val in nodes_array {
-        nodes.push(decode_frame(node_val)?);
-    }
+    let nodes = nodes_array
+        .iter()
+        .map(decode_frame)
+        .collect::<Result<Vec<_>, _>>()?;
 
     validate_indices(&nodes)?;
 
@@ -139,24 +139,26 @@ pub fn read_metadata(bytes: &[u8]) -> Result<(crate::DataConTable, MetaWarnings)
                 ))
             }
         };
-        let mut bangs = Vec::with_capacity(bangs_arr.len());
-        for b in bangs_arr {
-            let bang_str = match b {
-                Value::Text(t) => t.as_str(),
-                _ => return Err(ReadError::InvalidStructure("Bang must be text".to_string())),
-            };
-            bangs.push(match bang_str {
-                "SrcBang" => SrcBang::SrcBang,
-                "SrcUnpack" => SrcBang::SrcUnpack,
-                "NoSrcBang" => SrcBang::NoSrcBang,
-                _ => {
-                    return Err(ReadError::InvalidStructure(format!(
-                        "Unknown bang: {}",
-                        bang_str
-                    )))
-                }
-            });
-        }
+        let bangs = bangs_arr
+            .iter()
+            .map(|b| {
+                let bang_str = match b {
+                    Value::Text(t) => t.as_str(),
+                    _ => return Err(ReadError::InvalidStructure("Bang must be text".to_string())),
+                };
+                Ok(match bang_str {
+                    "SrcBang" => SrcBang::SrcBang,
+                    "SrcUnpack" => SrcBang::SrcUnpack,
+                    "NoSrcBang" => SrcBang::NoSrcBang,
+                    _ => {
+                        return Err(ReadError::InvalidStructure(format!(
+                            "Unknown bang: {}",
+                            bang_str
+                        )))
+                    }
+                })
+            })
+            .collect::<Result<Vec<_>, ReadError>>()?;
 
         // 6th element (optional): module-qualified name
         let qualified_name = if arr.len() >= 6 {
@@ -335,11 +337,13 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
         "LetRec" => {
             expect_array_len(val, 3)?;
             let bindings_arr = expect_array(&arr[1])?;
-            let mut bindings = Vec::with_capacity(bindings_arr.len());
-            for b_val in bindings_arr {
-                let b_arr = expect_array_len(b_val, 2)?;
-                bindings.push((VarId(as_u64(&b_arr[0])?), as_usize(&b_arr[1])?));
-            }
+            let bindings = bindings_arr
+                .iter()
+                .map(|b_val| {
+                    let b_arr = expect_array_len(b_val, 2)?;
+                    Ok((VarId(as_u64(&b_arr[0])?), as_usize(&b_arr[1])?))
+                })
+                .collect::<Result<Vec<_>, ReadError>>()?;
             Ok(CoreFrame::LetRec {
                 bindings,
                 body: as_usize(&arr[2])?,
@@ -348,10 +352,10 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
         "Case" => {
             expect_array_len(val, 4)?;
             let alts_arr = expect_array(&arr[3])?;
-            let mut alts = Vec::with_capacity(alts_arr.len());
-            for alt_val in alts_arr {
-                alts.push(decode_alt(alt_val)?);
-            }
+            let alts = alts_arr
+                .iter()
+                .map(decode_alt)
+                .collect::<Result<Vec<_>, _>>()?;
             Ok(CoreFrame::Case {
                 scrutinee: as_usize(&arr[1])?,
                 binder: VarId(as_u64(&arr[2])?),
@@ -361,10 +365,10 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
         "Con" => {
             expect_array_len(val, 3)?;
             let fields_arr = expect_array(&arr[2])?;
-            let mut fields = Vec::with_capacity(fields_arr.len());
-            for f_val in fields_arr {
-                fields.push(as_usize(f_val)?);
-            }
+            let fields = fields_arr
+                .iter()
+                .map(as_usize)
+                .collect::<Result<Vec<_>, _>>()?;
             Ok(CoreFrame::Con {
                 tag: DataConId(as_u64(&arr[1])?),
                 fields,
@@ -373,10 +377,10 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
         "Join" => {
             expect_array_len(val, 5)?;
             let params_arr = expect_array(&arr[2])?;
-            let mut params = Vec::with_capacity(params_arr.len());
-            for p_val in params_arr {
-                params.push(VarId(as_u64(p_val)?));
-            }
+            let params = params_arr
+                .iter()
+                .map(|p| Ok(VarId(as_u64(p)?)))
+                .collect::<Result<Vec<_>, ReadError>>()?;
             Ok(CoreFrame::Join {
                 label: JoinId(as_u64(&arr[1])?),
                 params,
@@ -387,10 +391,10 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
         "Jump" => {
             expect_array_len(val, 3)?;
             let args_arr = expect_array(&arr[2])?;
-            let mut args = Vec::with_capacity(args_arr.len());
-            for a_val in args_arr {
-                args.push(as_usize(a_val)?);
-            }
+            let args = args_arr
+                .iter()
+                .map(as_usize)
+                .collect::<Result<Vec<_>, _>>()?;
             Ok(CoreFrame::Jump {
                 label: JoinId(as_u64(&arr[1])?),
                 args,
@@ -401,10 +405,10 @@ fn decode_frame(val: &Value) -> Result<CoreFrame<usize>, ReadError> {
             let op_name = expect_text(&arr[1])?;
             let op = decode_primop(op_name)?;
             let args_arr = expect_array(&arr[2])?;
-            let mut args = Vec::with_capacity(args_arr.len());
-            for a_val in args_arr {
-                args.push(as_usize(a_val)?);
-            }
+            let args = args_arr
+                .iter()
+                .map(as_usize)
+                .collect::<Result<Vec<_>, _>>()?;
             Ok(CoreFrame::PrimOp { op, args })
         }
         _ => Err(ReadError::InvalidTag(tag.to_string())),
@@ -439,10 +443,10 @@ fn decode_alt(val: &Value) -> Result<Alt<usize>, ReadError> {
     let arr = expect_array_len(val, 3)?;
     let con = decode_alt_con(&arr[0])?;
     let binders_arr = expect_array(&arr[1])?;
-    let mut binders = Vec::with_capacity(binders_arr.len());
-    for b_val in binders_arr {
-        binders.push(VarId(as_u64(b_val)?));
-    }
+    let binders = binders_arr
+        .iter()
+        .map(|b| Ok(VarId(as_u64(b)?)))
+        .collect::<Result<Vec<_>, ReadError>>()?;
     let body = as_usize(&arr[2])?;
     Ok(Alt { con, binders, body })
 }

--- a/tidepool-repr/src/types.rs
+++ b/tidepool-repr/src/types.rs
@@ -62,6 +62,13 @@ macro_rules! define_primops {
                 }
             }
         }
+
+        impl std::str::FromStr for PrimOpKind {
+            type Err = String;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::from_serial_name(s).ok_or_else(|| format!("unknown primop: {}", s))
+            }
+        }
     };
 }
 
@@ -431,7 +438,18 @@ mod tests {
                 op,
                 name
             );
+
+            // Test FromStr
+            let from_str: PrimOpKind = name.parse().unwrap();
+            assert_eq!(from_str, *op);
         }
+    }
+
+    #[test]
+    fn test_primop_from_str_error() {
+        let res: Result<PrimOpKind, _> = "NoSuchOp".parse();
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err(), "unknown primop: NoSuchOp");
     }
 
     #[test]

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -45,17 +45,22 @@ fn fingerprint_dir(dir: &Path, hasher: &mut blake3::Hasher) {
         let path = entry.path();
         if path.is_dir() {
             fingerprint_dir(&path, hasher);
-        } else if let Some(ext) = path.extension() {
-            if ext == "hs" || ext == "hs-boot" {
-                if let Ok(meta) = entry.metadata() {
-                    hasher.update(path.as_os_str().as_encoded_bytes());
-                    hasher.update(&meta.len().to_le_bytes());
-                    if let Ok(mtime) = meta.modified() {
-                        if let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH) {
-                            hasher.update(&dur.as_nanos().to_le_bytes());
-                        }
-                    }
-                }
+            continue;
+        }
+        let Some(ext) = path.extension() else {
+            continue;
+        };
+        if ext != "hs" && ext != "hs-boot" {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        hasher.update(path.as_os_str().as_encoded_bytes());
+        hasher.update(&meta.len().to_le_bytes());
+        if let Ok(mtime) = meta.modified() {
+            if let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH) {
+                hasher.update(&dur.as_nanos().to_le_bytes());
             }
         }
     }

--- a/tidepool-runtime/src/render.rs
+++ b/tidepool-runtime/src/render.rs
@@ -21,7 +21,7 @@ impl EvalResult {
 
     /// Render the result as structured JSON.
     pub fn to_json(&self) -> serde_json::Value {
-        value_to_json(&self.value, &self.table, 0)
+        self.into()
     }
 
     /// Pretty-print the JSON representation.
@@ -57,6 +57,18 @@ impl EvalResult {
     /// Borrow the DataConTable.
     pub fn table(&self) -> &DataConTable {
         &self.table
+    }
+}
+
+impl From<&EvalResult> for serde_json::Value {
+    fn from(result: &EvalResult) -> Self {
+        value_to_json(&result.value, &result.table, 0)
+    }
+}
+
+impl From<EvalResult> for serde_json::Value {
+    fn from(result: EvalResult) -> Self {
+        (&result).into()
     }
 }
 


### PR DESCRIPTION
## Summary

Mechanical Rust idiom improvements across 8 crates, partitioned by crate to avoid conflicts:

- **tidepool-repr**: Iterator chains in serial/read.rs (9 for+push → `.map().collect::<Result<_,_>>()?`), `Display` impls for `CoreFrame<A>` and `CoreExpr`, `FromStr` for `PrimOpKind`
- **tidepool-eval**: Iterator chains and let-else test assertions in eval.rs
- **tidepool-optimize**: `.unzip()` for dual-accumulator loops (partial.rs), `.find_map()` chains (beta.rs), let-else patterns across all passes
- **tidepool-codegen**: `.ok_or_else()?` patterns (expr.rs), `.map_err()?` (jit_machine.rs), checked arithmetic combinators (host_fns.rs), `TryFrom` for `ConTags` (effect_machine.rs), `.extend()` (datacon_env.rs), let-else in tests
- **tidepool-runtime**: Let-else chains in cache.rs, `From<EvalResult>` impl in render.rs
- **tidepool-mcp**: Let-else for request extraction, iterator chains
- **tidepool-heap**: Let-else in test assertions, iterator cleanup in arena.rs

### What's NOT included
- Clone reduction (architectural — separate effort)
- No functional changes, no new deps, no type renames

## Verification
```
cargo test --workspace     ✅ all pass
cargo clippy --workspace   ✅ no warnings  
cargo fmt --all -- --check ✅ clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)