### PR TITLE
refactor: apply Rust idiom cleanups in tidepool-repr and tidepool-optimize

### DIFF
--- a/tidepool-optimize/src/occ.rs
+++ b/tidepool-optimize/src/occ.rs
@@ -16,6 +16,9 @@ pub enum Occ {
 
 impl Occ {
     /// Add two occurrence counts.
+    ///
+    /// This is a lattice join where Dead is the identity element,
+    /// and any combination of non-Dead values results in Many.
     #[allow(clippy::should_implement_trait)]
     pub fn add(self, other: Occ) -> Occ {
         match (self, other) {

--- a/tidepool-optimize/src/partial.rs
+++ b/tidepool-optimize/src/partial.rs
@@ -87,15 +87,19 @@ fn partial_eval_at(
                 tag: *tag,
                 fields: fi,
             });
-            let mut known_fields = Vec::new();
-            for v in fv {
-                if let PartialValue::Known(k) = v {
-                    known_fields.push(k);
-                } else {
-                    return (ni, PartialValue::Unknown);
-                }
+            let known_fields = fv
+                .into_iter()
+                .map(|v| match v {
+                    PartialValue::Known(k) => Some(k),
+                    _ => None,
+                })
+                .collect::<Option<Vec<_>>>();
+
+            if let Some(kf) = known_fields {
+                (ni, PartialValue::Known(KnownValue::Con(*tag, kf)))
+            } else {
+                (ni, PartialValue::Unknown)
             }
-            (ni, PartialValue::Known(KnownValue::Con(*tag, known_fields)))
         }
         CoreFrame::LetNonRec { binder, rhs, body } => {
             let (rhs_i, rhs_v) = partial_eval_at(expr, *rhs, env, new_nodes);

--- a/tidepool-repr/src/builder.rs
+++ b/tidepool-repr/src/builder.rs
@@ -40,9 +40,12 @@ impl TreeBuilder {
     /// Returns the offset of the first added node.
     pub fn push_tree(&mut self, other: TreeBuilder) -> usize {
         let offset = self.nodes.len();
-        for node in other.nodes {
-            self.nodes.push(node.map_layer(|idx| idx + offset));
-        }
+        self.nodes.extend(
+            other
+                .nodes
+                .into_iter()
+                .map(|node| node.map_layer(|idx| idx + offset)),
+        );
         offset
     }
 

--- a/tidepool-repr/src/datacon_table.rs
+++ b/tidepool-repr/src/datacon_table.rs
@@ -67,11 +67,9 @@ impl DataConTable {
     /// since the result would be ambiguous. Use `get_by_qualified_name`,
     /// `get_by_name_arity`, or `get_companion` instead.
     pub fn get_by_name(&self, name: &str) -> Option<DataConId> {
-        match self.by_name.get(name) {
-            Some(vec) if vec.len() > 1 => None,
-            Some(vec) => vec.last().copied(),
-            None => None,
-        }
+        self.by_name
+            .get(name)
+            .and_then(|vec| (vec.len() == 1).then(|| vec[0]))
     }
 
     /// Look up by name AND expected arity, scanning all entries with this name.

--- a/tidepool-repr/src/free_vars.rs
+++ b/tidepool-repr/src/free_vars.rs
@@ -38,14 +38,13 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
         }
         CoreFrame::LetRec { bindings, body } => {
             let bound: HashSet<VarId> = bindings.iter().map(|(v, _)| *v).collect();
-            let mut s: HashSet<VarId> = bindings
+            bindings
                 .iter()
-                .flat_map(|(_, rhs)| free_vars_at(tree, *rhs))
+                .map(|(_, rhs)| *rhs)
+                .chain(std::iter::once(*body))
+                .flat_map(|idx| free_vars_at(tree, idx))
                 .filter(|v| !bound.contains(v))
-                .collect();
-            let body_fvs = free_vars_at(tree, *body);
-            s.extend(body_fvs.difference(&bound));
-            s
+                .collect()
         }
         CoreFrame::Case {
             scrutinee,
@@ -53,14 +52,15 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
             alts,
         } => {
             let mut s = free_vars_at(tree, *scrutinee);
-            for alt in alts {
-                let mut alt_fvs = free_vars_at(tree, alt.body);
-                alt_fvs.remove(binder); // case binder
+            let alt_fvs = alts.iter().flat_map(|alt| {
+                let mut fvs = free_vars_at(tree, alt.body);
+                fvs.remove(binder);
                 for b in &alt.binders {
-                    alt_fvs.remove(b); // pattern binders
+                    fvs.remove(b);
                 }
-                s.extend(alt_fvs);
-            }
+                fvs
+            });
+            s.extend(alt_fvs);
             s
         }
         CoreFrame::Con { fields, .. } => {

--- a/tidepool-repr/src/free_vars.rs
+++ b/tidepool-repr/src/free_vars.rs
@@ -38,11 +38,11 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
         }
         CoreFrame::LetRec { bindings, body } => {
             let bound: HashSet<VarId> = bindings.iter().map(|(v, _)| *v).collect();
-            let mut s = HashSet::new();
-            for (_, rhs) in bindings {
-                let rhs_fvs = free_vars_at(tree, *rhs);
-                s.extend(rhs_fvs.difference(&bound));
-            }
+            let mut s: HashSet<VarId> = bindings
+                .iter()
+                .flat_map(|(_, rhs)| free_vars_at(tree, *rhs))
+                .filter(|v| !bound.contains(v))
+                .collect();
             let body_fvs = free_vars_at(tree, *body);
             s.extend(body_fvs.difference(&bound));
             s
@@ -64,11 +64,7 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
             s
         }
         CoreFrame::Con { fields, .. } => {
-            let mut s = HashSet::new();
-            for f in fields {
-                s.extend(free_vars_at(tree, *f));
-            }
-            s
+            fields.iter().flat_map(|f| free_vars_at(tree, *f)).collect()
         }
         CoreFrame::Join {
             label: _,
@@ -88,18 +84,10 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> HashSet<VarId> {
             s
         }
         CoreFrame::Jump { args, .. } => {
-            let mut s = HashSet::new();
-            for a in args {
-                s.extend(free_vars_at(tree, *a));
-            }
-            s
+            args.iter().flat_map(|a| free_vars_at(tree, *a)).collect()
         }
         CoreFrame::PrimOp { args, .. } => {
-            let mut s = HashSet::new();
-            for a in args {
-                s.extend(free_vars_at(tree, *a));
-            }
-            s
+            args.iter().flat_map(|a| free_vars_at(tree, *a)).collect()
         }
     }
 }


### PR DESCRIPTION
This PR applies several Rust idiom cleanups in `tidepool-repr` and `tidepool-optimize`:

1.  **`free_vars.rs`**: Converted manual `for` loops to `flat_map`/`collect` iterator chains for `LetRec`, `Con`, `Jump`, and `PrimOp`.
2.  **`builder.rs`**: Replaced a manual loop in `push_tree` with `self.nodes.extend` using a mapped iterator.
3.  **`datacon_table.rs`**: Simplified `get_by_name` using `and_then` and `then`.
4.  **`occ.rs`**: Added a doc comment to `Occ::add` explaining its lattice join behavior.
5.  **`partial.rs`**: Replaced a manual loop in the `Con` arm with a `map`/`collect` to `Option<Vec<_>>`.

All tests pass and `cargo clippy` is clean.