### PR TITLE
feat: use thiserror for runtime and bridge error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,6 +3416,7 @@ version = "0.1.0"
 dependencies = [
  "proptest",
  "serde_json",
+ "thiserror 2.0.18",
  "tidepool-eval",
  "tidepool-repr",
 ]
@@ -3566,6 +3567,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "thiserror 2.0.18",
  "tidepool-bridge",
  "tidepool-bridge-derive",
  "tidepool-codegen",

--- a/tidepool-bridge/Cargo.toml
+++ b/tidepool-bridge/Cargo.toml
@@ -10,6 +10,7 @@ description = "Bridge between Rust types and Tidepool Core values"
 readme = "../README.md"
 
 [dependencies]
+thiserror = "2"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 serde_json = "1"

--- a/tidepool-bridge/src/error.rs
+++ b/tidepool-bridge/src/error.rs
@@ -1,15 +1,17 @@
-use std::error::Error;
-use std::fmt;
 use tidepool_repr::DataConId;
+use thiserror::Error;
 
 /// Errors that can occur when bridging between Rust types and Core Values.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BridgeError {
     /// The `DataConId` was not found in the `DataConTable`.
+    #[error("Unknown DataConId: {0:?}")]
     UnknownDataCon(DataConId),
     /// The `DataConId` was found, but it has an unexpected name.
+    #[error("Unknown DataCon name: {0}")]
     UnknownDataConName(String),
     /// The number of fields in a constructor does not match the expected arity.
+    #[error("Arity mismatch for DataCon {con:?}: expected {expected}, got {got}")]
     ArityMismatch {
         /// The constructor identifier.
         con: DataConId,
@@ -19,6 +21,7 @@ pub enum BridgeError {
         got: usize,
     },
     /// The value has an unexpected type (e.g., expected a Literal, got a Con).
+    #[error("Type mismatch: expected {expected}, got {got}")]
     TypeMismatch {
         /// A description of the expected type.
         expected: String,
@@ -26,30 +29,9 @@ pub enum BridgeError {
         got: String,
     },
     /// The type is not supported by the bridge.
+    #[error("Unsupported type: {0}")]
     UnsupportedType(String),
     /// Internal invariant violation (should never happen).
+    #[error("Internal error: {0}")]
     InternalError(String),
 }
-
-impl fmt::Display for BridgeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            BridgeError::UnknownDataCon(id) => write!(f, "Unknown DataConId: {:?}", id),
-            BridgeError::UnknownDataConName(name) => write!(f, "Unknown DataCon name: {}", name),
-            BridgeError::ArityMismatch { con, expected, got } => {
-                write!(
-                    f,
-                    "Arity mismatch for DataCon {:?}: expected {}, got {}",
-                    con, expected, got
-                )
-            }
-            BridgeError::TypeMismatch { expected, got } => {
-                write!(f, "Type mismatch: expected {}, got {}", expected, got)
-            }
-            BridgeError::UnsupportedType(ty) => write!(f, "Unsupported type: {}", ty),
-            BridgeError::InternalError(msg) => write!(f, "Internal error: {}", msg),
-        }
-    }
-}
-
-impl Error for BridgeError {}

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -10,6 +10,7 @@ description = "Runtime support for Tidepool applications"
 readme = "../README.md"
 
 [dependencies]
+thiserror = "2"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -3,11 +3,11 @@
 //! Provides `compile_haskell` (source to Core) and `compile_and_run` (source to
 //! evaluated result), with filesystem caching of compiled CBOR artifacts.
 
-use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
+use thiserror::Error;
 pub use tidepool_codegen::host_fns::{drain_diagnostics, push_diagnostic};
 use tidepool_codegen::jit_machine::JitEffectMachine;
 pub use tidepool_codegen::jit_machine::JitError;
