### PR TITLE
refactor: consolidate error types with thiserror across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,6 +3449,7 @@ dependencies = [
  "recursion",
  "serial_test",
  "target-lexicon",
+ "thiserror 2.0.18",
  "tidepool-effect",
  "tidepool-eval",
  "tidepool-heap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,6 +3461,7 @@ version = "0.1.0"
 dependencies = [
  "frunk",
  "proptest",
+ "thiserror 2.0.18",
  "tidepool-bridge",
  "tidepool-eval",
  "tidepool-repr",
@@ -3471,6 +3472,7 @@ name = "tidepool-eval"
 version = "0.1.0"
 dependencies = [
  "im",
+ "thiserror 2.0.18",
  "tidepool-repr",
 ]
 
@@ -3495,7 +3497,7 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "proptest",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tidepool-eval",
  "tidepool-repr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,6 +3416,7 @@ version = "0.1.0"
 dependencies = [
  "proptest",
  "serde_json",
+ "thiserror 2.0.18",
  "tidepool-eval",
  "tidepool-repr",
 ]
@@ -3566,6 +3567,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "thiserror 2.0.18",
  "tidepool-bridge",
  "tidepool-bridge-derive",
  "tidepool-codegen",

--- a/examples/tide/Cargo.toml
+++ b/examples/tide/Cargo.toml
@@ -20,7 +20,7 @@ ureq = "2"
 url = "2"
 rustyline = "15"
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2"
 clap = { version = "4.4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/tidepool-bridge/Cargo.toml
+++ b/tidepool-bridge/Cargo.toml
@@ -10,6 +10,7 @@ description = "Bridge between Rust types and Tidepool Core values"
 readme = "../README.md"
 
 [dependencies]
+thiserror = "2"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 serde_json = "1"

--- a/tidepool-bridge/src/error.rs
+++ b/tidepool-bridge/src/error.rs
@@ -1,15 +1,17 @@
-use std::error::Error;
-use std::fmt;
 use tidepool_repr::DataConId;
+use thiserror::Error;
 
 /// Errors that can occur when bridging between Rust types and Core Values.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum BridgeError {
     /// The `DataConId` was not found in the `DataConTable`.
+    #[error("Unknown DataConId: {0:?}")]
     UnknownDataCon(DataConId),
     /// The `DataConId` was found, but it has an unexpected name.
+    #[error("Unknown DataCon name: {0}")]
     UnknownDataConName(String),
     /// The number of fields in a constructor does not match the expected arity.
+    #[error("Arity mismatch for DataCon {con:?}: expected {expected}, got {got}")]
     ArityMismatch {
         /// The constructor identifier.
         con: DataConId,
@@ -19,6 +21,7 @@ pub enum BridgeError {
         got: usize,
     },
     /// The value has an unexpected type (e.g., expected a Literal, got a Con).
+    #[error("Type mismatch: expected {expected}, got {got}")]
     TypeMismatch {
         /// A description of the expected type.
         expected: String,
@@ -26,30 +29,9 @@ pub enum BridgeError {
         got: String,
     },
     /// The type is not supported by the bridge.
+    #[error("Unsupported type: {0}")]
     UnsupportedType(String),
     /// Internal invariant violation (should never happen).
+    #[error("Internal error: {0}")]
     InternalError(String),
 }
-
-impl fmt::Display for BridgeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            BridgeError::UnknownDataCon(id) => write!(f, "Unknown DataConId: {:?}", id),
-            BridgeError::UnknownDataConName(name) => write!(f, "Unknown DataCon name: {}", name),
-            BridgeError::ArityMismatch { con, expected, got } => {
-                write!(
-                    f,
-                    "Arity mismatch for DataCon {:?}: expected {}, got {}",
-                    con, expected, got
-                )
-            }
-            BridgeError::TypeMismatch { expected, got } => {
-                write!(f, "Type mismatch: expected {}, got {}", expected, got)
-            }
-            BridgeError::UnsupportedType(ty) => write!(f, "Unsupported type: {}", ty),
-            BridgeError::InternalError(msg) => write!(f, "Internal error: {}", msg),
-        }
-    }
-}
-
-impl Error for BridgeError {}

--- a/tidepool-codegen/Cargo.toml
+++ b/tidepool-codegen/Cargo.toml
@@ -20,6 +20,7 @@ tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-heap = { version = "0.1.0", path = "../tidepool-heap" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }
+thiserror = "2"
 recursion = "0.5.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/tidepool-codegen/src/debug.rs
+++ b/tidepool-codegen/src/debug.rs
@@ -167,52 +167,34 @@ pub unsafe fn heap_describe(ptr: *const u8) -> String {
 // ── Heap Object Validation ───────────────────────────────────
 
 /// Validation errors for heap objects.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum HeapError {
+    #[error("null pointer")]
     NullPointer,
+    #[error("invalid heap tag: {0}")]
     InvalidTag(u8),
+    #[error("zero size")]
     ZeroSize,
     /// Closure has null code pointer
+    #[error("null code pointer in closure")]
     NullCodePtr,
     /// Size field doesn't match expected size for the object type
+    #[error("size mismatch: expected >= {expected_min}, got {actual}")]
     SizeMismatch {
         expected_min: u16,
         actual: u16,
     },
     /// A field pointer is null
+    #[error("null pointer in field {index}")]
     NullField {
         index: usize,
     },
     /// A field pointer has an invalid heap tag
+    #[error("field {index} has invalid tag: {tag}")]
     InvalidFieldTag {
         index: usize,
         tag: u8,
     },
-}
-
-impl std::fmt::Display for HeapError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            HeapError::NullPointer => write!(f, "null pointer"),
-            HeapError::InvalidTag(t) => write!(f, "invalid heap tag: {}", t),
-            HeapError::ZeroSize => write!(f, "zero size"),
-            HeapError::NullCodePtr => write!(f, "null code pointer in closure"),
-            HeapError::SizeMismatch {
-                expected_min,
-                actual,
-            } => {
-                write!(
-                    f,
-                    "size mismatch: expected >= {}, got {}",
-                    expected_min, actual
-                )
-            }
-            HeapError::NullField { index } => write!(f, "null pointer in field {}", index),
-            HeapError::InvalidFieldTag { index, tag } => {
-                write!(f, "field {} has invalid tag: {}", index, tag)
-            }
-        }
-    }
 }
 
 /// Validate a heap object's structural integrity.

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -171,47 +171,24 @@ pub struct JoinInfo {
 }
 
 /// Errors during IR emission.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum EmitError {
