### PR TITLE
refactor: add thiserror derives to error types in heap, eval, and effect crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,6 +3461,7 @@ version = "0.1.0"
 dependencies = [
  "frunk",
  "proptest",
+ "thiserror 2.0.18",
  "tidepool-bridge",
  "tidepool-eval",
  "tidepool-repr",
@@ -3471,6 +3472,7 @@ name = "tidepool-eval"
 version = "0.1.0"
 dependencies = [
  "im",
+ "thiserror 2.0.18",
  "tidepool-repr",
 ]
 
@@ -3495,7 +3497,7 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "proptest",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tidepool-eval",
  "tidepool-repr",
 ]

--- a/tidepool-effect/Cargo.toml
+++ b/tidepool-effect/Cargo.toml
@@ -14,6 +14,7 @@ tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-bridge = { version = "0.1.0", path = "../tidepool-bridge" }
 frunk = "0.4"
+thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-effect/src/error.rs
+++ b/tidepool-effect/src/error.rs
@@ -1,70 +1,28 @@
 use tidepool_bridge::BridgeError;
 use tidepool_eval::error::EvalError;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum EffectError {
-    Eval(EvalError),
-    Bridge(BridgeError),
-    UnhandledEffect {
-        tag: u64,
-    },
+    #[error("Eval error: {0}")]
+    Eval(#[from] EvalError),
+    #[error("Bridge error: {0}")]
+    Bridge(#[from] BridgeError),
+    #[error("Unhandled effect at tag {tag}")]
+    UnhandledEffect { tag: u64 },
     /// A required constructor was not found in the DataConTable.
-    MissingConstructor {
-        name: &'static str,
-    },
+    #[error("{name} constructor not found in DataConTable")]
+    MissingConstructor { name: &'static str },
     /// A constructor had the wrong number of fields.
+    #[error("{constructor} expects {expected} fields, got {got}")]
     FieldCountMismatch {
         constructor: &'static str,
         expected: usize,
         got: usize,
     },
     /// Encountered an unexpected value shape during dispatch.
-    UnexpectedValue {
-        context: &'static str,
-        got: String,
-    },
+    #[error("expected {context}, got {got}")]
+    UnexpectedValue { context: &'static str, got: String },
     /// An effect handler encountered a runtime error.
+    #[error("handler error: {0}")]
     Handler(String),
 }
-
-impl From<EvalError> for EffectError {
-    fn from(e: EvalError) -> Self {
-        EffectError::Eval(e)
-    }
-}
-
-impl From<BridgeError> for EffectError {
-    fn from(e: BridgeError) -> Self {
-        EffectError::Bridge(e)
-    }
-}
-
-impl std::fmt::Display for EffectError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EffectError::Eval(e) => write!(f, "Eval error: {}", e),
-            EffectError::Bridge(e) => write!(f, "Bridge error: {}", e),
-            EffectError::UnhandledEffect { tag } => write!(f, "Unhandled effect at tag {}", tag),
-            EffectError::MissingConstructor { name } => {
-                write!(f, "{} constructor not found in DataConTable", name)
-            }
-            EffectError::FieldCountMismatch {
-                constructor,
-                expected,
-                got,
-            } => {
-                write!(
-                    f,
-                    "{} expects {} fields, got {}",
-                    constructor, expected, got
-                )
-            }
-            EffectError::UnexpectedValue { context, got } => {
-                write!(f, "expected {}, got {}", context, got)
-            }
-            EffectError::Handler(msg) => write!(f, "handler error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for EffectError {}

--- a/tidepool-eval/Cargo.toml
+++ b/tidepool-eval/Cargo.toml
@@ -12,3 +12,4 @@ readme = "../README.md"
 [dependencies]
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 im = "15"
+thiserror = "2"

--- a/tidepool-eval/src/error.rs
+++ b/tidepool-eval/src/error.rs
@@ -25,76 +25,55 @@ impl std::fmt::Display for ValueKind {
 }
 
 /// Evaluation error.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum EvalError {
     /// Variable not found in environment
+    #[error("unbound variable: v_{}", .0 .0)]
     UnboundVar(VarId),
     /// Arity mismatch (wrong number of arguments or fields)
+    #[error("arity mismatch: expected {expected} {context}, got {got}")]
     ArityMismatch {
         context: &'static str, // "arguments", "fields", "case binders"
         expected: usize,
         got: usize,
     },
     /// Type mismatch during evaluation
+    #[error("type mismatch: expected {expected}, got {got}")]
     TypeMismatch {
         expected: &'static str,
         got: ValueKind,
     },
     /// No matching alternative in case expression
+    #[error("no matching case alternative")]
     NoMatchingAlt,
     /// Infinite loop detected (thunk forced itself)
+    #[error("infinite loop: thunk {} forced itself", .0 .0)]
     InfiniteLoop(ThunkId),
     /// Unsupported primop
+    #[error("unsupported primop: {0:?}")]
     UnsupportedPrimOp(PrimOpKind),
     /// Heap exhausted
+    #[error("heap exhausted")]
     HeapExhausted,
     /// Application of non-function value
+    #[error("application of non-function value")]
     NotAFunction,
     /// Jump to unknown join point
+    #[error("jump to unbound join point: j_{}", .0 .0)]
     UnboundJoin(JoinId),
     /// Haskell `error "..."` called
+    #[error("Haskell error called")]
     UserError,
     /// Haskell `undefined` forced
+    #[error("Haskell undefined forced")]
     Undefined,
     /// Recursion depth limit exceeded during deep_force
+    #[error("recursion depth limit exceeded")]
     DepthLimit,
     /// Internal invariant violation (should never happen)
+    #[error("internal error: {0}")]
     InternalError(String),
 }
-
-impl std::fmt::Display for EvalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EvalError::UnboundVar(v) => write!(f, "unbound variable: v_{}", v.0),
-            EvalError::ArityMismatch {
-                context,
-                expected,
-                got,
-            } => {
-                write!(
-                    f,
-                    "arity mismatch: expected {} {}, got {}",
-                    expected, context, got
-                )
-            }
-            EvalError::TypeMismatch { expected, got } => {
-                write!(f, "type mismatch: expected {}, got {}", expected, got)
-            }
-            EvalError::NoMatchingAlt => write!(f, "no matching case alternative"),
-            EvalError::InfiniteLoop(id) => write!(f, "infinite loop: thunk {} forced itself", id.0),
-            EvalError::UnsupportedPrimOp(op) => write!(f, "unsupported primop: {:?}", op),
-            EvalError::HeapExhausted => write!(f, "heap exhausted"),
-            EvalError::NotAFunction => write!(f, "application of non-function value"),
-            EvalError::UnboundJoin(id) => write!(f, "jump to unbound join point: j_{}", id.0),
-            EvalError::UserError => write!(f, "Haskell error called"),
-            EvalError::Undefined => write!(f, "Haskell undefined forced"),
-            EvalError::DepthLimit => write!(f, "recursion depth limit exceeded"),
-            EvalError::InternalError(msg) => write!(f, "internal error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for EvalError {}
 
 #[cfg(test)]
 mod tests {

--- a/tidepool-heap/Cargo.toml
+++ b/tidepool-heap/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 bumpalo = "3"
-thiserror = "1"
+thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-heap/src/gc/trace.rs
+++ b/tidepool-heap/src/gc/trace.rs
@@ -1,28 +1,13 @@
 use std::collections::VecDeque;
-use std::error::Error;
-use std::fmt;
 use tidepool_eval::heap::Heap;
 use tidepool_eval::value::ThunkId;
 
 /// Error during garbage collection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum GcError {
+    #[error("ThunkId {:?} not in forwarding table (not reachable during trace)", .0)]
     ThunkNotReachable(ThunkId),
 }
-
-impl fmt::Display for GcError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            GcError::ThunkNotReachable(id) => write!(
-                f,
-                "ThunkId {:?} not in forwarding table (not reachable during trace)",
-                id
-            ),
-        }
-    }
-}
-
-impl Error for GcError {}
 
 /// Maps old ThunkIds to new ThunkIds.
 pub struct ForwardingTable {


### PR DESCRIPTION
This PR adds `thiserror` derives to the error types in `tidepool-heap`, `tidepool-eval`, and `tidepool-effect`.

### Changes:
- **tidepool-heap**:
  - Upgraded `thiserror` to version 2 in `Cargo.toml`.
  - Replaced manual `Display` and `Error` implementations for `GcError` with `#[derive(thiserror::Error)]`.
- **tidepool-eval**:
  - Added `thiserror = "2"` to `Cargo.toml`.
  - Replaced manual `Display` and `Error` implementations for `EvalError` with `#[derive(thiserror::Error)]`, preserving the existing `Clone` derive and matching exactly the original error messages.
- **tidepool-effect**:
  - Added `thiserror = "2"` to `Cargo.toml`.
  - Replaced manual `Display`, `Error`, and `From` implementations for `EffectError` with `#[derive(thiserror::Error)]`.
  - Used `#[from]` for `Eval` and `Bridge` variants to automatically generate `From` implementations.

### Verification:
- Ran `cargo test -p tidepool-heap`
- Ran `cargo test -p tidepool-eval`
- Ran `cargo test -p tidepool-effect`
- Ran `cargo clippy` for each package.
- Verified that `ValueKind` remains unchanged as it is not an error type.