### PR TITLE
docs: add comprehensive doc comments to tidepool-eval pub items

### DIFF
--- a/tidepool-eval/src/env.rs
+++ b/tidepool-eval/src/env.rs
@@ -1,3 +1,5 @@
+//! Evaluation environment and variable bindings.
+
 use crate::value::Value;
 use im::HashMap;
 use tidepool_repr::VarId;

--- a/tidepool-eval/src/error.rs
+++ b/tidepool-eval/src/error.rs
@@ -1,12 +1,18 @@
+//! Evaluation errors and value type descriptions.
+
 use crate::value::ThunkId;
 use tidepool_repr::{JoinId, PrimOpKind, VarId};
 
 /// Describes the kind of a Value for error reporting.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValueKind {
+    /// Primitive literal value
     Literal(&'static str), // "Int#", "Word#", "Double#", "Char#", "String"
+    /// Saturated data constructor
     Constructor,
+    /// Function closure
     Closure,
+    /// Lazy thunk
     Thunk,
     /// Fallback for complex values — stores Debug output
     Other(String),

--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -1,3 +1,5 @@
+//! Tree-walking interpreter for Core expressions.
+
 use crate::env::Env;
 use crate::error::EvalError;
 use crate::heap::{Heap, ThunkState};

--- a/tidepool-eval/src/heap.rs
+++ b/tidepool-eval/src/heap.rs
@@ -1,3 +1,5 @@
+//! Thunk storage and lazy evaluation state.
+
 use crate::env::Env;
 use crate::value::{ThunkId, Value};
 use tidepool_repr::CoreExpr;
@@ -5,27 +7,26 @@ use tidepool_repr::CoreExpr;
 /// State of a thunk in the thunk store.
 #[derive(Debug, Clone)]
 pub enum ThunkState {
-    /// Not yet evaluated: captured env + expression
+    /// Initial state: captured environment and expression.
     Unevaluated(Env, CoreExpr),
-    /// Currently being forced (cycle detection)
+    /// Under evaluation: used for infinite loop (cycle) detection.
     BlackHole,
-    /// Already evaluated to a value
+    /// Final state: successfully evaluated to WHNF.
     Evaluated(Value),
 }
 
-/// Heap trait: thunk allocation and forcing.
-/// The interpreter uses VecHeap. Codegen uses ArenaHeap (from core-heap).
+/// Heap trait: abstraction for thunk storage.
 pub trait Heap {
-    /// Allocate a new thunk. Returns its id.
+    /// Reserve an ID and store an unevaluated expression.
     fn alloc(&mut self, env: Env, expr: CoreExpr) -> ThunkId;
 
-    /// Read the current state of a thunk.
+    /// Retrieve the current state of a thunk.
     fn read(&self, id: ThunkId) -> &ThunkState;
 
-    /// Write a new state to a thunk (for force protocol and LetRec back-patching).
+    /// Update a thunk's state (Unevaluated -> BlackHole -> Evaluated).
     fn write(&mut self, id: ThunkId, state: ThunkState);
 
-    /// Return all ThunkIds directly referenced by this thunk.
+    /// Get all thunks transitively reachable from this thunk.
     fn children_of(&self, id: ThunkId) -> Vec<ThunkId>;
 }
 
@@ -36,6 +37,7 @@ pub struct VecHeap {
 }
 
 impl VecHeap {
+    /// Create a new, empty thunk store.
     pub fn new() -> Self {
         Self { thunks: Vec::new() }
     }

--- a/tidepool-eval/src/heap.rs
+++ b/tidepool-eval/src/heap.rs
@@ -23,10 +23,13 @@ pub trait Heap {
     /// Retrieve the current state of a thunk.
     fn read(&self, id: ThunkId) -> &ThunkState;
 
-    /// Update a thunk's state (Unevaluated -> BlackHole -> Evaluated).
+    /// Update a thunk's state. Typically used to move through the lifecycle
+    /// `Unevaluated -> BlackHole -> Evaluated`, but other transitions (such as
+    /// restoring `Unevaluated(env, expr)` after an evaluation failure) are also allowed.
     fn write(&mut self, id: ThunkId, state: ThunkState);
 
-    /// Get all thunks transitively reachable from this thunk.
+    /// Get all thunks directly referenced from this thunk's current state.
+    /// Callers (e.g., GC) are responsible for performing any transitive traversal.
     fn children_of(&self, id: ThunkId) -> Vec<ThunkId>;
 }
 

--- a/tidepool-eval/src/pass.rs
+++ b/tidepool-eval/src/pass.rs
@@ -1,3 +1,5 @@
+//! Optimization passes for Core expressions.
+
 use tidepool_repr::CoreExpr;
 
 /// Whether a pass changed the expression.

--- a/tidepool-eval/src/value.rs
+++ b/tidepool-eval/src/value.rs
@@ -13,7 +13,7 @@ pub type SharedByteArray = Arc<Mutex<Vec<u8>>>;
 /// Runtime value for the tree-walking interpreter.
 #[derive(Debug, Clone)]
 pub enum Value {
-    /// Literal value (Int#, Word#, Char#, Addr#).
+    /// Primitive literal value (Int#, Word#, Char#, String#, Float#, Double#).
     Lit(Literal),
     /// Fully-applied data constructor (GHC DataCon).
     Con(DataConId, Vec<Value>),
@@ -23,7 +23,9 @@ pub enum Value {
     ThunkRef(ThunkId),
     /// Join point continuation (GHC Join Point).
     JoinCont(Vec<VarId>, CoreExpr, Env),
-    /// Partially-applied data constructor (GHC Worker/Wrapper).
+    /// Partially-applied data constructor function: carries the constructor id,
+    /// its total arity, and the arguments applied so far. When the number of
+    /// arguments reaches the arity, this is reduced to a `Con` value.
     ConFun(DataConId, usize, Vec<Value>),
     /// Mutable/immutable byte array (ByteArray# / MutableByteArray#).
     ByteArray(SharedByteArray),

--- a/tidepool-eval/src/value.rs
+++ b/tidepool-eval/src/value.rs
@@ -1,3 +1,5 @@
+//! Runtime values for the tree-walking interpreter.
+
 use crate::env::Env;
 use std::sync::{Arc, Mutex};
 use tidepool_repr::{CoreExpr, DataConId, Literal, VarId};
@@ -11,26 +13,28 @@ pub type SharedByteArray = Arc<Mutex<Vec<u8>>>;
 /// Runtime value for the tree-walking interpreter.
 #[derive(Debug, Clone)]
 pub enum Value {
-    /// Literal value (Int, Word, Char, String, Float, Double)
+    /// Literal value (Int#, Word#, Char#, Addr#).
     Lit(Literal),
-    /// Fully-applied data constructor
+    /// Fully-applied data constructor (GHC DataCon).
     Con(DataConId, Vec<Value>),
-    /// Closure: captured env + binder + body
+    /// Function closure: captured env + binder + body (GHC PAP/FUN).
     Closure(Env, VarId, CoreExpr),
-    /// Reference to a heap-allocated thunk
+    /// Reference to a heap-allocated thunk (GHC Thunk).
     ThunkRef(ThunkId),
-    /// Join point continuation (lives in Env only, never heap-allocated)
+    /// Join point continuation (GHC Join Point).
     JoinCont(Vec<VarId>, CoreExpr, Env),
-    /// Partially-applied data constructor: (tag, arity, accumulated args)
-    /// When all args are supplied, collapses to Con.
+    /// Partially-applied data constructor (GHC Worker/Wrapper).
     ConFun(DataConId, usize, Vec<Value>),
-    /// Mutable/immutable byte array (ByteArray# / MutableByteArray#)
+    /// Mutable/immutable byte array (ByteArray# / MutableByteArray#).
     ByteArray(SharedByteArray),
 }
 
 /// Thunk identifier — index into the thunk store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ThunkId(pub u32);
+pub struct ThunkId(
+    /// Raw index into the heap's thunk vector.
+    pub u32,
+);
 
 impl std::fmt::Display for ThunkId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Add documentation comments (`///` and `//!`) to all pub items in the `tidepool-eval` crate.
- Added module-level docs to all `.rs` files.
- Documented `Value`, `ValueKind`, and `ThunkState` variants.
- Documented `Heap` trait contract and `VecHeap` methods.
- Verified with `cargo doc` and existing tests.
- Addressed review feedback regarding literal variants and thunk state transitions.