### PR TITLE
docs(codegen): fix broken rustdoc links in host_fns.rs

### DIFF
--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -1084,7 +1084,7 @@ pub extern "C" fn runtime_compare_byte_arrays(
 // ---------------------------------------------------------------------------
 
 /// Allocate a new boxed array of `len` pointer slots, each initialized to `init`.
-/// Layout: [u64 length][ptr0][ptr1]...[ptrN-1]
+/// Layout: `[u64 length][ptr0][ptr1]...[ptrN-1]`
 /// Each slot is 8 bytes (a heap pointer).
 pub extern "C" fn runtime_new_boxed_array(len: i64, init: i64) -> i64 {
     if len < 0 {
@@ -1249,7 +1249,7 @@ pub extern "C" fn runtime_shrink_boxed_array(arr: i64, new_len: i64) {
     }
 }
 
-/// CAS on a boxed array slot: compare-and-swap arr[idx].
+/// CAS on a boxed array slot: compare-and-swap `arr[idx]`.
 /// Returns the old value. If old == expected, writes new.
 pub extern "C" fn runtime_cas_boxed_array(arr: i64, idx: i64, expected: i64, new: i64) -> i64 {
     if (arr as u64) < MIN_VALID_ADDR || idx < 0 {


### PR DESCRIPTION
This PR fixes two broken rustdoc links in `tidepool-codegen/src/host_fns.rs` where square brackets were being incorrectly interpreted as intra-doc links.

- Wrapped the layout description in `runtime_new_boxed_array` in backticks.
- Wrapped `arr[idx]` in `runtime_cas_boxed_array` in backticks.

Verified with `RUSTDOCFLAGS='-D warnings' cargo doc -p tidepool-codegen --no-deps`.