### PR TITLE
feat(tidepool-repr): add thiserror derives to error types

### DIFF
--- a/examples/tide/Cargo.toml
+++ b/examples/tide/Cargo.toml
@@ -20,7 +20,7 @@ ureq = "2"
 url = "2"
 rustyline = "15"
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2"
 clap = { version = "4.4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/tidepool-repr/Cargo.toml
+++ b/tidepool-repr/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 ciborium = "0.2"
+thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -6,45 +6,27 @@ pub use read::{read_metadata, MetaWarnings};
 pub use write::write_cbor;
 pub use write::write_metadata;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ReadError {
+    #[error("CBOR error: {0}")]
     Cbor(String),
+    #[error("Invalid tag: {0}")]
     InvalidTag(String),
+    #[error("Invalid literal: {0}")]
     InvalidLiteral(String),
+    #[error("Invalid primop: {0}")]
     InvalidPrimOp(String),
+    #[error("Invalid alt con: {0}")]
     InvalidAltCon(String),
+    #[error("Invalid structure: {0}")]
     InvalidStructure(String),
 }
 
-impl std::fmt::Display for ReadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ReadError::Cbor(e) => write!(f, "CBOR error: {}", e),
-            ReadError::InvalidTag(s) => write!(f, "Invalid tag: {}", s),
-            ReadError::InvalidLiteral(s) => write!(f, "Invalid literal: {}", s),
-            ReadError::InvalidPrimOp(s) => write!(f, "Invalid primop: {}", s),
-            ReadError::InvalidAltCon(s) => write!(f, "Invalid alt con: {}", s),
-            ReadError::InvalidStructure(s) => write!(f, "Invalid structure: {}", s),
-        }
-    }
-}
-
-impl std::error::Error for ReadError {}
-
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum WriteError {
+    #[error("CBOR error: {0}")]
     Cbor(String),
 }
-
-impl std::fmt::Display for WriteError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            WriteError::Cbor(e) => write!(f, "CBOR error: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for WriteError {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
- Added `thiserror = "2"` to `tidepool-repr/Cargo.toml`.
- Replaced manual `Display` and `Error` implementations for `ReadError` and `WriteError` with `thiserror` derives in `tidepool-repr/src/serial/mod.rs`.
- Verified that `tidepool-repr/src/serial/read.rs` and `tidepool-repr/src/serial/write.rs` don't contain any `.expect()` calls (they seem to have been already converted in previous commits).
- Verified with `cargo test -p tidepool-repr` and `cargo clippy -p tidepool-repr`.