### PR TITLE
refactor: idiomatic rust cleanup in tidepool-repr and tidepool-optimize

### DIFF
--- a/tidepool-optimize/src/occ.rs
+++ b/tidepool-optimize/src/occ.rs
@@ -16,6 +16,14 @@ pub enum Occ {
 
 impl Occ {
     /// Add two occurrence counts.
+    ///
+    /// This is a lattice join operation where:
+    /// - `Dead` is the identity element.
+    /// - `Once + Once = Many`.
+    /// - `Many` is the top element (anything + `Many` = `Many`).
+    ///
+    /// We suppress `clippy::should_implement_trait` because this is a specific
+    /// lattice join operation for occurrence analysis, not general-purpose addition.
     #[allow(clippy::should_implement_trait)]
     pub fn add(self, other: Occ) -> Occ {
         match (self, other) {

--- a/tidepool-optimize/src/occ.rs
+++ b/tidepool-optimize/src/occ.rs
@@ -15,15 +15,16 @@ pub enum Occ {
 }
 
 impl Occ {
-    /// Add two occurrence counts.
+    /// Combine two occurrence counts using saturated addition.
     ///
-    /// This is a lattice join operation where:
-    /// - `Dead` is the identity element.
+    /// This is a domain-specific, capped addition for occurrence analysis:
+    /// - `Dead` is the identity element (`Dead + x = x`).
     /// - `Once + Once = Many`.
-    /// - `Many` is the top element (anything + `Many` = `Many`).
+    /// - `Many` is the saturation point (`x + Many = Many` and `Many + x = Many`).
     ///
-    /// We suppress `clippy::should_implement_trait` because this is a specific
-    /// lattice join operation for occurrence analysis, not general-purpose addition.
+    /// We suppress `clippy::should_implement_trait` because this is a
+    /// domain-specific saturated addition for occurrence analysis, not
+    /// general-purpose numeric addition.
     #[allow(clippy::should_implement_trait)]
     pub fn add(self, other: Occ) -> Occ {
         match (self, other) {

--- a/tidepool-optimize/src/partial.rs
+++ b/tidepool-optimize/src/partial.rs
@@ -87,15 +87,19 @@ fn partial_eval_at(
                 tag: *tag,
                 fields: fi,
             });
-            let mut known_fields = Vec::new();
-            for v in fv {
-                if let PartialValue::Known(k) = v {
-                    known_fields.push(k);
-                } else {
-                    return (ni, PartialValue::Unknown);
-                }
+            let known_fields = fv
+                .into_iter()
+                .map(|v| match v {
+                    PartialValue::Known(k) => Some(k),
+                    _ => None,
+                })
+                .collect::<Option<Vec<_>>>();
+
+            if let Some(kf) = known_fields {
+                (ni, PartialValue::Known(KnownValue::Con(*tag, kf)))
+            } else {
+                (ni, PartialValue::Unknown)
             }
-            (ni, PartialValue::Known(KnownValue::Con(*tag, known_fields)))
         }
         CoreFrame::LetNonRec { binder, rhs, body } => {
             let (rhs_i, rhs_v) = partial_eval_at(expr, *rhs, env, new_nodes);

--- a/tidepool-repr/src/builder.rs
+++ b/tidepool-repr/src/builder.rs
@@ -40,9 +40,10 @@ impl TreeBuilder {
     /// Returns the offset of the first added node.
     pub fn push_tree(&mut self, other: TreeBuilder) -> usize {
         let offset = self.nodes.len();
-        for node in other.nodes {
-            self.nodes.push(node.map_layer(|idx| idx + offset));
-        }
+        self.nodes
+            .extend(other.nodes.into_iter().map(|node| {
+                node.map_layer(|idx| idx + offset)
+            }));
         offset
     }
 

--- a/tidepool-repr/src/datacon_table.rs
+++ b/tidepool-repr/src/datacon_table.rs
@@ -67,11 +67,9 @@ impl DataConTable {
     /// since the result would be ambiguous. Use `get_by_qualified_name`,
     /// `get_by_name_arity`, or `get_companion` instead.
     pub fn get_by_name(&self, name: &str) -> Option<DataConId> {
-        match self.by_name.get(name) {
-            Some(vec) if vec.len() > 1 => None,
-            Some(vec) => vec.last().copied(),
-            None => None,
-        }
+        self.by_name
+            .get(name)
+            .and_then(|vec| (vec.len() == 1).then(|| vec[0]))
     }
 
     /// Look up by name AND expected arity, scanning all entries with this name.

--- a/tidepool-repr/src/free_vars.rs
+++ b/tidepool-repr/src/free_vars.rs
@@ -38,11 +38,12 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
         }
         CoreFrame::LetRec { bindings, body } => {
             let bound: HashSet<VarId> = bindings.iter().map(|(v, _)| *v).collect();
-            let mut s = HashSet::new();
-            for (_, rhs) in bindings {
-                let rhs_fvs = free_vars_at(tree, *rhs);
-                s.extend(rhs_fvs.difference(&bound));
-            }
+            let mut s: HashSet<VarId> = bindings
+                .iter()
+                .flat_map(|(_, rhs)| free_vars_at(tree, *rhs))
+                .filter(|v| !bound.contains(v))
+                .collect();
+
             let body_fvs = free_vars_at(tree, *body);
             s.extend(body_fvs.difference(&bound));
             s
@@ -64,11 +65,7 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
             s
         }
         CoreFrame::Con { fields, .. } => {
-            let mut s = HashSet::new();
-            for f in fields {
-                s.extend(free_vars_at(tree, *f));
-            }
-            s
+            fields.iter().flat_map(|f| free_vars_at(tree, *f)).collect()
         }
         CoreFrame::Join {
             label: _,
@@ -88,18 +85,10 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
             s
         }
         CoreFrame::Jump { args, .. } => {
-            let mut s = HashSet::new();
-            for a in args {
-                s.extend(free_vars_at(tree, *a));
-            }
-            s
+            args.iter().flat_map(|a| free_vars_at(tree, *a)).collect()
         }
         CoreFrame::PrimOp { args, .. } => {
-            let mut s = HashSet::new();
-            for a in args {
-                s.extend(free_vars_at(tree, *a));
-            }
-            s
+            args.iter().flat_map(|a| free_vars_at(tree, *a)).collect()
         }
     }
 }


### PR DESCRIPTION
This PR performs a series of idiomatic Rust cleanups in `tidepool-repr` and `tidepool-optimize`.

Updates since initial filing:
- Corrected `Occ::add` documentation to describe it as saturated addition rather than a lattice join, as requested in review.

Initial changes:
- **tidepool-repr/src/free_vars.rs**: Converted manual `for` loops in `LetRec`, `Con`, `Jump`, and `PrimOp` cases to iterator chains using `flat_map`/`collect`.
- **tidepool-repr/src/builder.rs**: Refactored `push_tree` to use `self.nodes.extend(other.nodes.into_iter().map(...))`.
- **tidepool-repr/src/datacon_table.rs**: Simplified `get_by_name` using `and_then` and `then`.
- **tidepool-optimize/src/occ.rs**: Added documentation to `Occ::add` explaining its saturated addition semantics and why the clippy suppression is kept.
- **tidepool-optimize/src/partial.rs**: Refactored the `Con` arm in `partial_eval_at` to use iterator `collect` into an `Option<Vec<_>>`.

All tests in the workspace are passing. No logic or behavior was changed.