### PR TITLE
refactor: implement sealed trait pattern for bridge traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
  "ciborium",
  "proptest",
  "serial_test",
+ "thiserror 2.0.18",
  "tidepool-testing",
 ]
 
@@ -3605,7 +3606,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rustyline",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tidepool-bridge",
  "tidepool-bridge-derive",
  "tidepool-codegen",

--- a/tidepool-bridge-derive/src/codegen.rs
+++ b/tidepool-bridge-derive/src/codegen.rs
@@ -116,6 +116,8 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
+        impl #impl_generics tidepool_bridge::sealed::FromCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
                 match value {
@@ -185,6 +187,8 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
+        impl #impl_generics tidepool_bridge::sealed::ToCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
                 match self {
@@ -228,6 +232,8 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
+        impl #impl_generics tidepool_bridge::sealed::FromCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
                 match value {
@@ -296,6 +302,8 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
+        impl #impl_generics tidepool_bridge::sealed::ToCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
                 let #destructure = self;

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -1,5 +1,5 @@
 use crate::error::BridgeError;
-use crate::traits::{FromCore, ToCore};
+use crate::traits::{sealed::{FromCoreSealed, ToCoreSealed}, FromCore, ToCore};
 use std::sync::{Arc, Mutex};
 use tidepool_eval::Value;
 use tidepool_repr::{DataConId, DataConTable, Literal};
@@ -28,6 +28,9 @@ fn type_mismatch(expected: &str, got: &Value) -> BridgeError {
         got: got_str,
     }
 }
+
+impl<T> FromCoreSealed for std::marker::PhantomData<T> {}
+impl<T> ToCoreSealed for std::marker::PhantomData<T> {}
 
 impl<T> FromCore for std::marker::PhantomData<T> {
     fn from_value(value: &Value, _table: &DataConTable) -> Result<Self, BridgeError> {
@@ -61,6 +64,9 @@ impl<T> ToCore for std::marker::PhantomData<T> {
 // Box
 
 // Value identity — pass through without conversion.
+impl FromCoreSealed for Value {}
+impl ToCoreSealed for Value {}
+
 impl ToCore for Value {
     fn to_value(&self, _table: &DataConTable) -> Result<Value, BridgeError> {
         Ok(self.clone())
@@ -72,6 +78,9 @@ impl FromCore for Value {
         Ok(value.clone())
     }
 }
+
+impl<T> FromCoreSealed for Box<T> {}
+impl<T> ToCoreSealed for Box<T> {}
 
 impl<T: FromCore> FromCore for Box<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -86,6 +95,9 @@ impl<T: ToCore> ToCore for Box<T> {
 }
 
 // Unit
+
+impl FromCoreSealed for () {}
+impl ToCoreSealed for () {}
 
 impl ToCore for () {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
@@ -109,6 +121,9 @@ impl FromCore for () {
 
 /// Bridges Rust `i64` to Haskell `Int#` literal.
 /// Also transparently unwraps `I#(n)` (boxed Int).
+impl FromCoreSealed for i64 {}
+impl ToCoreSealed for i64 {}
+
 impl FromCore for i64 {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -136,6 +151,9 @@ impl ToCore for i64 {
 
 /// Bridges Rust `u64` to Haskell `Word#` literal.
 /// Also transparently unwraps `W#(n)` (boxed Word).
+impl FromCoreSealed for u64 {}
+impl ToCoreSealed for u64 {}
+
 impl FromCore for u64 {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -163,6 +181,9 @@ impl ToCore for u64 {
 
 /// Bridges Rust `f64` to Haskell `Double#` literal.
 /// Also transparently unwraps `D#(n)` (boxed Double).
+impl FromCoreSealed for f64 {}
+impl ToCoreSealed for f64 {}
+
 impl FromCore for f64 {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -193,6 +214,9 @@ impl ToCore for f64 {
 
 /// Bridges Rust `i32` to Haskell `Int#` literal.
 /// Returns error on overflow/underflow.
+impl FromCoreSealed for i32 {}
+impl ToCoreSealed for i32 {}
+
 impl FromCore for i32 {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         let n = i64::from_value(value, table)?;
@@ -213,6 +237,9 @@ impl ToCore for i32 {
 }
 
 /// Bridges Rust `bool` to Haskell `Bool` (True/False constructors).
+impl FromCoreSealed for bool {}
+impl ToCoreSealed for bool {}
+
 impl FromCore for bool {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -264,6 +291,9 @@ impl ToCore for bool {
 }
 
 /// Also transparently unwraps `C#(c)` (boxed Char).
+impl FromCoreSealed for char {}
+impl ToCoreSealed for char {}
+
 impl FromCore for char {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -288,6 +318,9 @@ impl ToCore for char {
         Ok(Value::Con(id, vec![Value::Lit(Literal::LitChar(*self))]))
     }
 }
+
+impl FromCoreSealed for String {}
+impl ToCoreSealed for String {}
 
 impl FromCore for String {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -405,6 +438,9 @@ impl ToCore for String {
 
 // Containers
 
+impl<T> FromCoreSealed for Option<T> {}
+impl<T> ToCoreSealed for Option<T> {}
+
 impl<T: FromCore> FromCore for Option<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -463,6 +499,9 @@ impl<T: ToCore> ToCore for Option<T> {
         }
     }
 }
+
+impl<T> FromCoreSealed for Vec<T> {}
+impl<T> ToCoreSealed for Vec<T> {}
 
 impl<T: FromCore> FromCore for Vec<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -529,6 +568,9 @@ impl<T: ToCore> ToCore for Vec<T> {
     }
 }
 
+impl<T, E> FromCoreSealed for Result<T, E> {}
+impl<T, E> ToCoreSealed for Result<T, E> {}
+
 impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -594,6 +636,9 @@ impl<T: ToCore, E: ToCore> ToCore for Result<T, E> {
 
 // Tuples
 
+impl<A, B> FromCoreSealed for (A, B) {}
+impl<A, B> ToCoreSealed for (A, B) {}
+
 impl<A: FromCore, B: FromCore> FromCore for (A, B) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -634,6 +679,9 @@ impl<A: ToCore, B: ToCore> ToCore for (A, B) {
         ))
     }
 }
+
+impl<A, B, C> FromCoreSealed for (A, B, C) {}
+impl<A, B, C> ToCoreSealed for (A, B, C) {}
 
 impl<A: FromCore, B: FromCore, C: FromCore> FromCore for (A, B, C) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {

--- a/tidepool-bridge/src/json.rs
+++ b/tidepool-bridge/src/json.rs
@@ -8,7 +8,7 @@
 //! represented as balanced binary trees of (Key, Value) pairs.
 
 use crate::error::BridgeError;
-use crate::traits::ToCore;
+use crate::traits::{sealed::ToCoreSealed, ToCore};
 use tidepool_eval::Value;
 use tidepool_repr::{DataConTable, Literal};
 
@@ -17,6 +17,8 @@ use tidepool_repr::{DataConTable, Literal};
 ///
 /// The resulting Core value can be passed to Haskell code that expects
 /// `Value` (the aeson-compatible type) and accessed via lens combinators.
+impl ToCoreSealed for serde_json::Value {}
+
 impl ToCore for serde_json::Value {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
         // Use get_by_name_arity to disambiguate aeson Value constructors from

--- a/tidepool-bridge/src/traits.rs
+++ b/tidepool-bridge/src/traits.rs
@@ -2,11 +2,18 @@ use crate::error::BridgeError;
 use tidepool_eval::Value;
 use tidepool_repr::DataConTable;
 
+/// Implementation detail for sealing traits.
+#[doc(hidden)]
+pub mod sealed {
+    pub trait FromCoreSealed {}
+    pub trait ToCoreSealed {}
+}
+
 /// Convert a Core Value (from evaluation) to a Rust type.
 ///
 /// This trait is used to extract native Rust values from evaluated Core expressions.
 /// Implementations should handle potential type mismatches and arity errors.
-pub trait FromCore: Sized {
+pub trait FromCore: Sized + sealed::FromCoreSealed {
     /// Convert a Value to this type using the provided DataConTable for lookups.
     ///
     /// # Errors
@@ -21,7 +28,7 @@ pub trait FromCore: Sized {
 /// Convert a Rust type to a Core Value (for interpolation into CoreExpr or evaluation).
 ///
 /// This trait is used to inject Rust values into the Core evaluator.
-pub trait ToCore {
+pub trait ToCore: sealed::ToCoreSealed {
     /// Convert this type to a Value using the provided DataConTable for lookups.
     ///
     /// # Errors

--- a/tidepool-effect/src/machine.rs
+++ b/tidepool-effect/src/machine.rs
@@ -360,6 +360,7 @@ mod tests {
         use tidepool_bridge::FromCore;
 
         struct TestReq(i64);
+        impl tidepool_bridge::sealed::FromCoreSealed for TestReq {}
         impl FromCore for TestReq {
             fn from_value(
                 value: &Value,
@@ -432,6 +433,7 @@ mod tests {
         use tidepool_bridge::FromCore;
 
         struct TestReq(i64);
+        impl tidepool_bridge::sealed::FromCoreSealed for TestReq {}
         impl FromCore for TestReq {
             fn from_value(
                 value: &Value,


### PR DESCRIPTION
This PR implements the sealed trait pattern for `FromCore` and `ToCore` in `tidepool-bridge` to prevent downstream manual implementations.

### Changes
- Added `FromCoreSealed` and `ToCoreSealed` traits in a doc-hidden `sealed` module in `tidepool-bridge/src/traits.rs`.
- Made `FromCoreSealed` a supertrait of `FromCore` and `ToCoreSealed` a supertrait of `ToCore`.
- Updated `tidepool-bridge-derive` to generate the appropriate `Sealed` implementations for types deriving `FromCore` or `ToCore`.
- Added manual `Sealed` implementations for primitive types and containers in `tidepool-bridge/src/impls.rs` and `tidepool-bridge/src/json.rs`.
- Added manual `Sealed` implementations for test request types in `tidepool-effect/src/machine.rs`.
- Audited `tidepool-runtime` error types for `#[from]` attributes (already present and correct).

Separate sealed traits were used for `FromCore` and `ToCore` to avoid implementation conflicts when a type derives both.

Verified with `cargo test --workspace` and `cargo clippy`.