@@ -25,93 +25,32 @@ pub use render::{value_to_json, EvalResult};
 pub type CompileResult = (CoreExpr, DataConTable, MetaWarnings);
 
 /// Errors that can occur during Haskell compilation.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum CompileError {
     /// I/O error during file operations or process execution.
-    Io(io::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
     /// The `tidepool-extract` process failed (e.g., GHC parse/type error).
+    #[error("Haskell compilation failed:\n{0}")]
     ExtractFailed(String),
     /// Failed to deserialize the CBOR output from `tidepool-extract`.
-    ReadError(ReadError),
+    #[error("CBOR deserialization error: {0}")]
+    ReadError(#[from] ReadError),
     /// A required output file (.cbor or meta.cbor) was not produced by the extractor.
+    #[error("Missing output file from extractor: {}", .0.display())]
     MissingOutput(PathBuf),
     /// The target binding has IO type, which is not supported.
+    #[error("IO type detected in result binding. IO operations (unsafePerformIO, etc.) are not supported in the Tidepool sandbox.")]
     IOTypeDetected,
 }
 
-impl fmt::Display for CompileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CompileError::Io(e) => write!(f, "I/O error: {}", e),
-            CompileError::ExtractFailed(msg) => write!(f, "Haskell compilation failed:\n{}", msg),
-            CompileError::ReadError(e) => write!(f, "CBOR deserialization error: {}", e),
-            CompileError::MissingOutput(path) => {
-                write!(f, "Missing output file from extractor: {}", path.display())
-            }
-            CompileError::IOTypeDetected => {
-                write!(f, "IO type detected in result binding. IO operations (unsafePerformIO, etc.) are not supported in the Tidepool sandbox.")
-            }
-        }
-    }
-}
-
-impl std::error::Error for CompileError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CompileError::Io(e) => Some(e),
-            CompileError::ReadError(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<io::Error> for CompileError {
-    fn from(e: io::Error) -> Self {
-        CompileError::Io(e)
-    }
-}
-
-impl From<ReadError> for CompileError {
-    fn from(e: ReadError) -> Self {
-        CompileError::ReadError(e)
-    }
-}
-
 /// Unified error type for compile + run pipeline.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum RuntimeError {
-    Compile(CompileError),
-    Jit(JitError),
-}
-
-impl fmt::Display for RuntimeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RuntimeError::Compile(e) => write!(f, "{}", e),
-            RuntimeError::Jit(e) => write!(f, "{}", e),
-        }
-    }
-}
-
-impl std::error::Error for RuntimeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            RuntimeError::Compile(e) => Some(e),
-            RuntimeError::Jit(e) => Some(e),
-        }
-    }
-}
-
-impl From<CompileError> for RuntimeError {
-    fn from(e: CompileError) -> Self {
-        Self::Compile(e)
-    }
-}
-
-impl From<JitError> for RuntimeError {
-    fn from(e: JitError) -> Self {
-        Self::Jit(e)
-    }
+    #[error(transparent)]
+    Compile(#[from] CompileError),
+    #[error(transparent)]
+    Jit(#[from] JitError),
 }
 
 /// Extract module name from Haskell source (e.g. "module Expr where" -> "Expr").


### PR DESCRIPTION
This PR replaces manual `Display`, `Error`, and `From` implementations with `thiserror` (v2) derives in both `tidepool-runtime` and `tidepool-bridge`.

Key changes:
- Added `thiserror = "2"` to both `Cargo.toml` files.
- Replaced `CompileError` and `RuntimeError` manual implementations in `tidepool-runtime/src/lib.rs` with `thiserror` derives.
- Replaced `BridgeError` manual implementations in `tidepool-bridge/src/error.rs` with `thiserror` derives.
- Used `#[from]` where appropriate (e.g., `Io(io::Error)`, `ReadError(ReadError)` in `CompileError` and both variants in `RuntimeError`).
- Preserved existing error message formatting and behavior.
- Verified with `cargo clippy` and `cargo test`.
