### PR TITLE
refactor: tidepool-codegen cleanup (visibility & named structs)

### DIFF
--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -240,14 +240,14 @@ fn perform_gc(fp: usize, vmctx: *mut VMContext) {
 }
 
 /// Set a hook to be called during gc_trigger with the collected roots.
-pub fn set_gc_test_hook(hook: GcHook) {
+pub(crate) fn set_gc_test_hook(hook: GcHook) {
     HOOK.with(|hook_cell| {
         *hook_cell.borrow_mut() = Some(hook);
     });
 }
 
 /// Clear the GC test hook.
-pub fn clear_gc_test_hook() {
+pub(crate) fn clear_gc_test_hook() {
     HOOK.with(|hook_cell| {
         *hook_cell.borrow_mut() = None;
     });
@@ -272,7 +272,7 @@ pub fn clear_stack_map_registry() {
 }
 
 /// Get collected roots from the last gc_trigger call.
-pub fn last_gc_roots() -> Vec<StackRoot> {
+pub(crate) fn last_gc_roots() -> Vec<StackRoot> {
     LAST_ROOTS.with(|roots_cell| roots_cell.borrow().clone())
 }
 

--- a/tidepool-codegen/src/pipeline.rs
+++ b/tidepool-codegen/src/pipeline.rs
@@ -7,7 +7,7 @@ use cranelift_module::{FuncId, Linkage, Module};
 use std::sync::Arc;
 
 use crate::debug::LambdaRegistry;
-use crate::stack_map::{RawStackMap, StackMapRegistry};
+use crate::stack_map::{RawStackMap, RawStackMapEntry, StackMapRegistry};
 
 /// Errors from the Cranelift compilation pipeline.
 #[derive(Debug, thiserror::Error)]
@@ -151,8 +151,15 @@ impl CodegenPipeline {
             .user_stack_maps()
             .iter()
             .map(|(offset, span, usm)| {
-                let entries: Vec<_> = usm.entries().collect();
-                (*offset, *span, entries)
+                let entries: Vec<_> = usm
+                    .entries()
+                    .map(|(ty, offset)| RawStackMapEntry { ty, offset })
+                    .collect();
+                RawStackMap {
+                    code_offset: *offset,
+                    frame_size: *span,
+                    entries,
+                }
             })
             .collect();
 

--- a/tidepool-codegen/src/stack_map.rs
+++ b/tidepool-codegen/src/stack_map.rs
@@ -10,8 +10,18 @@ pub struct StackMapInfo {
     pub offsets: Vec<u32>,
 }
 
-pub type RawStackMapEntry = (cranelift_codegen::ir::types::Type, u32);
-pub type RawStackMap = (u32, u32, Vec<RawStackMapEntry>);
+#[derive(Debug, Clone)]
+pub struct RawStackMapEntry {
+    pub ty: cranelift_codegen::ir::types::Type,
+    pub offset: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct RawStackMap {
+    pub code_offset: u32,
+    pub frame_size: u32,
+    pub entries: Vec<RawStackMapEntry>,
+}
 
 /// Maps absolute return addresses to stack map info.
 ///
@@ -44,13 +54,13 @@ impl StackMapRegistry {
     pub fn register(&mut self, base_ptr: usize, size: u32, raw_entries: &[RawStackMap]) {
         self.ranges.push((base_ptr, base_ptr + size as usize));
 
-        for (code_offset, frame_size, slot_entries) in raw_entries {
-            let return_addr = base_ptr + *code_offset as usize;
-            let offsets: Vec<u32> = slot_entries.iter().map(|(_, offset)| *offset).collect();
+        for entry in raw_entries {
+            let return_addr = base_ptr + entry.code_offset as usize;
+            let offsets: Vec<u32> = entry.entries.iter().map(|e| e.offset).collect();
             self.entries.insert(
                 return_addr,
                 StackMapInfo {
-                    frame_size: *frame_size,
+                    frame_size: entry.frame_size,
                     offsets,
                 },
             );


### PR DESCRIPTION
This PR performs Rust idiom cleanup in the `tidepool-codegen` crate.

### Changes:
1.  **Visibility Reduction in `host_fns.rs`**:
    *   Functions `set_gc_test_hook`, `clear_gc_test_hook`, and `last_gc_roots` are changed from `pub` to `pub(crate)` as they are not used outside of the crate's internal modules.
    *   Note: Other test-related functions remain `pub` because they are heavily used in the integration tests located in `tidepool-codegen/tests/`.
2.  **Named Structs in `stack_map.rs`**:
    *   Replaced `RawStackMapEntry` (tuple alias) with a named struct with `ty` and `offset` fields.
    *   Replaced `RawStackMap` (tuple alias) with a named struct with `code_offset`, `frame_size`, and `entries` fields.
    *   Updated `StackMapRegistry::register` and `CodegenPipeline::define_function` to use the new named fields instead of tuple indices.

### Verification:
*   Ran `cargo test -p tidepool-codegen` and confirmed all 72 unit tests and hundreds of integration tests (e.g., `emit_expr`, `gc_frame_walker`) pass.
*   Ran `cargo clippy -p tidepool-codegen`.
