### PR TITLE
Refactor: implement sealed trait pattern for FromCore/ToCore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
  "ciborium",
  "proptest",
  "serial_test",
+ "thiserror 2.0.18",
  "tidepool-testing",
 ]
 
@@ -3605,7 +3606,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rustyline",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tidepool-bridge",
  "tidepool-bridge-derive",
  "tidepool-codegen",

--- a/tidepool-bridge-derive/src/codegen.rs
+++ b/tidepool-bridge-derive/src/codegen.rs
@@ -116,6 +116,8 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
+        impl #impl_generics tidepool_bridge::FromCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
                 match value {
@@ -185,6 +187,8 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
+        impl #impl_generics tidepool_bridge::ToCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
                 match self {
@@ -228,6 +232,8 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
+        impl #impl_generics tidepool_bridge::FromCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
                 match value {
@@ -296,6 +302,8 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
+        impl #impl_generics tidepool_bridge::ToCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
                 let #destructure = self;

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -29,6 +29,9 @@ fn type_mismatch(expected: &str, got: &Value) -> BridgeError {
     }
 }
 
+impl<T> crate::traits::FromCoreSealed for std::marker::PhantomData<T> {}
+impl<T> crate::traits::ToCoreSealed for std::marker::PhantomData<T> {}
+
 impl<T> FromCore for std::marker::PhantomData<T> {
     fn from_value(value: &Value, _table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -60,6 +63,9 @@ impl<T> ToCore for std::marker::PhantomData<T> {
 
 // Box
 
+impl crate::traits::FromCoreSealed for Value {}
+impl crate::traits::ToCoreSealed for Value {}
+
 // Value identity — pass through without conversion.
 impl ToCore for Value {
     fn to_value(&self, _table: &DataConTable) -> Result<Value, BridgeError> {
@@ -72,6 +78,9 @@ impl FromCore for Value {
         Ok(value.clone())
     }
 }
+
+impl<T> crate::traits::FromCoreSealed for Box<T> {}
+impl<T> crate::traits::ToCoreSealed for Box<T> {}
 
 impl<T: FromCore> FromCore for Box<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -86,6 +95,9 @@ impl<T: ToCore> ToCore for Box<T> {
 }
 
 // Unit
+
+impl crate::traits::FromCoreSealed for () {}
+impl crate::traits::ToCoreSealed for () {}
 
 impl ToCore for () {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
@@ -106,6 +118,9 @@ impl FromCore for () {
 }
 
 // Primitives
+
+impl crate::traits::FromCoreSealed for i64 {}
+impl crate::traits::ToCoreSealed for i64 {}
 
 /// Bridges Rust `i64` to Haskell `Int#` literal.
 /// Also transparently unwraps `I#(n)` (boxed Int).
@@ -134,6 +149,9 @@ impl ToCore for i64 {
     }
 }
 
+impl crate::traits::FromCoreSealed for u64 {}
+impl crate::traits::ToCoreSealed for u64 {}
+
 /// Bridges Rust `u64` to Haskell `Word#` literal.
 /// Also transparently unwraps `W#(n)` (boxed Word).
 impl FromCore for u64 {
@@ -160,6 +178,9 @@ impl ToCore for u64 {
         Ok(Value::Con(id, vec![Value::Lit(Literal::LitWord(*self))]))
     }
 }
+
+impl crate::traits::FromCoreSealed for f64 {}
+impl crate::traits::ToCoreSealed for f64 {}
 
 /// Bridges Rust `f64` to Haskell `Double#` literal.
 /// Also transparently unwraps `D#(n)` (boxed Double).
@@ -191,6 +212,9 @@ impl ToCore for f64 {
     }
 }
 
+impl crate::traits::FromCoreSealed for i32 {}
+impl crate::traits::ToCoreSealed for i32 {}
+
 /// Bridges Rust `i32` to Haskell `Int#` literal.
 /// Returns error on overflow/underflow.
 impl FromCore for i32 {
@@ -211,6 +235,9 @@ impl ToCore for i32 {
         (*self as i64).to_value(table)
     }
 }
+
+impl crate::traits::FromCoreSealed for bool {}
+impl crate::traits::ToCoreSealed for bool {}
 
 /// Bridges Rust `bool` to Haskell `Bool` (True/False constructors).
 impl FromCore for bool {
@@ -263,6 +290,9 @@ impl ToCore for bool {
     }
 }
 
+impl crate::traits::FromCoreSealed for char {}
+impl crate::traits::ToCoreSealed for char {}
+
 /// Also transparently unwraps `C#(c)` (boxed Char).
 impl FromCore for char {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -288,6 +318,9 @@ impl ToCore for char {
         Ok(Value::Con(id, vec![Value::Lit(Literal::LitChar(*self))]))
     }
 }
+
+impl crate::traits::FromCoreSealed for String {}
+impl crate::traits::ToCoreSealed for String {}
 
 impl FromCore for String {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -405,6 +438,9 @@ impl ToCore for String {
 
 // Containers
 
+impl<T> crate::traits::FromCoreSealed for Option<T> {}
+impl<T> crate::traits::ToCoreSealed for Option<T> {}
+
 impl<T: FromCore> FromCore for Option<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -463,6 +499,9 @@ impl<T: ToCore> ToCore for Option<T> {
         }
     }
 }
+
+impl<T> crate::traits::FromCoreSealed for Vec<T> {}
+impl<T> crate::traits::ToCoreSealed for Vec<T> {}
 
 impl<T: FromCore> FromCore for Vec<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -529,6 +568,9 @@ impl<T: ToCore> ToCore for Vec<T> {
     }
 }
 
+impl<T, E> crate::traits::FromCoreSealed for Result<T, E> {}
+impl<T, E> crate::traits::ToCoreSealed for Result<T, E> {}
+
 impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -594,6 +636,9 @@ impl<T: ToCore, E: ToCore> ToCore for Result<T, E> {
 
 // Tuples
 
+impl<A, B> crate::traits::FromCoreSealed for (A, B) {}
+impl<A, B> crate::traits::ToCoreSealed for (A, B) {}
+
 impl<A: FromCore, B: FromCore> FromCore for (A, B) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -634,6 +679,9 @@ impl<A: ToCore, B: ToCore> ToCore for (A, B) {
         ))
     }
 }
+
+impl<A, B, C> crate::traits::FromCoreSealed for (A, B, C) {}
+impl<A, B, C> crate::traits::ToCoreSealed for (A, B, C) {}
 
 impl<A: FromCore, B: FromCore, C: FromCore> FromCore for (A, B, C) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {

--- a/tidepool-bridge/src/json.rs
+++ b/tidepool-bridge/src/json.rs
@@ -8,9 +8,11 @@
 //! represented as balanced binary trees of (Key, Value) pairs.
 
 use crate::error::BridgeError;
-use crate::traits::ToCore;
+use crate::traits::{ToCore, ToCoreSealed};
 use tidepool_eval::Value;
 use tidepool_repr::{DataConTable, Literal};
+
+impl ToCoreSealed for serde_json::Value {}
 
 /// Convert a `serde_json::Value` to a Tidepool Core `Value` matching the
 /// vendored `Tidepool.Aeson.Value` Haskell type.

--- a/tidepool-bridge/src/traits.rs
+++ b/tidepool-bridge/src/traits.rs
@@ -2,11 +2,16 @@ use crate::error::BridgeError;
 use tidepool_eval::Value;
 use tidepool_repr::DataConTable;
 
+mod sealed {
+    pub trait FromCoreSealed {}
+    pub trait ToCoreSealed {}
+}
+
 /// Convert a Core Value (from evaluation) to a Rust type.
 ///
 /// This trait is used to extract native Rust values from evaluated Core expressions.
 /// Implementations should handle potential type mismatches and arity errors.
-pub trait FromCore: Sized {
+pub trait FromCore: Sized + sealed::FromCoreSealed {
     /// Convert a Value to this type using the provided DataConTable for lookups.
     ///
     /// # Errors
@@ -21,7 +26,7 @@ pub trait FromCore: Sized {
 /// Convert a Rust type to a Core Value (for interpolation into CoreExpr or evaluation).
 ///
 /// This trait is used to inject Rust values into the Core evaluator.
-pub trait ToCore {
+pub trait ToCore: sealed::ToCoreSealed {
     /// Convert this type to a Value using the provided DataConTable for lookups.
     ///
     /// # Errors
@@ -29,3 +34,7 @@ pub trait ToCore {
     /// Returns `BridgeError::UnknownDataConName` if a required constructor is missing from the table.
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError>;
 }
+
+// Re-export Sealed traits for use in the derive macro, but keep them in a private-in-public path
+#[doc(hidden)]
+pub use sealed::{FromCoreSealed, ToCoreSealed};

--- a/tidepool-effect/src/machine.rs
+++ b/tidepool-effect/src/machine.rs
@@ -360,6 +360,7 @@ mod tests {
         use tidepool_bridge::FromCore;
 
         struct TestReq(i64);
+        impl tidepool_bridge::FromCoreSealed for TestReq {}
         impl FromCore for TestReq {
             fn from_value(
                 value: &Value,
@@ -432,6 +433,7 @@ mod tests {
         use tidepool_bridge::FromCore;
 
         struct TestReq(i64);
+        impl tidepool_bridge::FromCoreSealed for TestReq {}
         impl FromCore for TestReq {
             fn from_value(
                 value: &Value,


### PR DESCRIPTION
This PR implements the sealed trait pattern for `FromCore` and `ToCore` traits in the `tidepool-bridge` crate to prevent downstream implementations.

### Changes:
- Added `FromCoreSealed` and `ToCoreSealed` traits in a private `sealed` module within `tidepool-bridge/src/traits.rs`.
- Made `FromCore` and `ToCore` supertraits of their respective sealed traits.
- Updated all manual implementations in `tidepool-bridge` and `tidepool-effect` (tests) to implement the sealed traits.
- Updated the `tidepool-bridge-derive` proc-macro to automatically generate the sealed trait implementations.
- Performed an audit of `tidepool-runtime` error types; confirmed that `CompileError` and `RuntimeError` already correctly use `#[from]` for unambiguous downstream errors.

Using two separate sealed traits avoids conflicting implementations when both `FromCore` and `ToCore` are derived on the same type.

Verified with `cargo test --workspace`.