+    #[error("unbound variable: {0:?}")]
     UnboundVariable(VarId),
+    #[error("not yet implemented: {0}")]
     NotYetImplemented(String),
+    #[error("cranelift error: {0}")]
     CraneliftError(String),
-    Pipeline(crate::pipeline::PipelineError),
+    #[error("pipeline error: {0}")]
+    Pipeline(#[from] crate::pipeline::PipelineError),
+    #[error("invalid arity for {0:?}: expected {1}, got {2}")]
     InvalidArity(PrimOpKind, usize, usize),
     /// A variable needed for closure capture was not found in the environment.
+    #[error("missing capture variable VarId({id:#x}): {ctx}", id = .0.0, ctx = .1)]
     MissingCaptureVar(VarId, String),
     /// Internal invariant violation (should never happen).
+    #[error("internal error: {0}")]
     InternalError(String),
-}
-
-impl std::fmt::Display for EmitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EmitError::UnboundVariable(v) => write!(f, "unbound variable: {:?}", v),
-            EmitError::NotYetImplemented(s) => write!(f, "not yet implemented: {}", s),
-            EmitError::CraneliftError(s) => write!(f, "cranelift error: {}", s),
-            EmitError::Pipeline(e) => write!(f, "pipeline error: {}", e),
-            EmitError::InvalidArity(op, expected, got) => {
-                write!(
-                    f,
-                    "invalid arity for {:?}: expected {}, got {}",
-                    op, expected, got
-                )
-            }
-            EmitError::MissingCaptureVar(v, ctx) => {
-                write!(f, "missing capture variable VarId({:#x}): {}", v.0, ctx)
-            }
-            EmitError::InternalError(msg) => write!(f, "internal error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for EmitError {}
-
-impl From<crate::pipeline::PipelineError> for EmitError {
-    fn from(e: crate::pipeline::PipelineError) -> Self {
-        EmitError::Pipeline(e)
-    }
 }
 
 impl EmitContext {

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -3,45 +3,35 @@ use crate::layout::{
     self, LIT_TAG_ADDR, LIT_TAG_ARRAY, LIT_TAG_BYTEARRAY, LIT_TAG_CHAR, LIT_TAG_DOUBLE,
     LIT_TAG_FLOAT, LIT_TAG_INT, LIT_TAG_SMALLARRAY, LIT_TAG_STRING, LIT_TAG_WORD,
 };
-use std::fmt;
 use tidepool_eval::value::Value;
 use tidepool_heap::layout as heap_layout;
 use tidepool_repr::{DataConId, Literal};
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum BridgeError {
+    #[error("unexpected heap tag: {0}")]
     UnexpectedHeapTag(u8),
+    #[error("unexpected lit tag: {0}")]
     UnexpectedLitTag(u8),
+    #[error("null pointer")]
     NullPointer,
+    #[error("nursery exhausted")]
     NurseryExhausted,
+    #[error("too many Con fields: {count}")]
     TooManyFields { count: usize },
+    #[error("data too large: {len} bytes")]
     DataTooLarge { len: usize },
+    #[error("heap structure too deep (>10000 levels)")]
     TooDeep,
+    #[error("unevaluated thunk")]
     UnevaluatedThunk,
+    #[error("blackhole (thunk forcing itself)")]
     BlackHole,
+    #[error("unknown thunk state: {0}")]
     UnknownThunkState(u8),
+    #[error("internal error: {0}")]
     InternalError(String),
 }
-
-impl fmt::Display for BridgeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            BridgeError::UnexpectedHeapTag(t) => write!(f, "unexpected heap tag: {}", t),
-            BridgeError::UnexpectedLitTag(t) => write!(f, "unexpected lit tag: {}", t),
-            BridgeError::NullPointer => write!(f, "null pointer"),
-            BridgeError::NurseryExhausted => write!(f, "nursery exhausted"),
-            BridgeError::TooManyFields { count } => write!(f, "too many Con fields: {}", count),
-            BridgeError::DataTooLarge { len } => write!(f, "data too large: {} bytes", len),
-            BridgeError::TooDeep => write!(f, "heap structure too deep (>10000 levels)"),
-            BridgeError::UnevaluatedThunk => write!(f, "unevaluated thunk"),
-            BridgeError::BlackHole => write!(f, "blackhole (thunk forcing itself)"),
-            BridgeError::UnknownThunkState(state) => write!(f, "unknown thunk state: {}", state),
-            BridgeError::InternalError(msg) => write!(f, "internal error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for BridgeError {}
 
 /// Convert a heap-allocated object to a Value.
 ///

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -3,7 +3,6 @@ use crate::gc::frame_walker::{self, StackRoot};
 use crate::layout;
 use crate::stack_map::StackMapRegistry;
 use std::cell::{Cell, RefCell};
-use std::fmt;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use tidepool_heap::layout as heap_layout;
 
@@ -13,51 +12,34 @@ type GcHook = fn(&[StackRoot]);
 const MIN_VALID_ADDR: u64 = 0x1000;
 
 /// Runtime errors raised by JIT code via host functions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum RuntimeError {
+    #[error("division by zero")]
     DivisionByZero,
+    #[error("arithmetic overflow")]
     Overflow,
+    #[error("Haskell error called")]
     UserError,
+    #[error("Haskell undefined forced")]
     Undefined,
+    #[error("forced type metadata (should be dead code)")]
     TypeMetadata,
+    #[error("unresolved variable VarId({0:#x}) [tag='{tag}', key={key}]", tag=(*.0 >> 56) as u8 as char, key=(*.0 & ((1u64 << 56) - 1)))]
     UnresolvedVar(u64),
+    #[error("application of null function pointer")]
     NullFunPtr,
+    #[error("application of non-closure (tag={0})")]
     BadFunPtrTag(u8),
+    #[error("heap overflow (nursery exhausted after GC)")]
     HeapOverflow,
+    #[error("stack overflow (likely infinite list or unbounded recursion — use zipWithIndex/imap/enumFromTo instead of [0..])")]
     StackOverflow,
+    #[error("blackhole detected (infinite loop: thunk forced itself)")]
     BlackHole,
+    #[error("thunk has invalid evaluation state: {0}")]
     BadThunkState(u8),
+    #[error("Haskell error: {0}")]
     UserErrorMsg(String), // NEW: error with preserved message
-}
-
-impl std::fmt::Display for RuntimeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RuntimeError::DivisionByZero => write!(f, "division by zero"),
-            RuntimeError::Overflow => write!(f, "arithmetic overflow"),
-            RuntimeError::UserError => write!(f, "Haskell error called"),
-            RuntimeError::UserErrorMsg(msg) => write!(f, "Haskell error: {}", msg),
-            RuntimeError::Undefined => write!(f, "Haskell undefined forced"),
-            RuntimeError::TypeMetadata => write!(f, "forced type metadata (should be dead code)"),
-            RuntimeError::UnresolvedVar(id) => {
-                let tag_char = (*id >> 56) as u8 as char;
-                let key = *id & ((1u64 << 56) - 1);
-                write!(
-                    f,
-                    "unresolved variable VarId({:#x}) [tag='{}', key={}]",
-                    id, tag_char, key
-                )
-            }
-            RuntimeError::NullFunPtr => write!(f, "application of null function pointer"),
-            RuntimeError::BadFunPtrTag(tag) => {
-                write!(f, "application of non-closure (tag={})", tag)
-            }
-            RuntimeError::HeapOverflow => write!(f, "heap overflow (nursery exhausted after GC)"),
-            RuntimeError::StackOverflow => write!(f, "stack overflow (likely infinite list or unbounded recursion — use zipWithIndex/imap/enumFromTo instead of [0..])"),
-            RuntimeError::BlackHole => write!(f, "blackhole detected (infinite loop: thunk forced itself)"),
-            RuntimeError::BadThunkState(state) => write!(f, "thunk has invalid evaluation state: {}", state),
-        }
-    }
 }
 
 thread_local! {

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -39,7 +39,7 @@ pub enum RuntimeError {
     #[error("thunk has invalid evaluation state: {0}")]
     BadThunkState(u8),
     #[error("Haskell error: {0}")]
-    UserErrorMsg(String), // NEW: error with preserved message
+    UserErrorMsg(String),
 }
 
 thread_local! {

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -11,55 +11,24 @@ use crate::pipeline::CodegenPipeline;
 use crate::yield_type::Yield;
 
 /// Error type for JIT compilation/execution failures.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum JitError {
-    Compilation(crate::emit::EmitError),
-    Pipeline(crate::pipeline::PipelineError),
+    #[error("JIT compilation error: {0}")]
+    Compilation(#[from] crate::emit::EmitError),
+    #[error("pipeline error: {0}")]
+    Pipeline(#[from] crate::pipeline::PipelineError),
+    #[error("missing freer-simple constructor '{0}' in DataConTable")]
     MissingConTags(&'static str),
-    Effect(EffectError),
-    Yield(crate::yield_type::YieldError),
-    HeapBridge(crate::heap_bridge::BridgeError),
-    Signal(crate::signal_safety::SignalError),
+    #[error("effect dispatch error: {0}")]
+    Effect(#[from] EffectError),
+    #[error("yield error: {0}")]
+    Yield(#[from] crate::yield_type::YieldError),
+    #[error("heap bridge error: {0}")]
+    HeapBridge(#[from] crate::heap_bridge::BridgeError),
+    #[error("JIT signal during heap bridge: {0}")]
+    Signal(#[from] crate::signal_safety::SignalError),
+    #[error("Effect handler response too large ({nodes} value nodes, max {limit}). Narrow your query to return fewer results.")]
     EffectResponseTooLarge { nodes: usize, limit: usize },
-}
-
-impl std::fmt::Display for JitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            JitError::Compilation(e) => write!(f, "JIT compilation error: {}", e),
-            JitError::Pipeline(e) => write!(f, "pipeline error: {}", e),
-            JitError::MissingConTags(name) => {
-                write!(
-                    f,
-                    "missing freer-simple constructor '{}' in DataConTable",
-                    name
-                )
-            }
-            JitError::Effect(e) => write!(f, "effect dispatch error: {}", e),
-            JitError::Yield(e) => write!(f, "yield error: {}", e),
-            JitError::HeapBridge(e) => write!(f, "heap bridge error: {}", e),
-            JitError::Signal(e) => write!(f, "JIT signal during heap bridge: {}", e),
-            JitError::EffectResponseTooLarge { nodes, limit } => write!(
-                f,
-                "Effect handler response too large ({nodes} value nodes, max {limit}). \
-                 Narrow your query to return fewer results."
-            ),
-        }
-    }
-}
-
-impl std::error::Error for JitError {}
-
-impl From<EffectError> for JitError {
-    fn from(e: EffectError) -> Self {
-        JitError::Effect(e)
-    }
-}
-
-impl From<crate::pipeline::PipelineError> for JitError {
-    fn from(e: crate::pipeline::PipelineError) -> Self {
-        JitError::Pipeline(e)
-    }
 }
 
 /// High-level JIT effect machine.

--- a/tidepool-codegen/src/pipeline.rs
+++ b/tidepool-codegen/src/pipeline.rs
@@ -10,33 +10,24 @@ use crate::debug::LambdaRegistry;
 use crate::stack_map::{RawStackMap, StackMapRegistry};
 
 /// Errors from the Cranelift compilation pipeline.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum PipelineError {
     /// Pipeline initialization failed (ISA detection, memory reservation).
+    #[error("pipeline init failed: {0}")]
     Init(String),
     /// Function declaration failed.
+    #[error("function declaration failed: {0}")]
     Declaration(String),
     /// First-pass compilation failed (stack map extraction).
+    #[error("compilation failed: {0}")]
     Compilation(String),
     /// Module define_function failed.
+    #[error("define_function failed: {0}")]
     Definition(String),
     /// Module finalize_definitions failed.
+    #[error("finalize_definitions failed: {0}")]
     Finalization(String),
 }
-
-impl std::fmt::Display for PipelineError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PipelineError::Init(e) => write!(f, "pipeline init failed: {}", e),
-            PipelineError::Declaration(e) => write!(f, "function declaration failed: {}", e),
-            PipelineError::Compilation(e) => write!(f, "compilation failed: {}", e),
-            PipelineError::Definition(e) => write!(f, "define_function failed: {}", e),
-            PipelineError::Finalization(e) => write!(f, "finalize_definitions failed: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for PipelineError {}
 
 /// Cranelift JIT compilation pipeline.
 ///

--- a/tidepool-codegen/src/signal_safety.rs
+++ b/tidepool-codegen/src/signal_safety.rs
@@ -212,6 +212,8 @@ mod inner {
         }
     }
 
+    impl std::error::Error for SignalError {}
+
     // Thread-local jump buffer pointer. Synchronous signals (SIGILL, SIGSEGV,
     // SIGBUS) are delivered to the faulting thread, so per-thread storage is
     // correct. The `const` initializer avoids any lazy-init allocation, making
@@ -432,6 +434,8 @@ mod inner {
             write!(f, "JIT signal: {}", self.0)
         }
     }
+
+    impl std::error::Error for SignalError {}
 
     pub unsafe fn with_signal_protection<F, R>(f: F) -> Result<R, SignalError>
     where

--- a/tidepool-codegen/src/yield_type.rs
+++ b/tidepool-codegen/src/yield_type.rs
@@ -34,127 +34,100 @@ impl std::fmt::Display for Yield {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]
 pub enum YieldError {
     /// Result HeapObject had unexpected tag byte.
+    #[error("unexpected heap tag: {0}")]
     UnexpectedTag(u8),
     /// Result was Con but con_tag was neither Val nor E.
+    #[error("unexpected constructor tag: {0}")]
     UnexpectedConTag(u64),
     /// Val constructor had wrong number of fields.
+    #[error("Val constructor has {0} fields, expected >= 1")]
     BadValFields(u16),
     /// E constructor had wrong number of fields.
+    #[error("E constructor has {0} fields, expected 2")]
     BadEFields(u16),
     /// Union constructor had wrong number of fields.
+    #[error("Union constructor has {0} fields, expected 2")]
     BadUnionFields(u16),
     /// Null pointer encountered.
+    #[error("null pointer in effect result")]
     NullPointer,
     /// Division by zero in JIT code.
+    #[error("division by zero")]
     DivisionByZero,
     /// Arithmetic overflow in JIT code.
+    #[error("arithmetic overflow")]
     Overflow,
     /// Haskell `error` called in JIT code.
+    #[error("Haskell error called")]
     UserError,
     /// Haskell `error` called with a specific message.
+    #[error("Haskell error: {0}")]
     UserErrorMsg(String),
     /// Haskell `undefined` forced in JIT code.
+    #[error("Haskell undefined forced")]
     Undefined,
     /// GHC type metadata forced (should be dead code).
+    #[error("forced type metadata (should be dead code)")]
     TypeMetadata,
     /// Unresolved external variable forced.
+    #[error("unresolved variable VarId({0:#x}) [tag='{tag}', key={key}]", tag=(*.0 >> 56) as u8 as char, key=(*.0 & ((1u64 << 56) - 1)))]
     UnresolvedVar(u64),
     /// Application of null function pointer.
+    #[error("application of null function pointer")]
     NullFunPtr,
     /// Application of non-closure heap object.
+    #[error("application of non-closure (tag={0})")]
     BadFunPtrTag(u8),
     /// Heap overflow after GC.
+    #[error("heap overflow (nursery exhausted after GC)")]
     HeapOverflow,
     /// Call depth exceeded (likely infinite list or unbounded recursion).
+    #[error("stack overflow (likely infinite list or unbounded recursion — use zipWithIndex/imap/enumFromTo instead of [0..])")]
     StackOverflow,
     /// Fatal signal during JIT execution (SIGILL, SIGSEGV, SIGBUS, SIGTRAP).
+    #[error("{}", format_yield_signal(*.0))]
     Signal(i32),
     /// Blackhole detected (infinite loop: thunk forced itself).
+    #[error("blackhole detected (infinite loop: thunk forced itself)")]
     BlackHole,
     /// Thunk encountered with an invalid evaluation state.
+    #[error("thunk has invalid evaluation state: {0}")]
     BadThunkState(u8),
 }
 
-impl std::fmt::Display for YieldError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            YieldError::UnexpectedTag(tag) => write!(f, "unexpected heap tag: {}", tag),
-            YieldError::UnexpectedConTag(tag) => write!(f, "unexpected constructor tag: {}", tag),
-            YieldError::BadValFields(n) => {
-                write!(f, "Val constructor has {} fields, expected >= 1", n)
-            }
-            YieldError::BadEFields(n) => write!(f, "E constructor has {} fields, expected 2", n),
-            YieldError::BadUnionFields(n) => {
-                write!(f, "Union constructor has {} fields, expected 2", n)
-            }
-            YieldError::NullPointer => write!(f, "null pointer in effect result"),
-            YieldError::DivisionByZero => write!(f, "division by zero"),
-            YieldError::Overflow => write!(f, "arithmetic overflow"),
-            YieldError::UserError => write!(f, "Haskell error called"),
-            YieldError::UserErrorMsg(msg) => write!(f, "Haskell error: {}", msg),
-            YieldError::Undefined => write!(f, "Haskell undefined forced"),
-            YieldError::TypeMetadata => write!(f, "forced type metadata (should be dead code)"),
-            YieldError::UnresolvedVar(id) => {
-                let tag_char = (*id >> 56) as u8 as char;
-                let key = *id & ((1u64 << 56) - 1);
-                write!(
-                    f,
-                    "unresolved variable VarId({:#x}) [tag='{}', key={}]",
-                    id, tag_char, key
-                )
-            }
-            YieldError::NullFunPtr => write!(f, "application of null function pointer"),
-            YieldError::BadFunPtrTag(tag) => write!(f, "application of non-closure (tag={})", tag),
-            YieldError::HeapOverflow => write!(f, "heap overflow (nursery exhausted after GC)"),
-            YieldError::StackOverflow => write!(f, "stack overflow (likely infinite list or unbounded recursion — use zipWithIndex/imap/enumFromTo instead of [0..])"),
-            YieldError::BlackHole => write!(f, "blackhole detected (infinite loop: thunk forced itself)"),
-            YieldError::BadThunkState(state) => write!(f, "thunk has invalid evaluation state: {}", state),
-            YieldError::Signal(sig) => {
-                let ctx = crate::host_fns::get_exec_context();
-                #[cfg(unix)]
-                {
-                    let name = match *sig {
-                        libc::SIGILL => {
-                            "SIGILL (illegal instruction — likely exhausted case branch)"
-                        }
-                        libc::SIGSEGV => {
-                            "SIGSEGV (segmentation fault — likely invalid memory access)"
-                        }
-                        libc::SIGBUS => "SIGBUS (bus error)",
-                        libc::SIGTRAP => "SIGTRAP (trap — likely Cranelift trap instruction)",
-                        _ => {
-                            if !ctx.is_empty() {
-                                return write!(
-                                    f,
-                                    "JIT signal: signal {} (unknown, context: {})",
-                                    sig, ctx
-                                );
-                            } else {
-                                return write!(f, "JIT signal: signal {} (unknown)", sig);
-                            }
-                        }
-                    };
-                    if !ctx.is_empty() {
-                        write!(f, "JIT signal: {} (context: {})", name, ctx)
-                    } else {
-                        write!(f, "JIT signal: {}", name)
-                    }
-                }
-                #[cfg(not(unix))]
+fn format_yield_signal(sig: i32) -> String {
+    let ctx = crate::host_fns::get_exec_context();
+    #[cfg(unix)]
+    {
+        let name = match sig {
+            libc::SIGILL => "SIGILL (illegal instruction — likely exhausted case branch)",
+            libc::SIGSEGV => "SIGSEGV (segmentation fault — likely invalid memory access)",
+            libc::SIGBUS => "SIGBUS (bus error)",
+            libc::SIGTRAP => "SIGTRAP (trap — likely Cranelift trap instruction)",
+            _ => {
                 if !ctx.is_empty() {
-                    write!(f, "JIT signal: signal {} (context: {})", sig, ctx)
+                    return format!("JIT signal: signal {} (unknown, context: {})", sig, ctx);
                 } else {
-                    write!(f, "JIT signal: signal {}", sig)
+                    return format!("JIT signal: signal {} (unknown)", sig);
                 }
             }
+        };
+        if !ctx.is_empty() {
+            format!("JIT signal: {} (context: {})", name, ctx)
+        } else {
+            format!("JIT signal: {}", name)
         }
     }
+    #[cfg(not(unix))]
+    if !ctx.is_empty() {
+        format!("JIT signal: signal {} (context: {})", sig, ctx)
+    } else {
+        format!("JIT signal: signal {}", sig)
+    }
 }
-
-impl std::error::Error for YieldError {}
 
 impl From<crate::host_fns::RuntimeError> for YieldError {
     fn from(err: crate::host_fns::RuntimeError) -> Self {

--- a/tidepool-codegen/src/yield_type.rs
+++ b/tidepool-codegen/src/yield_type.rs
@@ -107,6 +107,9 @@ fn format_yield_signal(sig: i32) -> String {
             libc::SIGSEGV => "SIGSEGV (segmentation fault — likely invalid memory access)",
             libc::SIGBUS => "SIGBUS (bus error)",
             libc::SIGTRAP => "SIGTRAP (trap — likely Cranelift trap instruction)",
+            libc::SIGFPE => {
+                "SIGFPE (arithmetic exception — likely division by zero or overflow)"
+            }
             _ => {
                 if !ctx.is_empty() {
                     return format!("JIT signal: signal {} (unknown, context: {})", sig, ctx);

--- a/tidepool-effect/Cargo.toml
+++ b/tidepool-effect/Cargo.toml
@@ -14,6 +14,7 @@ tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-bridge = { version = "0.1.0", path = "../tidepool-bridge" }
 frunk = "0.4"
+thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-effect/src/error.rs
+++ b/tidepool-effect/src/error.rs
@@ -1,70 +1,28 @@
 use tidepool_bridge::BridgeError;
 use tidepool_eval::error::EvalError;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum EffectError {
-    Eval(EvalError),
-    Bridge(BridgeError),
-    UnhandledEffect {
-        tag: u64,
-    },
+    #[error("Eval error: {0}")]
+    Eval(#[from] EvalError),
+    #[error("Bridge error: {0}")]
+    Bridge(#[from] BridgeError),
+    #[error("Unhandled effect at tag {tag}")]
+    UnhandledEffect { tag: u64 },
     /// A required constructor was not found in the DataConTable.
-    MissingConstructor {
-        name: &'static str,
-    },
+    #[error("{name} constructor not found in DataConTable")]
+    MissingConstructor { name: &'static str },
     /// A constructor had the wrong number of fields.
+    #[error("{constructor} expects {expected} fields, got {got}")]
     FieldCountMismatch {
         constructor: &'static str,
         expected: usize,
         got: usize,
     },
     /// Encountered an unexpected value shape during dispatch.
-    UnexpectedValue {
-        context: &'static str,
-        got: String,
-    },
+    #[error("expected {context}, got {got}")]
+    UnexpectedValue { context: &'static str, got: String },
     /// An effect handler encountered a runtime error.
+    #[error("handler error: {0}")]
     Handler(String),
 }
-
-impl From<EvalError> for EffectError {
-    fn from(e: EvalError) -> Self {
-        EffectError::Eval(e)
-    }
-}
-
-impl From<BridgeError> for EffectError {
-    fn from(e: BridgeError) -> Self {
-        EffectError::Bridge(e)
-    }
-}
-
-impl std::fmt::Display for EffectError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EffectError::Eval(e) => write!(f, "Eval error: {}", e),
-            EffectError::Bridge(e) => write!(f, "Bridge error: {}", e),
-            EffectError::UnhandledEffect { tag } => write!(f, "Unhandled effect at tag {}", tag),
-            EffectError::MissingConstructor { name } => {
-                write!(f, "{} constructor not found in DataConTable", name)
-            }
-            EffectError::FieldCountMismatch {
-                constructor,
-                expected,
-                got,
-            } => {
-                write!(
-                    f,
-                    "{} expects {} fields, got {}",
-                    constructor, expected, got
-                )
-            }
-            EffectError::UnexpectedValue { context, got } => {
-                write!(f, "expected {}, got {}", context, got)
-            }
-            EffectError::Handler(msg) => write!(f, "handler error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for EffectError {}

--- a/tidepool-eval/Cargo.toml
+++ b/tidepool-eval/Cargo.toml
@@ -12,3 +12,4 @@ readme = "../README.md"
 [dependencies]
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 im = "15"
+thiserror = "2"

--- a/tidepool-eval/src/error.rs
+++ b/tidepool-eval/src/error.rs
@@ -25,76 +25,55 @@ impl std::fmt::Display for ValueKind {
 }
 
 /// Evaluation error.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum EvalError {
     /// Variable not found in environment
+    #[error("unbound variable: v_{}", .0 .0)]
     UnboundVar(VarId),
     /// Arity mismatch (wrong number of arguments or fields)
+    #[error("arity mismatch: expected {expected} {context}, got {got}")]
     ArityMismatch {
         context: &'static str, // "arguments", "fields", "case binders"
         expected: usize,
         got: usize,
     },
     /// Type mismatch during evaluation
+    #[error("type mismatch: expected {expected}, got {got}")]
     TypeMismatch {
         expected: &'static str,
         got: ValueKind,
     },
     /// No matching alternative in case expression
+    #[error("no matching case alternative")]
     NoMatchingAlt,
     /// Infinite loop detected (thunk forced itself)
+    #[error("infinite loop: thunk {} forced itself", .0 .0)]
     InfiniteLoop(ThunkId),
     /// Unsupported primop
+    #[error("unsupported primop: {0:?}")]
     UnsupportedPrimOp(PrimOpKind),
     /// Heap exhausted
+    #[error("heap exhausted")]
     HeapExhausted,
     /// Application of non-function value
+    #[error("application of non-function value")]
     NotAFunction,
     /// Jump to unknown join point
+    #[error("jump to unbound join point: j_{}", .0 .0)]
     UnboundJoin(JoinId),
     /// Haskell `error "..."` called
+    #[error("Haskell error called")]
     UserError,
     /// Haskell `undefined` forced
+    #[error("Haskell undefined forced")]
     Undefined,
     /// Recursion depth limit exceeded during deep_force
+    #[error("recursion depth limit exceeded")]
     DepthLimit,
     /// Internal invariant violation (should never happen)
+    #[error("internal error: {0}")]
     InternalError(String),
 }
-
-impl std::fmt::Display for EvalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EvalError::UnboundVar(v) => write!(f, "unbound variable: v_{}", v.0),
-            EvalError::ArityMismatch {
-                context,
-                expected,
-                got,
-            } => {
-                write!(
-                    f,
-                    "arity mismatch: expected {} {}, got {}",
-                    expected, context, got
-                )
-            }
-            EvalError::TypeMismatch { expected, got } => {
-                write!(f, "type mismatch: expected {}, got {}", expected, got)
-            }
-            EvalError::NoMatchingAlt => write!(f, "no matching case alternative"),
-            EvalError::InfiniteLoop(id) => write!(f, "infinite loop: thunk {} forced itself", id.0),
-            EvalError::UnsupportedPrimOp(op) => write!(f, "unsupported primop: {:?}", op),
-            EvalError::HeapExhausted => write!(f, "heap exhausted"),
-            EvalError::NotAFunction => write!(f, "application of non-function value"),
-            EvalError::UnboundJoin(id) => write!(f, "jump to unbound join point: j_{}", id.0),
-            EvalError::UserError => write!(f, "Haskell error called"),
-            EvalError::Undefined => write!(f, "Haskell undefined forced"),
-            EvalError::DepthLimit => write!(f, "recursion depth limit exceeded"),
-            EvalError::InternalError(msg) => write!(f, "internal error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for EvalError {}
 
 #[cfg(test)]
 mod tests {

--- a/tidepool-heap/Cargo.toml
+++ b/tidepool-heap/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 bumpalo = "3"
-thiserror = "1"
+thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-heap/src/gc/trace.rs
+++ b/tidepool-heap/src/gc/trace.rs
@@ -1,28 +1,13 @@
 use std::collections::VecDeque;
-use std::error::Error;
-use std::fmt;
 use tidepool_eval::heap::Heap;
 use tidepool_eval::value::ThunkId;
 
 /// Error during garbage collection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum GcError {
+    #[error("ThunkId {:?} not in forwarding table (not reachable during trace)", .0)]
     ThunkNotReachable(ThunkId),
 }
-
-impl fmt::Display for GcError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            GcError::ThunkNotReachable(id) => write!(
-                f,
-                "ThunkId {:?} not in forwarding table (not reachable during trace)",
-                id
-            ),
-        }
-    }
-}
-
-impl Error for GcError {}
 
 /// Maps old ThunkIds to new ThunkIds.
 pub struct ForwardingTable {

--- a/tidepool-repr/Cargo.toml
+++ b/tidepool-repr/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 ciborium = "0.2"
+thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -6,45 +6,27 @@ pub use read::{read_metadata, MetaWarnings};
 pub use write::write_cbor;
 pub use write::write_metadata;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ReadError {
+    #[error("CBOR error: {0}")]
     Cbor(String),
+    #[error("Invalid tag: {0}")]
     InvalidTag(String),
+    #[error("Invalid literal: {0}")]
     InvalidLiteral(String),
+    #[error("Invalid primop: {0}")]
     InvalidPrimOp(String),
+    #[error("Invalid alt con: {0}")]
     InvalidAltCon(String),
+    #[error("Invalid structure: {0}")]
     InvalidStructure(String),
 }
 
-impl std::fmt::Display for ReadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ReadError::Cbor(e) => write!(f, "CBOR error: {}", e),
-            ReadError::InvalidTag(s) => write!(f, "Invalid tag: {}", s),
-            ReadError::InvalidLiteral(s) => write!(f, "Invalid literal: {}", s),
-            ReadError::InvalidPrimOp(s) => write!(f, "Invalid primop: {}", s),
-            ReadError::InvalidAltCon(s) => write!(f, "Invalid alt con: {}", s),
-            ReadError::InvalidStructure(s) => write!(f, "Invalid structure: {}", s),
-        }
-    }
-}
-
-impl std::error::Error for ReadError {}
-
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum WriteError {
+    #[error("CBOR error: {0}")]
     Cbor(String),
 }
-
-impl std::fmt::Display for WriteError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            WriteError::Cbor(e) => write!(f, "CBOR error: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for WriteError {}
 
 #[cfg(test)]
 mod tests {

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -10,6 +10,7 @@ description = "Runtime support for Tidepool applications"
 readme = "../README.md"
 
 [dependencies]
+thiserror = "2"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -3,11 +3,11 @@
 //! Provides `compile_haskell` (source to Core) and `compile_and_run` (source to
 //! evaluated result), with filesystem caching of compiled CBOR artifacts.
 
-use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
+use thiserror::Error;
 pub use tidepool_codegen::host_fns::{drain_diagnostics, push_diagnostic};
 use tidepool_codegen::jit_machine::JitEffectMachine;
 pub use tidepool_codegen::jit_machine::JitError;
@@ -25,93 +25,32 @@ pub use render::{value_to_json, EvalResult};
 pub type CompileResult = (CoreExpr, DataConTable, MetaWarnings);
 
 /// Errors that can occur during Haskell compilation.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum CompileError {
     /// I/O error during file operations or process execution.
-    Io(io::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
     /// The `tidepool-extract` process failed (e.g., GHC parse/type error).
+    #[error("Haskell compilation failed:\n{0}")]
     ExtractFailed(String),
     /// Failed to deserialize the CBOR output from `tidepool-extract`.
-    ReadError(ReadError),
+    #[error("CBOR deserialization error: {0}")]
+    ReadError(#[from] ReadError),
     /// A required output file (.cbor or meta.cbor) was not produced by the extractor.
+    #[error("Missing output file from extractor: {}", .0.display())]
     MissingOutput(PathBuf),
     /// The target binding has IO type, which is not supported.
+    #[error("IO type detected in result binding. IO operations (unsafePerformIO, etc.) are not supported in the Tidepool sandbox.")]
     IOTypeDetected,
 }
 
-impl fmt::Display for CompileError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CompileError::Io(e) => write!(f, "I/O error: {}", e),
-            CompileError::ExtractFailed(msg) => write!(f, "Haskell compilation failed:\n{}", msg),
-            CompileError::ReadError(e) => write!(f, "CBOR deserialization error: {}", e),
-            CompileError::MissingOutput(path) => {
-                write!(f, "Missing output file from extractor: {}", path.display())
-            }
-            CompileError::IOTypeDetected => {
-                write!(f, "IO type detected in result binding. IO operations (unsafePerformIO, etc.) are not supported in the Tidepool sandbox.")
-            }
-        }
-    }
-}
-
-impl std::error::Error for CompileError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CompileError::Io(e) => Some(e),
-            CompileError::ReadError(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<io::Error> for CompileError {
-    fn from(e: io::Error) -> Self {
-        CompileError::Io(e)
-    }
-}
-
-impl From<ReadError> for CompileError {
-    fn from(e: ReadError) -> Self {
-        CompileError::ReadError(e)
-    }
-}
-
 /// Unified error type for compile + run pipeline.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum RuntimeError {
-    Compile(CompileError),
-    Jit(JitError),
-}
-
-impl fmt::Display for RuntimeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RuntimeError::Compile(e) => write!(f, "{}", e),
-            RuntimeError::Jit(e) => write!(f, "{}", e),
-        }
-    }
-}
-
-impl std::error::Error for RuntimeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            RuntimeError::Compile(e) => Some(e),
-            RuntimeError::Jit(e) => Some(e),
-        }
-    }
-}
-
-impl From<CompileError> for RuntimeError {
-    fn from(e: CompileError) -> Self {
-        Self::Compile(e)
-    }
-}
-
-impl From<JitError> for RuntimeError {
-    fn from(e: JitError) -> Self {
-        Self::Jit(e)
-    }
+    #[error(transparent)]
+    Compile(#[from] CompileError),
+    #[error(transparent)]
+    Jit(#[from] JitError),
 }
 
 /// Extract module name from Haskell source (e.g. "module Expr where" -> "Expr").


### PR DESCRIPTION
## Summary

Replace manual `Display` + `Error` + `From` impls with `thiserror` derives across all 8 crates with error types. Also converts `.expect()` to `?` in `tidepool-repr` serial code.

- **tidepool-repr**: thiserror derives on `ReadError`/`WriteError`, `.expect()` → `?` in serial/read.rs and serial/write.rs (#230)
- **tidepool-codegen**: thiserror derives on all 7 error types (`JitError`, `PipelineError`, `EmitError`, `YieldError`, `RuntimeError`, `BridgeError`, `HeapError`), added `Error` impl on `SignalError`, `#[from]` on all wrapping variants (#233)
- **tidepool-heap** + **tidepool-eval** + **tidepool-effect**: thiserror derives on `GcError`, `HeapError`, `EvalError`, `EffectError`, `#[from]` on `EffectError` variants (#229)
- **tidepool-runtime** + **tidepool-bridge**: thiserror derives on `CompileError`, `RuntimeError`, `BridgeError`, `#[from]` replacing manual `From` + `source()` impls (#232)

No behavioral changes — same errors, better types. `thiserror` v2 is the only new dependency.

## Verification
- `cargo check --workspace` ✅
- `cargo test --workspace` ✅
- `cargo clippy --workspace` ✅