### PR TITLE
feat: add thiserror derives and From impls to tidepool-codegen errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,6 +3448,7 @@ dependencies = [
  "recursion",
  "serial_test",
  "target-lexicon",
+ "thiserror 2.0.18",
  "tidepool-effect",
  "tidepool-eval",
  "tidepool-heap",

--- a/tidepool-codegen/Cargo.toml
+++ b/tidepool-codegen/Cargo.toml
@@ -20,6 +20,7 @@ tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-heap = { version = "0.1.0", path = "../tidepool-heap" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }
+thiserror = "2"
 recursion = "0.5.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/tidepool-codegen/src/debug.rs
+++ b/tidepool-codegen/src/debug.rs
@@ -167,52 +167,34 @@ pub unsafe fn heap_describe(ptr: *const u8) -> String {
 // ── Heap Object Validation ───────────────────────────────────
 
 /// Validation errors for heap objects.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum HeapError {
+    #[error("null pointer")]
     NullPointer,
+    #[error("invalid heap tag: {0}")]
     InvalidTag(u8),
+    #[error("zero size")]
     ZeroSize,
     /// Closure has null code pointer
+    #[error("null code pointer in closure")]
     NullCodePtr,
     /// Size field doesn't match expected size for the object type
+    #[error("size mismatch: expected >= {expected_min}, got {actual}")]
     SizeMismatch {
         expected_min: u16,
         actual: u16,
     },
     /// A field pointer is null
+    #[error("null pointer in field {index}")]
     NullField {
         index: usize,
     },
     /// A field pointer has an invalid heap tag
+    #[error("field {index} has invalid tag: {tag}")]
     InvalidFieldTag {
         index: usize,
         tag: u8,
     },
-}
-
-impl std::fmt::Display for HeapError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            HeapError::NullPointer => write!(f, "null pointer"),
-            HeapError::InvalidTag(t) => write!(f, "invalid heap tag: {}", t),
-            HeapError::ZeroSize => write!(f, "zero size"),
-            HeapError::NullCodePtr => write!(f, "null code pointer in closure"),
-            HeapError::SizeMismatch {
-                expected_min,
-                actual,
-            } => {
-                write!(
-                    f,
-                    "size mismatch: expected >= {}, got {}",
-                    expected_min, actual
-                )
-            }
-            HeapError::NullField { index } => write!(f, "null pointer in field {}", index),
-            HeapError::InvalidFieldTag { index, tag } => {
-                write!(f, "field {} has invalid tag: {}", index, tag)
-            }
-        }
-    }
 }
 
 /// Validate a heap object's structural integrity.

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -171,47 +171,24 @@ pub struct JoinInfo {
 }
 
 /// Errors during IR emission.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum EmitError {
+    #[error("unbound variable: {0:?}")]
     UnboundVariable(VarId),
+    #[error("not yet implemented: {0}")]
     NotYetImplemented(String),
+    #[error("cranelift error: {0}")]
     CraneliftError(String),
-    Pipeline(crate::pipeline::PipelineError),
+    #[error("pipeline error: {0}")]
+    Pipeline(#[from] crate::pipeline::PipelineError),
+    #[error("invalid arity for {0:?}: expected {1}, got {2}")]
     InvalidArity(PrimOpKind, usize, usize),
     /// A variable needed for closure capture was not found in the environment.
+    #[error("missing capture variable VarId({id:#x}): {ctx}", id = .0.0, ctx = .1)]
     MissingCaptureVar(VarId, String),
     /// Internal invariant violation (should never happen).
+    #[error("internal error: {0}")]
     InternalError(String),
-}
-
-impl std::fmt::Display for EmitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EmitError::UnboundVariable(v) => write!(f, "unbound variable: {:?}", v),
-            EmitError::NotYetImplemented(s) => write!(f, "not yet implemented: {}", s),
-            EmitError::CraneliftError(s) => write!(f, "cranelift error: {}", s),
-            EmitError::Pipeline(e) => write!(f, "pipeline error: {}", e),
-            EmitError::InvalidArity(op, expected, got) => {
-                write!(
-                    f,
-                    "invalid arity for {:?}: expected {}, got {}",
-                    op, expected, got
-                )
-            }
-            EmitError::MissingCaptureVar(v, ctx) => {
-                write!(f, "missing capture variable VarId({:#x}): {}", v.0, ctx)
-            }
-            EmitError::InternalError(msg) => write!(f, "internal error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for EmitError {}
-
-impl From<crate::pipeline::PipelineError> for EmitError {
-    fn from(e: crate::pipeline::PipelineError) -> Self {
-        EmitError::Pipeline(e)
-    }
 }
 
 impl EmitContext {

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -3,45 +3,35 @@ use crate::layout::{
     self, LIT_TAG_ADDR, LIT_TAG_ARRAY, LIT_TAG_BYTEARRAY, LIT_TAG_CHAR, LIT_TAG_DOUBLE,
     LIT_TAG_FLOAT, LIT_TAG_INT, LIT_TAG_SMALLARRAY, LIT_TAG_STRING, LIT_TAG_WORD,
 };
-use std::fmt;
 use tidepool_eval::value::Value;
 use tidepool_heap::layout as heap_layout;
 use tidepool_repr::{DataConId, Literal};
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum BridgeError {
+    #[error("unexpected heap tag: {0}")]
     UnexpectedHeapTag(u8),
+    #[error("unexpected lit tag: {0}")]
     UnexpectedLitTag(u8),
+    #[error("null pointer")]
     NullPointer,
+    #[error("nursery exhausted")]
     NurseryExhausted,
+    #[error("too many Con fields: {count}")]
     TooManyFields { count: usize },
+    #[error("data too large: {len} bytes")]
     DataTooLarge { len: usize },
+    #[error("heap structure too deep (>10000 levels)")]
     TooDeep,
+    #[error("unevaluated thunk")]
     UnevaluatedThunk,
+    #[error("blackhole (thunk forcing itself)")]
     BlackHole,
+    #[error("unknown thunk state: {0}")]
     UnknownThunkState(u8),
+    #[error("internal error: {0}")]
     InternalError(String),
 }
-
-impl fmt::Display for BridgeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            BridgeError::UnexpectedHeapTag(t) => write!(f, "unexpected heap tag: {}", t),
-            BridgeError::UnexpectedLitTag(t) => write!(f, "unexpected lit tag: {}", t),
-            BridgeError::NullPointer => write!(f, "null pointer"),
-            BridgeError::NurseryExhausted => write!(f, "nursery exhausted"),
-            BridgeError::TooManyFields { count } => write!(f, "too many Con fields: {}", count),
-            BridgeError::DataTooLarge { len } => write!(f, "data too large: {} bytes", len),
-            BridgeError::TooDeep => write!(f, "heap structure too deep (>10000 levels)"),
-            BridgeError::UnevaluatedThunk => write!(f, "unevaluated thunk"),
-            BridgeError::BlackHole => write!(f, "blackhole (thunk forcing itself)"),
-            BridgeError::UnknownThunkState(state) => write!(f, "unknown thunk state: {}", state),
-            BridgeError::InternalError(msg) => write!(f, "internal error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for BridgeError {}
 
 /// Convert a heap-allocated object to a Value.
 ///

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -3,7 +3,6 @@ use crate::gc::frame_walker::{self, StackRoot};
 use crate::layout;
 use crate::stack_map::StackMapRegistry;
 use std::cell::{Cell, RefCell};
-use std::fmt;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use tidepool_heap::layout as heap_layout;
 
@@ -13,51 +12,34 @@ type GcHook = fn(&[StackRoot]);
 const MIN_VALID_ADDR: u64 = 0x1000;
 
 /// Runtime errors raised by JIT code via host functions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum RuntimeError {
+    #[error("division by zero")]
     DivisionByZero,
+    #[error("arithmetic overflow")]
     Overflow,
+    #[error("Haskell error called")]
     UserError,
+    #[error("Haskell undefined forced")]
     Undefined,
+    #[error("forced type metadata (should be dead code)")]
     TypeMetadata,
+    #[error("unresolved variable VarId({0:#x}) [tag='{tag}', key={key}]", tag=(*.0 >> 56) as u8 as char, key=(*.0 & ((1u64 << 56) - 1)))]
     UnresolvedVar(u64),
+    #[error("application of null function pointer")]
     NullFunPtr,
+    #[error("application of non-closure (tag={0})")]
     BadFunPtrTag(u8),
+    #[error("heap overflow (nursery exhausted after GC)")]
     HeapOverflow,
+    #[error("stack overflow (likely infinite list or unbounded recursion — use zipWithIndex/imap/enumFromTo instead of [0..])")]
     StackOverflow,
+    #[error("blackhole detected (infinite loop: thunk forced itself)")]
     BlackHole,
+    #[error("thunk has invalid evaluation state: {0}")]
     BadThunkState(u8),
+    #[error("Haskell error: {0}")]
     UserErrorMsg(String), // NEW: error with preserved message
-}
-
-impl std::fmt::Display for RuntimeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RuntimeError::DivisionByZero => write!(f, "division by zero"),
-            RuntimeError::Overflow => write!(f, "arithmetic overflow"),
-            RuntimeError::UserError => write!(f, "Haskell error called"),
-            RuntimeError::UserErrorMsg(msg) => write!(f, "Haskell error: {}", msg),
-            RuntimeError::Undefined => write!(f, "Haskell undefined forced"),
-            RuntimeError::TypeMetadata => write!(f, "forced type metadata (should be dead code)"),
-            RuntimeError::UnresolvedVar(id) => {
-                let tag_char = (*id >> 56) as u8 as char;
-                let key = *id & ((1u64 << 56) - 1);
-                write!(
-                    f,
-                    "unresolved variable VarId({:#x}) [tag='{}', key={}]",
-                    id, tag_char, key
-                )
-            }
-            RuntimeError::NullFunPtr => write!(f, "application of null function pointer"),
-            RuntimeError::BadFunPtrTag(tag) => {
-                write!(f, "application of non-closure (tag={})", tag)
-            }
-            RuntimeError::HeapOverflow => write!(f, "heap overflow (nursery exhausted after GC)"),
-            RuntimeError::StackOverflow => write!(f, "stack overflow (likely infinite list or unbounded recursion — use zipWithIndex/imap/enumFromTo instead of [0..])"),
-            RuntimeError::BlackHole => write!(f, "blackhole detected (infinite loop: thunk forced itself)"),
-            RuntimeError::BadThunkState(state) => write!(f, "thunk has invalid evaluation state: {}", state),
-        }
-    }
 }
 
 thread_local! {

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -11,55 +11,24 @@ use crate::pipeline::CodegenPipeline;
 use crate::yield_type::Yield;
 
 /// Error type for JIT compilation/execution failures.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum JitError {
-    Compilation(crate::emit::EmitError),
-    Pipeline(crate::pipeline::PipelineError),
+    #[error("JIT compilation error: {0}")]
+    Compilation(#[from] crate::emit::EmitError),
+    #[error("pipeline error: {0}")]
+    Pipeline(#[from] crate::pipeline::PipelineError),
+    #[error("missing freer-simple constructor '{0}' in DataConTable")]
     MissingConTags(&'static str),
-    Effect(EffectError),
-    Yield(crate::yield_type::YieldError),
-    HeapBridge(crate::heap_bridge::BridgeError),
-    Signal(crate::signal_safety::SignalError),
+    #[error("effect dispatch error: {0}")]
+    Effect(#[from] EffectError),
+    #[error("yield error: {0}")]
+    Yield(#[from] crate::yield_type::YieldError),
+    #[error("heap bridge error: {0}")]
+    HeapBridge(#[from] crate::heap_bridge::BridgeError),
+    #[error("JIT signal during heap bridge: {0}")]
+    Signal(#[from] crate::signal_safety::SignalError),
+    #[error("Effect handler response too large ({nodes} value nodes, max {limit}). Narrow your query to return fewer results.")]
     EffectResponseTooLarge { nodes: usize, limit: usize },
-}
-
-impl std::fmt::Display for JitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            JitError::Compilation(e) => write!(f, "JIT compilation error: {}", e),
-            JitError::Pipeline(e) => write!(f, "pipeline error: {}", e),
-            JitError::MissingConTags(name) => {
-                write!(
-                    f,
-                    "missing freer-simple constructor '{}' in DataConTable",
-                    name
-                )
-            }
-            JitError::Effect(e) => write!(f, "effect dispatch error: {}", e),
-            JitError::Yield(e) => write!(f, "yield error: {}", e),
-            JitError::HeapBridge(e) => write!(f, "heap bridge error: {}", e),
-            JitError::Signal(e) => write!(f, "JIT signal during heap bridge: {}", e),
-            JitError::EffectResponseTooLarge { nodes, limit } => write!(
-                f,
-                "Effect handler response too large ({nodes} value nodes, max {limit}). \
-                 Narrow your query to return fewer results."
-            ),
-        }
-    }
-}
-
-impl std::error::Error for JitError {}
-
-impl From<EffectError> for JitError {
-    fn from(e: EffectError) -> Self {
-        JitError::Effect(e)
-    }
-}
-
-impl From<crate::pipeline::PipelineError> for JitError {
-    fn from(e: crate::pipeline::PipelineError) -> Self {
-        JitError::Pipeline(e)
-    }
 }
 
 /// High-level JIT effect machine.

--- a/tidepool-codegen/src/pipeline.rs
+++ b/tidepool-codegen/src/pipeline.rs
@@ -10,33 +10,24 @@ use crate::debug::LambdaRegistry;
 use crate::stack_map::{RawStackMap, StackMapRegistry};
 
 /// Errors from the Cranelift compilation pipeline.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PipelineError {
     /// Pipeline initialization failed (ISA detection, memory reservation).
+    #[error("pipeline init failed: {0}")]
     Init(String),
     /// Function declaration failed.
+    #[error("function declaration failed: {0}")]
     Declaration(String),
     /// First-pass compilation failed (stack map extraction).
+    #[error("compilation failed: {0}")]
     Compilation(String),
     /// Module define_function failed.
+    #[error("define_function failed: {0}")]
     Definition(String),
     /// Module finalize_definitions failed.
+    #[error("finalize_definitions failed: {0}")]
     Finalization(String),
 }
-
-impl std::fmt::Display for PipelineError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PipelineError::Init(e) => write!(f, "pipeline init failed: {}", e),
-            PipelineError::Declaration(e) => write!(f, "function declaration failed: {}", e),
-            PipelineError::Compilation(e) => write!(f, "compilation failed: {}", e),
-            PipelineError::Definition(e) => write!(f, "define_function failed: {}", e),
-            PipelineError::Finalization(e) => write!(f, "finalize_definitions failed: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for PipelineError {}
 
 /// Cranelift JIT compilation pipeline.
 ///

--- a/tidepool-codegen/src/signal_safety.rs
+++ b/tidepool-codegen/src/signal_safety.rs
@@ -212,6 +212,8 @@ mod inner {
         }
     }
 
+    impl std::error::Error for SignalError {}
+
     // Thread-local jump buffer pointer. Synchronous signals (SIGILL, SIGSEGV,
     // SIGBUS) are delivered to the faulting thread, so per-thread storage is
     // correct. The `const` initializer avoids any lazy-init allocation, making
@@ -432,6 +434,8 @@ mod inner {
             write!(f, "JIT signal: {}", self.0)
         }
     }
+
+    impl std::error::Error for SignalError {}
 
     pub unsafe fn with_signal_protection<F, R>(f: F) -> Result<R, SignalError>
     where

--- a/tidepool-codegen/src/yield_type.rs
+++ b/tidepool-codegen/src/yield_type.rs
@@ -34,127 +34,100 @@ impl std::fmt::Display for Yield {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]
 pub enum YieldError {
     /// Result HeapObject had unexpected tag byte.
+    #[error("unexpected heap tag: {0}")]
     UnexpectedTag(u8),
     /// Result was Con but con_tag was neither Val nor E.
+    #[error("unexpected constructor tag: {0}")]
     UnexpectedConTag(u64),
     /// Val constructor had wrong number of fields.
+    #[error("Val constructor has {0} fields, expected >= 1")]
     BadValFields(u16),
     /// E constructor had wrong number of fields.
+    #[error("E constructor has {0} fields, expected 2")]
     BadEFields(u16),
     /// Union constructor had wrong number of fields.
+    #[error("Union constructor has {0} fields, expected 2")]
     BadUnionFields(u16),
     /// Null pointer encountered.
+    #[error("null pointer in effect result")]
     NullPointer,
     /// Division by zero in JIT code.
+    #[error("division by zero")]
     DivisionByZero,
     /// Arithmetic overflow in JIT code.
+    #[error("arithmetic overflow")]
     Overflow,
     /// Haskell `error` called in JIT code.
+    #[error("Haskell error called")]
     UserError,
     /// Haskell `error` called with a specific message.
+    #[error("Haskell error: {0}")]
     UserErrorMsg(String),
     /// Haskell `undefined` forced in JIT code.
+    #[error("Haskell undefined forced")]
     Undefined,
     /// GHC type metadata forced (should be dead code).
+    #[error("forced type metadata (should be dead code)")]
     TypeMetadata,
     /// Unresolved external variable forced.
+    #[error("unresolved variable VarId({0:#x}) [tag='{tag}', key={key}]", tag=(*.0 >> 56) as u8 as char, key=(*.0 & ((1u64 << 56) - 1)))]
     UnresolvedVar(u64),
     /// Application of null function pointer.
+    #[error("application of null function pointer")]
     NullFunPtr,
     /// Application of non-closure heap object.
+    #[error("application of non-closure (tag={0})")]
     BadFunPtrTag(u8),
     /// Heap overflow after GC.
+    #[error("heap overflow (nursery exhausted after GC)")]
     HeapOverflow,
     /// Call depth exceeded (likely infinite list or unbounded recursion).
+    #[error("stack overflow (likely infinite list or unbounded recursion — use zipWithIndex/imap/enumFromTo instead of [0..])")]
     StackOverflow,
     /// Fatal signal during JIT execution (SIGILL, SIGSEGV, SIGBUS, SIGTRAP).
+    #[error("{}", format_yield_signal(*.0))]
     Signal(i32),
     /// Blackhole detected (infinite loop: thunk forced itself).
+    #[error("blackhole detected (infinite loop: thunk forced itself)")]
     BlackHole,
     /// Thunk encountered with an invalid evaluation state.
+    #[error("thunk has invalid evaluation state: {0}")]
     BadThunkState(u8),
 }
 
-impl std::fmt::Display for YieldError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            YieldError::UnexpectedTag(tag) => write!(f, "unexpected heap tag: {}", tag),
-            YieldError::UnexpectedConTag(tag) => write!(f, "unexpected constructor tag: {}", tag),
-            YieldError::BadValFields(n) => {
-                write!(f, "Val constructor has {} fields, expected >= 1", n)
-            }
-            YieldError::BadEFields(n) => write!(f, "E constructor has {} fields, expected 2", n),
-            YieldError::BadUnionFields(n) => {
-                write!(f, "Union constructor has {} fields, expected 2", n)
-            }
-            YieldError::NullPointer => write!(f, "null pointer in effect result"),
-            YieldError::DivisionByZero => write!(f, "division by zero"),
-            YieldError::Overflow => write!(f, "arithmetic overflow"),
-            YieldError::UserError => write!(f, "Haskell error called"),
-            YieldError::UserErrorMsg(msg) => write!(f, "Haskell error: {}", msg),
-            YieldError::Undefined => write!(f, "Haskell undefined forced"),
-            YieldError::TypeMetadata => write!(f, "forced type metadata (should be dead code)"),
-            YieldError::UnresolvedVar(id) => {
-                let tag_char = (*id >> 56) as u8 as char;
-                let key = *id & ((1u64 << 56) - 1);
-                write!(
-                    f,
-                    "unresolved variable VarId({:#x}) [tag='{}', key={}]",
-                    id, tag_char, key
-                )
-            }
-            YieldError::NullFunPtr => write!(f, "application of null function pointer"),
-            YieldError::BadFunPtrTag(tag) => write!(f, "application of non-closure (tag={})", tag),
-            YieldError::HeapOverflow => write!(f, "heap overflow (nursery exhausted after GC)"),
-            YieldError::StackOverflow => write!(f, "stack overflow (likely infinite list or unbounded recursion — use zipWithIndex/imap/enumFromTo instead of [0..])"),
-            YieldError::BlackHole => write!(f, "blackhole detected (infinite loop: thunk forced itself)"),
-            YieldError::BadThunkState(state) => write!(f, "thunk has invalid evaluation state: {}", state),
-            YieldError::Signal(sig) => {
-                let ctx = crate::host_fns::get_exec_context();
-                #[cfg(unix)]
-                {
-                    let name = match *sig {
-                        libc::SIGILL => {
-                            "SIGILL (illegal instruction — likely exhausted case branch)"
-                        }
-                        libc::SIGSEGV => {
-                            "SIGSEGV (segmentation fault — likely invalid memory access)"
-                        }
-                        libc::SIGBUS => "SIGBUS (bus error)",
-                        libc::SIGTRAP => "SIGTRAP (trap — likely Cranelift trap instruction)",
-                        _ => {
-                            if !ctx.is_empty() {
-                                return write!(
-                                    f,
-                                    "JIT signal: signal {} (unknown, context: {})",
-                                    sig, ctx
-                                );
-                            } else {
-                                return write!(f, "JIT signal: signal {} (unknown)", sig);
-                            }
-                        }
-                    };
-                    if !ctx.is_empty() {
-                        write!(f, "JIT signal: {} (context: {})", name, ctx)
-                    } else {
-                        write!(f, "JIT signal: {}", name)
-                    }
-                }
-                #[cfg(not(unix))]
+fn format_yield_signal(sig: i32) -> String {
+    let ctx = crate::host_fns::get_exec_context();
+    #[cfg(unix)]
+    {
+        let name = match sig {
+            libc::SIGILL => "SIGILL (illegal instruction — likely exhausted case branch)",
+            libc::SIGSEGV => "SIGSEGV (segmentation fault — likely invalid memory access)",
+            libc::SIGBUS => "SIGBUS (bus error)",
+            libc::SIGTRAP => "SIGTRAP (trap — likely Cranelift trap instruction)",
+            _ => {
                 if !ctx.is_empty() {
-                    write!(f, "JIT signal: signal {} (context: {})", sig, ctx)
+                    return format!("JIT signal: signal {} (unknown, context: {})", sig, ctx);
                 } else {
-                    write!(f, "JIT signal: signal {}", sig)
+                    return format!("JIT signal: signal {} (unknown)", sig);
                 }
             }
+        };
+        if !ctx.is_empty() {
+            format!("JIT signal: {} (context: {})", name, ctx)
+        } else {
+            format!("JIT signal: {}", name)
         }
     }
+    #[cfg(not(unix))]
+    if !ctx.is_empty() {
+        format!("JIT signal: signal {} (context: {})", sig, ctx)
+    } else {
+        format!("JIT signal: signal {}", sig)
+    }
 }
-
-impl std::error::Error for YieldError {}
 
 impl From<crate::host_fns::RuntimeError> for YieldError {
     fn from(err: crate::host_fns::RuntimeError) -> Self {


### PR DESCRIPTION
This PR adds `thiserror` v2 derives to all 7 error types in `tidepool-codegen` and adds missing `From` implementations in the error hierarchy.

### Changes:
- Added `thiserror = "2"` to `tidepool-codegen/Cargo.toml`.
- Replaced manual `Display` and `Error` implementations with `#[derive(thiserror::Error)]` and `#[error("...")]` for:
    - `PipelineError`
    - `EmitError`
    - `RuntimeError`
    - `BridgeError`
    - `HeapError`
    - `YieldError`
    - `JitError`
- Added `impl std::error::Error for SignalError {}` in `signal_safety.rs`.
- Added `#[from]` to appropriate variants in `JitError` and `EmitError`.
- Removed manual `From` implementations that are now handled by `thiserror`.
- Fixed minor issues with named arguments in `thiserror` format strings to avoid ambiguity.
- Cleaned up unused `std::fmt` imports.

### Verification:
- `cargo test -p tidepool-codegen` (72 unit tests + integration tests passed)
- `cargo clippy -p tidepool-codegen -- -D warnings` (clean)
