### PR TITLE
refactor: bundle emission parameters into EmitArgs struct

### DIFF
--- a/tidepool-codegen/src/emit/case.rs
+++ b/tidepool-codegen/src/emit/case.rs
@@ -8,11 +8,8 @@ use cranelift_module::{Linkage, Module};
 use tidepool_repr::{Alt, AltCon, Literal, VarId};
 
 /// Emit Case dispatch. The scrutinee has already been evaluated (stack-safe).
-#[allow(clippy::too_many_arguments)]
 pub fn emit_case(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     scrut: SsaVal,
     binder: &VarId,
     alts: &[Alt<usize>],
@@ -24,7 +21,7 @@ pub fn emit_case(
     // 2. Bind case binder (save old value for restore)
     // NOTE: EnvGuard cannot be used here because it would borrow ctx.env mutably,
     // preventing the use of ctx in subsequent emit_* calls.
-    let old_case_binder = ctx.env.insert(*binder, scrut);
+    let old_case_binder = args.ctx.env.insert(*binder, scrut);
 
     // 3. Classify alts
     let data_alts: Vec<_> = alts
@@ -38,15 +35,17 @@ pub fn emit_case(
     let default_alt = alts.iter().find(|alt| matches!(alt.con, AltCon::Default));
 
     // 4. Create merge block
-    let merge_block = builder.create_block();
-    builder.append_block_param(merge_block, types::I64);
+    let merge_block = args.builder.create_block();
+    args.builder.append_block_param(merge_block, types::I64);
 
     // 5. Dispatch
     if !data_alts.is_empty() {
         emit_data_dispatch(
-            ctx,
-            sess,
-            builder,
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
             scrut_ptr,
             &data_alts,
             default_alt,
@@ -55,9 +54,11 @@ pub fn emit_case(
         )?;
     } else if !lit_alts.is_empty() {
         emit_lit_dispatch(
-            ctx,
-            sess,
-            builder,
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
             scrut,
             &lit_alts,
             default_alt,
@@ -66,36 +67,47 @@ pub fn emit_case(
         )?;
     } else if let Some(alt) = default_alt {
         // Default only
-        let result = ctx.emit_node(sess, builder, alt.body, tail)?;
-        let result_ptr = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, result);
-        builder
+        let result = EmitContext::emit_node(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            alt.body,
+            tail,
+        )?;
+        let result_ptr = ensure_heap_ptr(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            result,
+        );
+        args.builder
             .ins()
             .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
         // No alts? Call runtime_case_trap to handle pending errors gracefully.
-        emit_case_trap(sess, builder, scrut_ptr, &[], merge_block)?;
+        emit_case_trap(args.sess, args.builder, scrut_ptr, &[], merge_block)?;
     }
 
     // Seal merge block
-    builder.seal_block(merge_block);
+    args.builder.seal_block(merge_block);
 
     // Switch to merge block
-    builder.switch_to_block(merge_block);
-    let result = builder.block_params(merge_block)[0];
-    builder.declare_value_needs_stack_map(result);
-    ctx.declare_env(builder);
+    args.builder.switch_to_block(merge_block);
+    let result = args.builder.block_params(merge_block)[0];
+    args.builder.declare_value_needs_stack_map(result);
+    args.ctx.declare_env(args.builder);
 
     // 6. Restore case binder
-    ctx.env.restore(*binder, old_case_binder);
+    args.ctx.env.restore(*binder, old_case_binder);
 
     Ok(SsaVal::HeapPtr(result))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn emit_data_dispatch(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     initial_scrut_ptr: Value,
     data_alts: &[&Alt<usize>],
     default_alt: Option<&Alt<usize>>,
@@ -103,16 +115,20 @@ fn emit_data_dispatch(
     tail: TailCtx,
 ) -> Result<(), EmitError> {
     // 1. Force if needed (tag < 2: Closure or Thunk)
-    let tag = builder
+    let tag = args
+        .builder
         .ins()
         .load(types::I8, MemFlags::trusted(), initial_scrut_ptr, 0);
-    let needs_force = builder.ins().icmp_imm(IntCC::UnsignedLessThan, tag, 2);
+    let needs_force = args
+        .builder
+        .ins()
+        .icmp_imm(IntCC::UnsignedLessThan, tag, 2);
 
-    let force_block = builder.create_block();
-    let dispatch_block = builder.create_block();
-    builder.append_block_param(dispatch_block, types::I64);
+    let force_block = args.builder.create_block();
+    let dispatch_block = args.builder.create_block();
+    args.builder.append_block_param(dispatch_block, types::I64);
 
-    builder.ins().brif(
+    args.builder.ins().brif(
         needs_force,
         force_block,
         &[],
@@ -121,42 +137,46 @@ fn emit_data_dispatch(
     );
 
     // Force block: call host_fns::heap_force
-    builder.switch_to_block(force_block);
-    builder.seal_block(force_block);
+    args.builder.switch_to_block(force_block);
+    args.builder.seal_block(force_block);
 
-    let force_fn = sess
+    let force_fn = args
+        .sess
         .pipeline
         .module
         .declare_function("heap_force", Linkage::Import, &{
-            let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+            let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
             sig.params.push(AbiParam::new(types::I64)); // vmctx
             sig.params.push(AbiParam::new(types::I64)); // thunk
             sig.returns.push(AbiParam::new(types::I64)); // result
             sig
         })
         .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-    let force_ref = sess
+    let force_ref = args
+        .sess
         .pipeline
         .module
-        .declare_func_in_func(force_fn, builder.func);
+        .declare_func_in_func(force_fn, args.builder.func);
 
-    let call = builder
+    let call = args
+        .builder
         .ins()
-        .call(force_ref, &[sess.vmctx, initial_scrut_ptr]);
-    let force_result = builder.inst_results(call)[0];
-    builder.declare_value_needs_stack_map(force_result);
-    builder
+        .call(force_ref, &[args.sess.vmctx, initial_scrut_ptr]);
+    let force_result = args.builder.inst_results(call)[0];
+    args.builder.declare_value_needs_stack_map(force_result);
+    args.builder
         .ins()
         .jump(dispatch_block, &[BlockArg::Value(force_result)]);
 
     // Dispatch block: actual pattern matching starts here
-    builder.switch_to_block(dispatch_block);
-    builder.seal_block(dispatch_block);
-    let scrut_ptr = builder.block_params(dispatch_block)[0];
-    builder.declare_value_needs_stack_map(scrut_ptr);
+    args.builder.switch_to_block(dispatch_block);
+    args.builder.seal_block(dispatch_block);
+    let scrut_ptr = args.builder.block_params(dispatch_block)[0];
+    args.builder.declare_value_needs_stack_map(scrut_ptr);
 
     // Load con_tag as u64 from offset 8
-    let con_tag = builder
+    let con_tag = args
+        .builder
         .ins()
         .load(types::I64, MemFlags::trusted(), scrut_ptr, CON_TAG_OFFSET);
 
@@ -167,21 +187,21 @@ fn emit_data_dispatch(
             continue;
         };
 
-        let alt_block = builder.create_block();
-        let next_check_block = builder.create_block();
+        let alt_block = args.builder.create_block();
+        let next_check_block = args.builder.create_block();
 
-        let tag_val = builder.ins().iconst(types::I64, tag.0 as i64);
-        let eq = builder.ins().icmp(IntCC::Equal, con_tag, tag_val);
-        builder
+        let tag_val = args.builder.ins().iconst(types::I64, tag.0 as i64);
+        let eq = args.builder.ins().icmp(IntCC::Equal, con_tag, tag_val);
+        args.builder
             .ins()
             .brif(eq, alt_block, &[], next_check_block, &[]);
 
         // Emit alt body
-        builder.switch_to_block(alt_block);
-        builder.seal_block(alt_block);
-        ctx.declare_env(builder);
+        args.builder.switch_to_block(alt_block);
+        args.builder.seal_block(alt_block);
+        args.ctx.declare_env(args.builder);
 
-        // Bind pattern variables — do NOT force thunked fields.
+        // Bind pattern variables \u2014 do NOT force thunked fields.
         // In Haskell, case alt binders are lazy. Thunked Con fields
         // remain as thunks until used in a strict context (case scrutiny,
         // primop args, etc.). Forcing here causes infinite loops for
@@ -190,9 +210,9 @@ fn emit_data_dispatch(
         // INVARIANT: All strict consumers must force thunked values before
         // reading heap layout. The forcing points are:
         //   - emit_lit_dispatch: force_thunk_ssaval on scrutinee
-        //   - emit_data_dispatch: tag < 2 check → heap_force on scrutinee
+        //   - emit_data_dispatch: tag < 2 check \u2192 heap_force on scrutinee
         //   - PrimOp collapse: force_thunk_ssaval on all args
-        //   - App collapse: tag check → heap_force on fun position
+        //   - App collapse: tag check \u2192 heap_force on fun position
         //   - unbox_int/unbox_double/unbox_float: defensive trap on TAG_THUNK
         // See force_thunk_ssaval in expr.rs.
         let mut scope = EnvScope::new();
@@ -200,38 +220,68 @@ fn emit_data_dispatch(
         // mutably, preventing the use of ctx in emit_node.
         for (i, &binder) in alt.binders.iter().enumerate() {
             let offset = CON_FIELDS_OFFSET + (8 * i as i32);
-            let field_val = builder
+            let field_val = args
+                .builder
                 .ins()
                 .load(types::I64, MemFlags::trusted(), scrut_ptr, offset);
-            builder.declare_value_needs_stack_map(field_val);
-            ctx.env
+            args.builder.declare_value_needs_stack_map(field_val);
+            args.ctx
+                .env
                 .insert_scoped(&mut scope, binder, SsaVal::HeapPtr(field_val));
         }
 
-        let result = ctx.emit_node(sess, builder, alt.body, tail)?;
-        let result_ptr = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, result);
-        builder
+        let result = EmitContext::emit_node(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            alt.body,
+            tail,
+        )?;
+        let result_ptr = ensure_heap_ptr(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            result,
+        );
+        args.builder
             .ins()
             .jump(merge_block, &[BlockArg::Value(result_ptr)]);
 
         // Restore pattern variable bindings
-        ctx.env.restore_scope(scope);
+        args.ctx.env.restore_scope(scope);
 
         // Continue to next check
-        builder.switch_to_block(next_check_block);
-        builder.seal_block(next_check_block);
+        args.builder.switch_to_block(next_check_block);
+        args.builder.seal_block(next_check_block);
     }
 
     // Default or trap
     if let Some(alt) = default_alt {
-        ctx.declare_env(builder);
-        let result = ctx.emit_node(sess, builder, alt.body, tail)?;
-        let result_ptr = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, result);
-        builder
+        args.ctx.declare_env(args.builder);
+        let result = EmitContext::emit_node(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            alt.body,
+            tail,
+        )?;
+        let result_ptr = ensure_heap_ptr(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            result,
+        );
+        args.builder
             .ins()
             .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
-        emit_case_trap(sess, builder, scrut_ptr, data_alts, merge_block)?;
+        emit_case_trap(args.sess, args.builder, scrut_ptr, data_alts, merge_block)?;
     }
 
     Ok(())
@@ -296,83 +346,81 @@ fn emit_case_trap(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn emit_lit_dispatch(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     scrut: SsaVal,
     lit_alts: &[&Alt<usize>],
     default_alt: Option<&Alt<usize>>,
     merge_block: ir::Block,
     tail: TailCtx,
 ) -> Result<(), EmitError> {
-    // Force thunked scrutinees: literal case dispatch is strict —
+    // Force thunked scrutinees: literal case dispatch is strict \u2014
     // ThunkCon fields extracted by data alt matching may still be thunks.
-    let scrut = force_thunk_ssaval(sess.pipeline, builder, sess.vmctx, scrut)?;
+    let scrut = force_thunk_ssaval(args.sess.pipeline, args.builder, args.sess.vmctx, scrut)?;
 
     // Unbox scrutinee: Raw values are already unboxed, HeapPtr needs LIT_VALUE_OFFSET load
     let scrut_value = match scrut {
         SsaVal::Raw(v, _) => v,
-        SsaVal::HeapPtr(ptr) => {
-            builder
-                .ins()
-                .load(types::I64, MemFlags::trusted(), ptr, LIT_VALUE_OFFSET)
-        }
+        SsaVal::HeapPtr(ptr) => args
+            .builder
+            .ins()
+            .load(types::I64, MemFlags::trusted(), ptr, LIT_VALUE_OFFSET),
     };
 
     for &alt in lit_alts {
-        let alt_block = builder.create_block();
-        let next_check_block = builder.create_block();
+        let alt_block = args.builder.create_block();
+        let next_check_block = args.builder.create_block();
 
         if let AltCon::LitAlt(lit) = &alt.con {
             match lit {
                 Literal::LitInt(n) => {
-                    let lit_val = builder.ins().iconst(types::I64, *n);
-                    let eq = builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
-                    builder
+                    let lit_val = args.builder.ins().iconst(types::I64, *n);
+                    let eq = args.builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
+                    args.builder
                         .ins()
                         .brif(eq, alt_block, &[], next_check_block, &[]);
                 }
                 Literal::LitWord(n) => {
-                    let lit_val = builder.ins().iconst(types::I64, *n as i64);
-                    let eq = builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
-                    builder
+                    let lit_val = args.builder.ins().iconst(types::I64, *n as i64);
+                    let eq = args.builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
+                    args.builder
                         .ins()
                         .brif(eq, alt_block, &[], next_check_block, &[]);
                 }
                 Literal::LitChar(c) => {
-                    let lit_val = builder.ins().iconst(types::I64, *c as i64);
-                    let eq = builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
-                    builder
+                    let lit_val = args.builder.ins().iconst(types::I64, *c as i64);
+                    let eq = args.builder.ins().icmp(IntCC::Equal, scrut_value, lit_val);
+                    args.builder
                         .ins()
                         .brif(eq, alt_block, &[], next_check_block, &[]);
                 }
                 Literal::LitFloat(bits) => {
-                    let scrut_f64 = builder.ins().bitcast(
+                    let scrut_f64 = args.builder.ins().bitcast(
                         types::F64,
                         MemFlags::new().with_endianness(ir::Endianness::Little),
                         scrut_value,
                     );
-                    let lit_val = builder.ins().f64const(f64::from_bits(*bits));
-                    let eq = builder
+                    let lit_val = args.builder.ins().f64const(f64::from_bits(*bits));
+                    let eq = args
+                        .builder
                         .ins()
                         .fcmp(ir::condcodes::FloatCC::Equal, scrut_f64, lit_val);
-                    builder
+                    args.builder
                         .ins()
                         .brif(eq, alt_block, &[], next_check_block, &[]);
                 }
                 Literal::LitDouble(bits) => {
-                    let scrut_f64 = builder.ins().bitcast(
+                    let scrut_f64 = args.builder.ins().bitcast(
                         types::F64,
                         MemFlags::new().with_endianness(ir::Endianness::Little),
                         scrut_value,
                     );
-                    let lit_val = builder.ins().f64const(f64::from_bits(*bits));
-                    let eq = builder
+                    let lit_val = args.builder.ins().f64const(f64::from_bits(*bits));
+                    let eq = args
+                        .builder
                         .ins()
                         .fcmp(ir::condcodes::FloatCC::Equal, scrut_f64, lit_val);
-                    builder
+                    args.builder
                         .ins()
                         .brif(eq, alt_block, &[], next_check_block, &[]);
                 }
@@ -383,32 +431,60 @@ fn emit_lit_dispatch(
         }
 
         // Emit alt body
-        builder.switch_to_block(alt_block);
-        builder.seal_block(alt_block);
-        ctx.declare_env(builder);
-        let result = ctx.emit_node(sess, builder, alt.body, tail)?;
-        let result_ptr = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, result);
-        builder
+        args.builder.switch_to_block(alt_block);
+        args.builder.seal_block(alt_block);
+        args.ctx.declare_env(args.builder);
+        let result = EmitContext::emit_node(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            alt.body,
+            tail,
+        )?;
+        let result_ptr = ensure_heap_ptr(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            result,
+        );
+        args.builder
             .ins()
             .jump(merge_block, &[BlockArg::Value(result_ptr)]);
 
         // Continue to next check
-        builder.switch_to_block(next_check_block);
-        builder.seal_block(next_check_block);
+        args.builder.switch_to_block(next_check_block);
+        args.builder.seal_block(next_check_block);
     }
 
     // Default or trap
     if let Some(alt) = default_alt {
-        ctx.declare_env(builder);
-        let result = ctx.emit_node(sess, builder, alt.body, tail)?;
-        let result_ptr = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, result);
-        builder
+        args.ctx.declare_env(args.builder);
+        let result = EmitContext::emit_node(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            alt.body,
+            tail,
+        )?;
+        let result_ptr = ensure_heap_ptr(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            result,
+        );
+        args.builder
             .ins()
             .jump(merge_block, &[BlockArg::Value(result_ptr)]);
     } else {
         // No alts matched.
         // We pass empty data_alts since these are lit alts.
-        emit_case_trap(sess, builder, scrut_value, &[], merge_block)?;
+        emit_case_trap(args.sess, args.builder, scrut_value, &[], merge_block)?;
     }
 
     Ok(())

--- a/tidepool-codegen/src/emit/expr.rs
+++ b/tidepool-codegen/src/emit/expr.rs
@@ -29,7 +29,7 @@ enum EmitFrame<A> {
     Lit(Literal),
     LitString(Vec<u8>),
 
-    // Simple recursive — children are A (stack-safe)
+    // Simple recursive \u2014 children are A (stack-safe)
     Con {
         tag: DataConId,
         fields: Vec<A>,
@@ -197,88 +197,111 @@ fn expand_node(tree: &CoreExpr, idx: usize) -> Result<EmitFrame<usize>, EmitErro
 }
 
 /// Collapse: assemble Cranelift IR from child results.
-#[allow(clippy::too_many_arguments)]
 fn collapse_frame(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     frame: EmitFrame<SsaVal>,
     tail: TailCtx,
 ) -> Result<SsaVal, EmitError> {
     match frame {
         EmitFrame::LitString(ref bytes) => emit_lit_string(
-            sess.pipeline,
-            builder,
-            sess.vmctx,
-            sess.gc_sig,
-            sess.oom_func,
+            args.sess.pipeline,
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
             bytes,
-            &mut ctx.lambda_counter,
+            &mut args.ctx.lambda_counter,
         ),
-        EmitFrame::Lit(ref lit) => emit_lit(builder, sess.vmctx, sess.gc_sig, sess.oom_func, lit),
-        EmitFrame::Var(vid) => match ctx.env.get(&vid).copied() {
+        EmitFrame::Lit(ref lit) => emit_lit(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            lit,
+        ),
+        EmitFrame::Var(vid) => match args.ctx.env.get(&vid).copied() {
             Some(v) => Ok(v),
             None => {
                 let tag = (vid.0 >> 56) as u8;
                 if tag == tidepool_repr::ERROR_SENTINEL_TAG {
                     // Lazy poison: emit a constant pointer to a pre-allocated
-                    // poison closure. The error flag is NOT set now — only when
+                    // poison closure. The error flag is NOT set now \u2014 only when
                     // the closure is actually called (forced). This is critical
                     // for typeclass dictionaries that contain error methods for
                     // impossible branches (e.g., $fFloatingDouble).
                     let kind = vid.0 & 0xFF;
                     let poison_addr = crate::host_fns::error_poison_ptr_lazy(kind) as i64;
-                    let poison_val = builder.ins().iconst(types::I64, poison_addr);
+                    let poison_val = args.builder.ins().iconst(types::I64, poison_addr);
                     return Ok(SsaVal::HeapPtr(poison_val));
                 }
 
-                ctx.trace_scope(&format!(
+                args.ctx.trace_scope(&format!(
                     "MISS var {:?} (env has {} entries)",
                     vid,
-                    ctx.env.len()
+                    args.ctx.env.len()
                 ));
-                let trap_fn = sess
+                let trap_fn = args
+                    .sess
                     .pipeline
                     .module
                     .declare_function("unresolved_var_trap", Linkage::Import, &{
-                        let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+                        let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
                         sig.params.push(AbiParam::new(types::I64));
                         sig.returns.push(AbiParam::new(types::I64));
                         sig
                     })
                     .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-                let trap_ref = sess
+                let trap_ref = args
+                    .sess
                     .pipeline
                     .module
-                    .declare_func_in_func(trap_fn, builder.func);
-                let var_id_val = builder.ins().iconst(types::I64, vid.0 as i64);
-                let inst = builder.ins().call(trap_ref, &[var_id_val]);
-                let result = builder.inst_results(inst)[0];
-                builder.declare_value_needs_stack_map(result);
+                    .declare_func_in_func(trap_fn, args.builder.func);
+                let var_id_val = args.builder.ins().iconst(types::I64, vid.0 as i64);
+                let inst = args.builder.ins().call(trap_ref, &[var_id_val]);
+                let result = args.builder.inst_results(inst)[0];
+                args.builder.declare_value_needs_stack_map(result);
                 Ok(SsaVal::HeapPtr(result))
             }
         },
         EmitFrame::Con { tag, fields } => {
             let field_vals: Vec<Value> = fields
                 .iter()
-                .map(|v| ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *v))
+                .map(|v| {
+                    ensure_heap_ptr(
+                        args.builder,
+                        args.sess.vmctx,
+                        args.sess.gc_sig,
+                        args.sess.oom_func,
+                        *v,
+                    )
+                })
                 .collect();
 
             let num_fields = field_vals.len();
             let size = 24 + 8 * num_fields as u64;
-            let ptr = emit_alloc_fast_path(builder, sess.vmctx, size, sess.gc_sig, sess.oom_func);
+            let ptr = emit_alloc_fast_path(
+                args.builder,
+                args.sess.vmctx,
+                size,
+                args.sess.gc_sig,
+                args.sess.oom_func,
+            );
 
-            let tag_val = builder.ins().iconst(types::I8, layout::TAG_CON as i64);
-            builder.ins().store(MemFlags::trusted(), tag_val, ptr, 0);
-            let size_val = builder.ins().iconst(types::I16, size as i64);
-            builder.ins().store(MemFlags::trusted(), size_val, ptr, 1);
+            let tag_val = args.builder.ins().iconst(types::I8, layout::TAG_CON as i64);
+            args.builder
+                .ins()
+                .store(MemFlags::trusted(), tag_val, ptr, 0);
+            let size_val = args.builder.ins().iconst(types::I16, size as i64);
+            args.builder
+                .ins()
+                .store(MemFlags::trusted(), size_val, ptr, 1);
 
-            let con_tag_val = builder.ins().iconst(types::I64, tag.0 as i64);
-            builder
+            let con_tag_val = args.builder.ins().iconst(types::I64, tag.0 as i64);
+            args.builder
                 .ins()
                 .store(MemFlags::trusted(), con_tag_val, ptr, CON_TAG_OFFSET);
-            let num_fields_val = builder.ins().iconst(types::I16, num_fields as i64);
-            builder.ins().store(
+            let num_fields_val = args.builder.ins().iconst(types::I16, num_fields as i64);
+            args.builder.ins().store(
                 MemFlags::trusted(),
                 num_fields_val,
                 ptr,
@@ -286,7 +309,7 @@ fn collapse_frame(
             );
 
             for (i, field_val) in field_vals.into_iter().enumerate() {
-                builder.ins().store(
+                args.builder.ins().store(
                     MemFlags::trusted(),
                     field_val,
                     ptr,
@@ -294,7 +317,7 @@ fn collapse_frame(
                 );
             }
 
-            builder.declare_value_needs_stack_map(ptr);
+            args.builder.declare_value_needs_stack_map(ptr);
             Ok(SsaVal::HeapPtr(ptr))
         }
         EmitFrame::ThunkCon { tag, field_indices } => {
@@ -302,19 +325,29 @@ fn collapse_frame(
             // compile non-trivial fields as thunks.
             let num_fields = field_indices.len();
             let size = 24 + 8 * num_fields as u64;
-            let ptr = emit_alloc_fast_path(builder, sess.vmctx, size, sess.gc_sig, sess.oom_func);
+            let ptr = emit_alloc_fast_path(
+                args.builder,
+                args.sess.vmctx,
+                size,
+                args.sess.gc_sig,
+                args.sess.oom_func,
+            );
 
-            let tag_val = builder.ins().iconst(types::I8, layout::TAG_CON as i64);
-            builder.ins().store(MemFlags::trusted(), tag_val, ptr, 0);
-            let size_val = builder.ins().iconst(types::I16, size as i64);
-            builder.ins().store(MemFlags::trusted(), size_val, ptr, 1);
+            let tag_val = args.builder.ins().iconst(types::I8, layout::TAG_CON as i64);
+            args.builder
+                .ins()
+                .store(MemFlags::trusted(), tag_val, ptr, 0);
+            let size_val = args.builder.ins().iconst(types::I16, size as i64);
+            args.builder
+                .ins()
+                .store(MemFlags::trusted(), size_val, ptr, 1);
 
-            let con_tag_val = builder.ins().iconst(types::I64, tag.0 as i64);
-            builder
+            let con_tag_val = args.builder.ins().iconst(types::I64, tag.0 as i64);
+            args.builder
                 .ins()
                 .store(MemFlags::trusted(), con_tag_val, ptr, CON_TAG_OFFSET);
-            let num_fields_val = builder.ins().iconst(types::I16, num_fields as i64);
-            builder.ins().store(
+            let num_fields_val = args.builder.ins().iconst(types::I16, num_fields as i64);
+            args.builder.ins().store(
                 MemFlags::trusted(),
                 num_fields_val,
                 ptr,
@@ -322,16 +355,37 @@ fn collapse_frame(
             );
 
             for (i, &f_idx) in field_indices.iter().enumerate() {
-                let field_val = if is_trivial_field(f_idx, sess.tree) {
+                let field_val = if is_trivial_field(f_idx, args.sess.tree) {
                     // Trivial: evaluate eagerly (existing path)
-                    let val = ctx.emit_node(sess, builder, f_idx, TailCtx::NonTail)?;
-                    ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, val)
+                    let val = EmitContext::emit_node(
+                        EmitArgs {
+                            ctx: args.ctx,
+                            sess: args.sess,
+                            builder: args.builder,
+                        },
+                        f_idx,
+                        TailCtx::NonTail,
+                    )?;
+                    ensure_heap_ptr(
+                        args.builder,
+                        args.sess.vmctx,
+                        args.sess.gc_sig,
+                        args.sess.oom_func,
+                        val,
+                    )
                 } else {
                     // Non-trivial: compile as thunk
-                    let thunk_val = emit_thunk(ctx, sess, builder, f_idx)?;
+                    let thunk_val = emit_thunk(
+                        EmitArgs {
+                            ctx: args.ctx,
+                            sess: args.sess,
+                            builder: args.builder,
+                        },
+                        f_idx,
+                    )?;
                     thunk_val.value()
                 };
-                builder.ins().store(
+                args.builder.ins().store(
                     MemFlags::trusted(),
                     field_val,
                     ptr,
@@ -339,66 +393,75 @@ fn collapse_frame(
                 );
             }
 
-            builder.declare_value_needs_stack_map(ptr);
+            args.builder.declare_value_needs_stack_map(ptr);
             Ok(SsaVal::HeapPtr(ptr))
         }
-        EmitFrame::PrimOp { ref op, ref args } => {
+        EmitFrame::PrimOp { ref op, args: ref prim_args } => {
             if matches!(op, tidepool_repr::PrimOpKind::Raise) {
-                // raise# is GHC's exception primitive — used for impossible branches
+                // raise# is GHC's exception primitive \u2014 used for impossible branches
                 // and `error` calls. Emit a call to runtime_error(2) which sets a
                 // thread-local error flag and returns null. The JIT machine converts
                 // null results to Result::Err(JitError::Yield(UserError)).
-                let err_fn = sess
+                let err_fn = args
+                    .sess
                     .pipeline
                     .module
                     .declare_function("runtime_error", Linkage::Import, &{
-                        let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+                        let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
                         sig.params.push(AbiParam::new(types::I64));
                         sig.returns.push(AbiParam::new(types::I64));
                         sig
                     })
                     .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-                let err_ref = sess
+                let err_ref = args
+                    .sess
                     .pipeline
                     .module
-                    .declare_func_in_func(err_fn, builder.func);
-                let kind_val = builder.ins().iconst(types::I64, 2); // UserError
-                let inst = builder.ins().call(err_ref, &[kind_val]);
-                let result = builder.inst_results(inst)[0];
-                builder.declare_value_needs_stack_map(result);
+                    .declare_func_in_func(err_fn, args.builder.func);
+                let kind_val = args.builder.ins().iconst(types::I64, 2); // UserError
+                let inst = args.builder.ins().call(err_ref, &[kind_val]);
+                let result = args.builder.inst_results(inst)[0];
+                args.builder.declare_value_needs_stack_map(result);
                 return Ok(SsaVal::HeapPtr(result));
             }
             // Force thunked args: PrimOps are strict in all arguments.
             // Case alt binders can be thunks (lazy Con fields), so force
             // them before passing to primop unboxing.
-            let forced_args: Vec<SsaVal> = args
+            let forced_args: Vec<SsaVal> = prim_args
                 .iter()
-                .map(|a| force_thunk_ssaval(sess.pipeline, builder, sess.vmctx, *a))
+                .map(|a| force_thunk_ssaval(args.sess.pipeline, args.builder, args.sess.vmctx, *a))
                 .collect::<Result<Vec<_>, EmitError>>()?;
-            primop::emit_primop(sess, builder, op, &forced_args)
+            primop::emit_primop(args.sess, args.builder, op, &forced_args)
         }
         EmitFrame::App { fun, arg } => {
-            ctx.declare_env(builder);
+            args.ctx.declare_env(args.builder);
             let raw_fun_ptr = fun.value();
-            let arg_ptr = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, arg);
+            let arg_ptr = ensure_heap_ptr(
+                args.builder,
+                args.sess.vmctx,
+                args.sess.gc_sig,
+                args.sess.oom_func,
+                arg,
+            );
 
             // Force thunked function values. Case alt binders can be
             // thunks (lazy fields), so when one is applied as a function,
             // we must force it to get the underlying closure.
-            let fun_tag = builder
+            let fun_tag = args
+                .builder
                 .ins()
                 .load(types::I8, MemFlags::trusted(), raw_fun_ptr, 0);
-            let is_thunk = builder.ins().icmp_imm(
+            let is_thunk = args.builder.ins().icmp_imm(
                 IntCC::Equal,
                 fun_tag,
                 tidepool_heap::layout::TAG_THUNK as i64,
             );
 
-            let force_fun_block = builder.create_block();
-            let fun_ready_block = builder.create_block();
-            builder.append_block_param(fun_ready_block, types::I64);
+            let force_fun_block = args.builder.create_block();
+            let fun_ready_block = args.builder.create_block();
+            args.builder.append_block_param(fun_ready_block, types::I64);
 
-            builder.ins().brif(
+            args.builder.ins().brif(
                 is_thunk,
                 force_fun_block,
                 &[],
@@ -406,62 +469,69 @@ fn collapse_frame(
                 &[BlockArg::Value(raw_fun_ptr)],
             );
 
-            builder.switch_to_block(force_fun_block);
-            builder.seal_block(force_fun_block);
+            args.builder.switch_to_block(force_fun_block);
+            args.builder.seal_block(force_fun_block);
 
-            let force_fn = sess
+            let force_fn = args
+                .sess
                 .pipeline
                 .module
                 .declare_function("heap_force", Linkage::Import, &{
-                    let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+                    let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
                     sig.params.push(AbiParam::new(types::I64)); // vmctx
                     sig.params.push(AbiParam::new(types::I64)); // thunk
                     sig.returns.push(AbiParam::new(types::I64)); // result
                     sig
                 })
                 .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-            let force_ref = sess
+            let force_ref = args
+                .sess
                 .pipeline
                 .module
-                .declare_func_in_func(force_fn, builder.func);
-            let force_call = builder.ins().call(force_ref, &[sess.vmctx, raw_fun_ptr]);
-            let forced_fun = builder.inst_results(force_call)[0];
-            builder.declare_value_needs_stack_map(forced_fun);
-            builder
+                .declare_func_in_func(force_fn, args.builder.func);
+            let force_call = args
+                .builder
+                .ins()
+                .call(force_ref, &[args.sess.vmctx, raw_fun_ptr]);
+            let forced_fun = args.builder.inst_results(force_call)[0];
+            args.builder.declare_value_needs_stack_map(forced_fun);
+            args.builder
                 .ins()
                 .jump(fun_ready_block, &[BlockArg::Value(forced_fun)]);
 
-            builder.switch_to_block(fun_ready_block);
-            builder.seal_block(fun_ready_block);
-            let fun_ptr = builder.block_params(fun_ready_block)[0];
-            builder.declare_value_needs_stack_map(fun_ptr);
+            args.builder.switch_to_block(fun_ready_block);
+            args.builder.seal_block(fun_ready_block);
+            let fun_ptr = args.builder.block_params(fun_ready_block)[0];
+            args.builder.declare_value_needs_stack_map(fun_ptr);
 
             // Debug: call host fn to validate fun_ptr tag before call_indirect.
             // Returns 0 (null) if ok, or a poison pointer if call should be skipped.
-            let check_fn = sess
+            let check_fn = args
+                .sess
                 .pipeline
                 .module
                 .declare_function("debug_app_check", Linkage::Import, &{
-                    let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+                    let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
                     sig.params.push(AbiParam::new(types::I64)); // fun_ptr
                     sig.returns.push(AbiParam::new(types::I64)); // 0 = ok, non-zero = poison
                     sig
                 })
                 .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-            let check_ref = sess
+            let check_ref = args
+                .sess
                 .pipeline
                 .module
-                .declare_func_in_func(check_fn, builder.func);
-            let check_inst = builder.ins().call(check_ref, &[fun_ptr]);
-            let check_result = builder.inst_results(check_inst)[0];
+                .declare_func_in_func(check_fn, args.builder.func);
+            let check_inst = args.builder.ins().call(check_ref, &[fun_ptr]);
+            let check_result = args.builder.inst_results(check_inst)[0];
 
             // If debug_app_check returned non-zero (poison), short-circuit
-            let call_block = builder.create_block();
-            let merge_block = builder.create_block();
-            builder.append_block_param(merge_block, types::I64);
+            let call_block = args.builder.create_block();
+            let merge_block = args.builder.create_block();
+            args.builder.append_block_param(merge_block, types::I64);
 
-            let is_zero = builder.ins().icmp_imm(IntCC::Equal, check_result, 0);
-            builder.ins().brif(
+            let is_zero = args.builder.ins().icmp_imm(IntCC::Equal, check_result, 0);
+            args.builder.ins().brif(
                 is_zero,
                 call_block,
                 &[],
@@ -470,79 +540,83 @@ fn collapse_frame(
             );
 
             // call_block: normal function call
-            builder.switch_to_block(call_block);
-            builder.seal_block(call_block);
+            args.builder.switch_to_block(call_block);
+            args.builder.seal_block(call_block);
 
-            let code_ptr = builder.ins().load(
+            let code_ptr = args.builder.ins().load(
                 types::I64,
                 MemFlags::trusted(),
                 fun_ptr,
                 CLOSURE_CODE_PTR_OFFSET,
             );
 
-            let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+            let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
             sig.params.push(AbiParam::new(types::I64)); // vmctx
             sig.params.push(AbiParam::new(types::I64)); // self
             sig.params.push(AbiParam::new(types::I64)); // arg
             sig.returns.push(AbiParam::new(types::I64));
-            let call_sig = builder.import_signature(sig);
+            let call_sig = args.builder.import_signature(sig);
 
-            let inst =
-                builder
-                    .ins()
-                    .call_indirect(call_sig, code_ptr, &[sess.vmctx, fun_ptr, arg_ptr]);
-            let ret_val = builder.inst_results(inst)[0];
+            let inst = args.builder.ins().call_indirect(
+                call_sig,
+                code_ptr,
+                &[args.sess.vmctx, fun_ptr, arg_ptr],
+            );
+            let ret_val = args.builder.inst_results(inst)[0];
 
             // TCO null check: if callee returned null, it might be a tail call
-            let ret_is_null = builder.ins().icmp_imm(IntCC::Equal, ret_val, 0);
-            let null_check_block = builder.create_block();
-            let ret_ok_block = builder.create_block();
+            let ret_is_null = args.builder.ins().icmp_imm(IntCC::Equal, ret_val, 0);
+            let null_check_block = args.builder.create_block();
+            let ret_ok_block = args.builder.create_block();
 
-            builder
+            args.builder
                 .ins()
                 .brif(ret_is_null, null_check_block, &[], ret_ok_block, &[]);
 
             // ret_ok_block: normal return, jump to merge
-            builder.switch_to_block(ret_ok_block);
-            builder.seal_block(ret_ok_block);
-            builder.ins().jump(merge_block, &[BlockArg::Value(ret_val)]);
+            args.builder.switch_to_block(ret_ok_block);
+            args.builder.seal_block(ret_ok_block);
+            args.builder
+                .ins()
+                .jump(merge_block, &[BlockArg::Value(ret_val)]);
 
             // null_check_block: check if VMContext has a pending tail call
-            builder.switch_to_block(null_check_block);
-            builder.seal_block(null_check_block);
+            args.builder.switch_to_block(null_check_block);
+            args.builder.seal_block(null_check_block);
 
-            let tail_callee = builder.ins().load(
+            let tail_callee = args.builder.ins().load(
                 types::I64,
                 MemFlags::trusted(),
-                sess.vmctx,
+                args.sess.vmctx,
                 VMCTX_TAIL_CALLEE_OFFSET,
             );
-            let has_tail_call = builder.ins().icmp_imm(IntCC::NotEqual, tail_callee, 0);
+            let has_tail_call = args.builder.ins().icmp_imm(IntCC::NotEqual, tail_callee, 0);
 
-            let resolve_block = builder.create_block();
-            let null_propagate_block = builder.create_block();
+            let resolve_block = args.builder.create_block();
+            let null_propagate_block = args.builder.create_block();
 
-            builder
+            args.builder
                 .ins()
                 .brif(has_tail_call, resolve_block, &[], null_propagate_block, &[]);
 
             // null_propagate_block: no tail call pending, propagate null (error)
-            builder.switch_to_block(null_propagate_block);
-            builder.seal_block(null_propagate_block);
-            let null_val = builder.ins().iconst(types::I64, 0);
-            builder
+            args.builder.switch_to_block(null_propagate_block);
+            args.builder.seal_block(null_propagate_block);
+            let null_val = args.builder.ins().iconst(types::I64, 0);
+            args.builder
                 .ins()
                 .jump(merge_block, &[BlockArg::Value(null_val)]);
 
             // resolve_block: call trampoline_resolve to execute the pending tail call
-            builder.switch_to_block(resolve_block);
-            builder.seal_block(resolve_block);
+            args.builder.switch_to_block(resolve_block);
+            args.builder.seal_block(resolve_block);
 
-            let resolve_fn = sess
+            let resolve_fn = args
+                .sess
                 .pipeline
                 .module
                 .declare_function("trampoline_resolve", Linkage::Import, &{
-                    let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+                    let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
                     sig.params.push(AbiParam::new(types::I64)); // vmctx
                     sig.returns.push(AbiParam::new(types::I64)); // result
                     sig
@@ -550,97 +624,136 @@ fn collapse_frame(
                 .map_err(|e: cranelift_module::ModuleError| {
                     EmitError::CraneliftError(e.to_string())
                 })?;
-            let resolve_ref = sess
+            let resolve_ref = args
+                .sess
                 .pipeline
                 .module
-                .declare_func_in_func(resolve_fn, builder.func);
-            let resolve_inst = builder.ins().call(resolve_ref, &[sess.vmctx]);
-            let resolved_val = builder.inst_results(resolve_inst)[0];
-            builder.declare_value_needs_stack_map(resolved_val);
-            builder
+                .declare_func_in_func(resolve_fn, args.builder.func);
+            let resolve_inst = args.builder.ins().call(resolve_ref, &[args.sess.vmctx]);
+            let resolved_val = args.builder.inst_results(resolve_inst)[0];
+            args.builder.declare_value_needs_stack_map(resolved_val);
+            args.builder
                 .ins()
                 .jump(merge_block, &[BlockArg::Value(resolved_val)]);
 
             // merge_block: result from any path
-            builder.switch_to_block(merge_block);
-            builder.seal_block(merge_block);
-            let merged_val = builder.block_params(merge_block)[0];
-            builder.declare_value_needs_stack_map(merged_val);
+            args.builder.switch_to_block(merge_block);
+            args.builder.seal_block(merge_block);
+            let merged_val = args.builder.block_params(merge_block)[0];
+            args.builder.declare_value_needs_stack_map(merged_val);
             Ok(SsaVal::HeapPtr(merged_val))
         }
-        EmitFrame::Lam { binder, body_idx } => emit_lam(ctx, sess, builder, binder, body_idx),
+        EmitFrame::Lam { binder, body_idx } => emit_lam(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            binder,
+            body_idx,
+        ),
         EmitFrame::Case {
             scrutinee,
             binder,
             alts,
-        } => crate::emit::case::emit_case(ctx, sess, builder, scrutinee, &binder, &alts, tail),
+        } => crate::emit::case::emit_case(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            scrutinee,
+            &binder,
+            &alts,
+            tail,
+        ),
         EmitFrame::Join {
             label,
             params,
             rhs_idx,
             body_idx,
-        } => crate::emit::join::emit_join(ctx, sess, builder, &label, &params, rhs_idx, body_idx),
-        EmitFrame::Jump { label, args } => {
-            let join_block = ctx.join_blocks.get(&label)?.block;
+        } => crate::emit::join::emit_join(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            &label,
+            &params,
+            rhs_idx,
+            body_idx,
+        ),
+        EmitFrame::Jump { label, args: jump_args } => {
+            let join_block = args.ctx.join_blocks.get(&label)?.block;
 
-            let arg_values: Vec<BlockArg> = args
+            let arg_values: Vec<BlockArg> = jump_args
                 .iter()
                 .map(|v| {
                     BlockArg::Value(ensure_heap_ptr(
-                        builder,
-                        sess.vmctx,
-                        sess.gc_sig,
-                        sess.oom_func,
+                        args.builder,
+                        args.sess.vmctx,
+                        args.sess.gc_sig,
+                        args.sess.oom_func,
                         *v,
                     ))
                 })
                 .collect();
 
-            builder.ins().jump(join_block, &arg_values);
+            args.builder.ins().jump(join_block, &arg_values);
 
-            let unreachable_block = builder.create_block();
-            builder.switch_to_block(unreachable_block);
-            builder.seal_block(unreachable_block);
+            let unreachable_block = args.builder.create_block();
+            args.builder.switch_to_block(unreachable_block);
+            args.builder.seal_block(unreachable_block);
 
             Ok(SsaVal::Raw(
-                builder.ins().iconst(types::I64, 0),
+                args.builder.ins().iconst(types::I64, 0),
                 LIT_TAG_INT,
             ))
         }
         EmitFrame::LetBoundary(idx) => {
             // A LetBoundary appearing as a mapped child of a frame (e.g.,
-            // Case scrutinee, App argument) is NEVER in tail position —
+            // Case scrutinee, App argument) is NEVER in tail position \u2014
             // the parent frame still has work to do after this sub-expression.
             // Without this, a LetRec body App inside a Case scrutinee gets
             // compiled as a tail call, bypassing the Case dispatch entirely.
-            ctx.emit_node(sess, builder, idx, TailCtx::NonTail)
+            EmitContext::emit_node(
+                EmitArgs {
+                    ctx: args.ctx,
+                    sess: args.sess,
+                    builder: args.builder,
+                },
+                idx,
+                TailCtx::NonTail,
+            )
         }
     }
 }
 
 /// Stack-safe emission of a non-Let expression subtree via hylomorphism.
-#[allow(clippy::too_many_arguments)]
-fn emit_subtree(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
-    idx: usize,
-) -> Result<SsaVal, EmitError> {
-    emit_subtree_with_tail(ctx, sess, builder, idx, TailCtx::NonTail)
+fn emit_subtree(args: EmitArgs, idx: usize) -> Result<SsaVal, EmitError> {
+    emit_subtree_with_tail(args, idx, TailCtx::NonTail)
 }
 
 /// Stack-safe emission with explicit tail context. Case alt bodies inherit `tail`.
 fn emit_subtree_with_tail(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     idx: usize,
     tail: TailCtx,
 ) -> Result<SsaVal, EmitError> {
     try_expand_and_collapse::<EmitFrameToken, _, _, _>(
         idx,
-        |idx| expand_node(sess.tree, idx),
-        |frame| collapse_frame(ctx, sess, builder, frame, tail),
+        |idx| expand_node(args.sess.tree, idx),
+        |frame| {
+            collapse_frame(
+                EmitArgs {
+                    ctx: args.ctx,
+                    sess: args.sess,
+                    builder: args.builder,
+                },
+                frame,
+                tail,
+            )
+        },
     )
 }
 
@@ -700,42 +813,45 @@ fn compute_captures(
     (body_tree, sorted_fvs)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn emit_lam(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     binder: VarId,
     body_idx: usize,
 ) -> Result<SsaVal, EmitError> {
-    let (body_tree, sorted_fvs) = compute_captures(ctx, sess.tree, body_idx, Some(binder), "lam");
+    let (body_tree, sorted_fvs) =
+        compute_captures(args.ctx, args.sess.tree, body_idx, Some(binder), "lam");
 
     let captures: Vec<(VarId, SsaVal)> = sorted_fvs
         .iter()
         .map(|v| {
-            let val = ctx.env.get(v).ok_or_else(|| {
+            let val = args.ctx.env.get(v).ok_or_else(|| {
                 EmitError::MissingCaptureVar(
                     *v,
-                    format!("Lam capture: not in env (env has {} vars)", ctx.env.len()),
+                    format!(
+                        "Lam capture: not in env (env has {} vars)",
+                        args.ctx.env.len()
+                    ),
                 )
             })?;
             Ok::<_, EmitError>((*v, *val))
         })
         .collect::<Result<Vec<_>, EmitError>>()?;
 
-    let lambda_name = ctx.next_lambda_name();
-    let mut closure_sig = Signature::new(sess.pipeline.isa.default_call_conv());
+    let lambda_name = args.ctx.next_lambda_name();
+    let mut closure_sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
     closure_sig.params.push(AbiParam::new(types::I64)); // vmctx
     closure_sig.params.push(AbiParam::new(types::I64)); // self
     closure_sig.params.push(AbiParam::new(types::I64)); // arg
     closure_sig.returns.push(AbiParam::new(types::I64));
 
-    let lambda_func_id = sess
+    let lambda_func_id = args
+        .sess
         .pipeline
         .module
         .declare_function(&lambda_name, Linkage::Local, &closure_sig)
         .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-    sess.pipeline
+    args.sess
+        .pipeline
         .register_lambda(lambda_func_id, lambda_name.clone());
 
     let mut inner_ctx = Context::new();
@@ -756,25 +872,27 @@ fn emit_lam(
     inner_builder.declare_value_needs_stack_map(closure_self);
     inner_builder.declare_value_needs_stack_map(arg_param);
 
-    let mut inner_gc_sig = Signature::new(sess.pipeline.isa.default_call_conv());
+    let mut inner_gc_sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
     inner_gc_sig.params.push(AbiParam::new(types::I64));
     let inner_gc_sig_ref = inner_builder.import_signature(inner_gc_sig);
 
     let inner_oom_func = {
-        let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+        let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
         sig.returns.push(AbiParam::new(types::I64));
-        let func_id = sess
+        let func_id = args
+            .sess
             .pipeline
             .module
             .declare_function("runtime_oom", Linkage::Import, &sig)
             .map_err(|e| EmitError::CraneliftError(format!("declare runtime_oom: {e}")))?;
-        sess.pipeline
+        args.sess
+            .pipeline
             .module
             .declare_func_in_func(func_id, inner_builder.func)
     };
 
-    let mut inner_emit = EmitContext::new(ctx.prefix.clone());
-    inner_emit.lambda_counter = ctx.lambda_counter;
+    let mut inner_emit = EmitContext::new(args.ctx.prefix.clone());
+    inner_emit.lambda_counter = args.ctx.lambda_counter;
 
     inner_emit.trace_scope(&format!("insert lam binder {:?}", binder));
     inner_emit.env.insert(binder, SsaVal::HeapPtr(arg_param));
@@ -791,15 +909,18 @@ fn emit_lam(
 
     let body_root = body_tree.nodes.len() - 1;
     let mut inner_sess = EmitSession {
-        pipeline: sess.pipeline,
+        pipeline: args.sess.pipeline,
         vmctx: inner_vmctx,
         gc_sig: inner_gc_sig_ref,
         oom_func: inner_oom_func,
         tree: &body_tree,
     };
-    let body_result = inner_emit.emit_node(
-        &mut inner_sess,
-        &mut inner_builder,
+    let body_result = EmitContext::emit_node(
+        EmitArgs {
+            ctx: &mut inner_emit,
+            sess: &mut inner_sess,
+            builder: &mut inner_builder,
+        },
         body_root,
         TailCtx::Tail,
     )?;
@@ -814,7 +935,7 @@ fn emit_lam(
     inner_builder.ins().return_(&[ret_val]);
     inner_builder.finalize();
 
-    ctx.lambda_counter = inner_emit.lambda_counter;
+    args.ctx.lambda_counter = inner_emit.lambda_counter;
 
     // Debug: dump Cranelift IR for each lambda when TIDEPOOL_DUMP_CLIF=1
     if std::env::var("TIDEPOOL_DUMP_CLIF").is_ok() {
@@ -830,42 +951,47 @@ fn emit_lam(
         eprintln!("=== END CLIF {} ===", lambda_name);
     }
 
-    sess.pipeline
+    args.sess
+        .pipeline
         .define_function(lambda_func_id, &mut inner_ctx)?;
 
-    let func_ref = sess
+    let func_ref = args
+        .sess
         .pipeline
         .module
-        .declare_func_in_func(lambda_func_id, builder.func);
-    let code_ptr = builder.ins().func_addr(types::I64, func_ref);
+        .declare_func_in_func(lambda_func_id, args.builder.func);
+    let code_ptr = args.builder.ins().func_addr(types::I64, func_ref);
 
     let num_captures = captures.len();
     let closure_size = 24 + 8 * num_captures as u64;
     let closure_ptr = emit_alloc_fast_path(
-        builder,
-        sess.vmctx,
+        args.builder,
+        args.sess.vmctx,
         closure_size,
-        sess.gc_sig,
-        sess.oom_func,
+        args.sess.gc_sig,
+        args.sess.oom_func,
     );
 
-    let tag_val = builder.ins().iconst(types::I8, layout::TAG_CLOSURE as i64);
-    builder
+    let tag_val = args
+        .builder
+        .ins()
+        .iconst(types::I8, layout::TAG_CLOSURE as i64);
+    args.builder
         .ins()
         .store(MemFlags::trusted(), tag_val, closure_ptr, 0);
-    let size_val = builder.ins().iconst(types::I16, closure_size as i64);
-    builder
+    let size_val = args.builder.ins().iconst(types::I16, closure_size as i64);
+    args.builder
         .ins()
         .store(MemFlags::trusted(), size_val, closure_ptr, 1);
 
-    builder.ins().store(
+    args.builder.ins().store(
         MemFlags::trusted(),
         code_ptr,
         closure_ptr,
         CLOSURE_CODE_PTR_OFFSET,
     );
-    let num_cap_val = builder.ins().iconst(types::I16, num_captures as i64);
-    builder.ins().store(
+    let num_cap_val = args.builder.ins().iconst(types::I16, num_captures as i64);
+    args.builder.ins().store(
         MemFlags::trusted(),
         num_cap_val,
         closure_ptr,
@@ -873,14 +999,20 @@ fn emit_lam(
     );
 
     for (i, (_, ssaval)) in captures.iter().enumerate() {
-        let cap_val = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *ssaval);
+        let cap_val = ensure_heap_ptr(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            *ssaval,
+        );
         let offset = CLOSURE_CAPTURED_OFFSET + 8 * i as i32;
-        builder
+        args.builder
             .ins()
             .store(MemFlags::trusted(), cap_val, closure_ptr, offset);
     }
 
-    builder.declare_value_needs_stack_map(closure_ptr);
+    args.builder.declare_value_needs_stack_map(closure_ptr);
     Ok(SsaVal::HeapPtr(closure_ptr))
 }
 
@@ -893,25 +1025,26 @@ fn emit_lam(
 /// the thunk object and evaluates the deferred expression. Returns the allocated
 /// thunk heap pointer.
 ///
-/// The thunk entry function is a pure computation — `heap_force` handles the
+/// The thunk entry function is a pure computation \u2014 `heap_force` handles the
 /// state machine (blackhole, call entry, write indirection, set evaluated).
-#[allow(clippy::too_many_arguments)]
 fn emit_thunk(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     body_idx: usize,
 ) -> Result<SsaVal, EmitError> {
     // Extract the sub-expression and compute free variables
-    let (body_tree, sorted_fvs) = compute_captures(ctx, sess.tree, body_idx, None, "thunk");
+    let (body_tree, sorted_fvs) =
+        compute_captures(args.ctx, args.sess.tree, body_idx, None, "thunk");
 
     let captures: Vec<(VarId, SsaVal)> = sorted_fvs
         .iter()
         .map(|v| {
-            let val = ctx.env.get(v).ok_or_else(|| {
+            let val = args.ctx.env.get(v).ok_or_else(|| {
                 EmitError::MissingCaptureVar(
                     *v,
-                    format!("Thunk capture: not in env (env has {} vars)", ctx.env.len()),
+                    format!(
+                        "Thunk capture: not in env (env has {} vars)",
+                        args.ctx.env.len()
+                    ),
                 )
             })?;
             Ok::<_, EmitError>((*v, *val))
@@ -919,18 +1052,20 @@ fn emit_thunk(
         .collect::<Result<Vec<_>, EmitError>>()?;
 
     // Declare the thunk entry function: (vmctx, thunk_ptr) -> result
-    let thunk_name = ctx.next_thunk_name();
-    let mut thunk_sig = Signature::new(sess.pipeline.isa.default_call_conv());
+    let thunk_name = args.ctx.next_thunk_name();
+    let mut thunk_sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
     thunk_sig.params.push(AbiParam::new(types::I64)); // vmctx
     thunk_sig.params.push(AbiParam::new(types::I64)); // thunk_ptr (self)
     thunk_sig.returns.push(AbiParam::new(types::I64));
 
-    let thunk_func_id = sess
+    let thunk_func_id = args
+        .sess
         .pipeline
         .module
         .declare_function(&thunk_name, Linkage::Local, &thunk_sig)
         .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-    sess.pipeline
+    args.sess
+        .pipeline
         .register_lambda(thunk_func_id, thunk_name.clone());
 
     // Build the inner function
@@ -950,25 +1085,27 @@ fn emit_thunk(
 
     inner_builder.declare_value_needs_stack_map(thunk_self);
 
-    let mut inner_gc_sig = Signature::new(sess.pipeline.isa.default_call_conv());
+    let mut inner_gc_sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
     inner_gc_sig.params.push(AbiParam::new(types::I64));
     let inner_gc_sig_ref = inner_builder.import_signature(inner_gc_sig);
 
     let inner_oom_func = {
-        let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+        let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
         sig.returns.push(AbiParam::new(types::I64));
-        let func_id = sess
+        let func_id = args
+            .sess
             .pipeline
             .module
             .declare_function("runtime_oom", Linkage::Import, &sig)
             .map_err(|e| EmitError::CraneliftError(format!("declare runtime_oom: {e}")))?;
-        sess.pipeline
+        args.sess
+            .pipeline
             .module
             .declare_func_in_func(func_id, inner_builder.func)
     };
 
-    let mut inner_emit = EmitContext::new(ctx.prefix.clone());
-    inner_emit.lambda_counter = ctx.lambda_counter;
+    let mut inner_emit = EmitContext::new(args.ctx.prefix.clone());
+    inner_emit.lambda_counter = args.ctx.lambda_counter;
 
     // Load captures from thunk object: thunk_ptr + THUNK_CAPTURED_OFFSET + 8*i
     for (i, (var_id, _)) in captures.iter().enumerate() {
@@ -984,15 +1121,18 @@ fn emit_thunk(
     // Emit the deferred expression body
     let body_root = body_tree.nodes.len() - 1;
     let mut inner_sess = EmitSession {
-        pipeline: sess.pipeline,
+        pipeline: args.sess.pipeline,
         vmctx: inner_vmctx,
         gc_sig: inner_gc_sig_ref,
         oom_func: inner_oom_func,
         tree: &body_tree,
     };
-    let body_result = inner_emit.emit_node(
-        &mut inner_sess,
-        &mut inner_builder,
+    let body_result = EmitContext::emit_node(
+        EmitArgs {
+            ctx: &mut inner_emit,
+            sess: &mut inner_sess,
+            builder: &mut inner_builder,
+        },
         body_root,
         TailCtx::NonTail,
     )?;
@@ -1007,7 +1147,7 @@ fn emit_thunk(
     inner_builder.ins().return_(&[ret_val]);
     inner_builder.finalize();
 
-    ctx.lambda_counter = inner_emit.lambda_counter;
+    args.ctx.lambda_counter = inner_emit.lambda_counter;
 
     // Debug: dump Cranelift IR for thunk when TIDEPOOL_DUMP_CLIF=1
     if std::env::var("TIDEPOOL_DUMP_CLIF").is_ok() {
@@ -1023,37 +1163,45 @@ fn emit_thunk(
         eprintln!("=== END CLIF {} ===", thunk_name);
     }
 
-    sess.pipeline
+    args.sess
+        .pipeline
         .define_function(thunk_func_id, &mut inner_ctx)?;
 
     // Get code pointer in the parent function
-    let func_ref = sess
+    let func_ref = args
+        .sess
         .pipeline
         .module
-        .declare_func_in_func(thunk_func_id, builder.func);
-    let code_ptr = builder.ins().func_addr(types::I64, func_ref);
+        .declare_func_in_func(thunk_func_id, args.builder.func);
+    let code_ptr = args.builder.ins().func_addr(types::I64, func_ref);
 
     // Allocate the thunk heap object
     let num_captures = captures.len();
     let thunk_size = 24 + 8 * num_captures as u64;
-    let thunk_ptr =
-        emit_alloc_fast_path(builder, sess.vmctx, thunk_size, sess.gc_sig, sess.oom_func);
+    let thunk_ptr = emit_alloc_fast_path(
+        args.builder,
+        args.sess.vmctx,
+        thunk_size,
+        args.sess.gc_sig,
+        args.sess.oom_func,
+    );
 
     // Header: tag + size
-    let tag_val = builder.ins().iconst(types::I8, layout::TAG_THUNK as i64);
-    builder
+    let tag_val = args.builder.ins().iconst(types::I8, layout::TAG_THUNK as i64);
+    args.builder
         .ins()
         .store(MemFlags::trusted(), tag_val, thunk_ptr, 0);
-    let size_val = builder.ins().iconst(types::I16, thunk_size as i64);
-    builder
+    let size_val = args.builder.ins().iconst(types::I16, thunk_size as i64);
+    args.builder
         .ins()
         .store(MemFlags::trusted(), size_val, thunk_ptr, 1);
 
     // State = Unevaluated
-    let state_val = builder
+    let state_val = args
+        .builder
         .ins()
         .iconst(types::I8, layout::THUNK_UNEVALUATED as i64);
-    builder.ins().store(
+    args.builder.ins().store(
         MemFlags::trusted(),
         state_val,
         thunk_ptr,
@@ -1061,7 +1209,7 @@ fn emit_thunk(
     );
 
     // Code pointer
-    builder.ins().store(
+    args.builder.ins().store(
         MemFlags::trusted(),
         code_ptr,
         thunk_ptr,
@@ -1070,14 +1218,20 @@ fn emit_thunk(
 
     // Store captures
     for (i, (_, ssaval)) in captures.iter().enumerate() {
-        let cap_val = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *ssaval);
+        let cap_val = ensure_heap_ptr(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            *ssaval,
+        );
         let offset = THUNK_CAPTURED_OFFSET + 8 * i as i32;
-        builder
+        args.builder
             .ins()
             .store(MemFlags::trusted(), cap_val, thunk_ptr, offset);
     }
 
-    builder.declare_value_needs_stack_map(thunk_ptr);
+    args.builder.declare_value_needs_stack_map(thunk_ptr);
     Ok(SsaVal::HeapPtr(thunk_ptr))
 }
 
@@ -1150,9 +1304,12 @@ pub fn compile_expr(
         tree,
     };
 
-    let result = emit_ctx.emit_node(
-        &mut sess,
-        &mut builder,
+    let result = EmitContext::emit_node(
+        EmitArgs {
+            ctx: &mut emit_ctx,
+            sess: &mut sess,
+            builder: &mut builder,
+        },
         tree.nodes.len() - 1,
         TailCtx::NonTail,
     )?;
@@ -1234,11 +1391,8 @@ impl EmitContext {
     /// - emit_lam/emit_thunk: create new EmitContext, bounded by lambda nesting
     /// - emit_case/emit_join: called from hylomorphism collapse, bounded by case nesting
     /// - Trivial Con field eval: constant stack depth (Var/Lit)
-    #[allow(clippy::too_many_arguments)]
     pub fn emit_node(
-        &mut self,
-        sess: &mut EmitSession,
-        builder: &mut FunctionBuilder,
+        args: EmitArgs,
         root_idx: usize,
         tail: TailCtx,
     ) -> Result<SsaVal, EmitError> {
@@ -1251,35 +1405,35 @@ impl EmitContext {
                     // Inner iterative loop: skip through Let chains in tail position
                     let mut idx = start_idx;
                     loop {
-                        match &sess.tree.nodes[idx] {
+                        match &args.sess.tree.nodes[idx] {
                             CoreFrame::LetNonRec { binder, rhs, body } => {
                                 let binder = *binder;
                                 let rhs = *rhs;
                                 let body = *body;
                                 // Dead code elimination: skip RHS if binder is unused in body.
                                 let body_fvs = tidepool_repr::free_vars::free_vars(
-                                    &sess.tree.extract_subtree(body),
+                                    &args.sess.tree.extract_subtree(body),
                                 );
                                 if body_fvs.contains(&binder) {
-                                    if Self::rhs_is_error_call(sess.tree, rhs) {
-                                        // Bind to lazy poison closure — error only triggers on call.
-                                        let poison_addr = self.emit_error_poison(sess.tree, rhs);
+                                    if Self::rhs_is_error_call(args.sess.tree, rhs) {
+                                        // Bind to lazy poison closure \u2014 error only triggers on call.
+                                        let poison_addr = args.ctx.emit_error_poison(args.sess.tree, rhs);
                                         let poison_val =
-                                            builder.ins().iconst(types::I64, poison_addr);
-                                        self.trace_scope(&format!(
+                                            args.builder.ins().iconst(types::I64, poison_addr);
+                                        args.ctx.trace_scope(&format!(
                                             "defer error LetNonRec {:?}",
                                             binder
                                         ));
                                         let old_val =
-                                            self.env.insert(binder, SsaVal::HeapPtr(poison_val));
+                                            args.ctx.env.insert(binder, SsaVal::HeapPtr(poison_val));
                                         // No RHS eval needed, just push cleanup and continue to body
                                         work.push(EmitWork::LetCleanupMark(LetCleanup::Single(
                                             binder, old_val,
                                         )));
                                     } else {
                                         // Push work in LIFO order: cleanup, eval body, bind, eval rhs
-                                        // After rhs eval → bind → eval body → cleanup
-                                        let old_val = self.env.get(&binder).cloned();
+                                        // After rhs eval \u2192 bind \u2192 eval body \u2192 cleanup
+                                        let old_val = args.ctx.env.get(&binder).cloned();
                                         work.push(EmitWork::LetCleanupMark(LetCleanup::Single(
                                             binder, old_val,
                                         )));
@@ -1289,7 +1443,7 @@ impl EmitContext {
                                         break; // exit inner loop, process work stack
                                     }
                                 } else {
-                                    self.trace_scope(&format!("DCE skip LetNonRec {:?}", binder));
+                                    args.ctx.trace_scope(&format!("DCE skip LetNonRec {:?}", binder));
                                 }
                                 idx = body;
                                 continue;
@@ -1300,24 +1454,47 @@ impl EmitContext {
                                 // Run phases 1-3b inline, push deferred evals + finish + cleanup
                                 let mut scope = EnvScope::new();
                                 for (b, _) in &bindings {
-                                    scope.saved.push((*b, self.env.get(b).copied()));
+                                    scope.saved.push((*b, args.ctx.env.get(b).copied()));
                                 }
                                 work.push(EmitWork::LetCleanupMark(LetCleanup::Rec(scope)));
-                                self.emit_letrec_phases(
-                                    sess, builder, &bindings, body, &mut work, tail_ctx,
+                                Self::emit_letrec_phases(
+                                    EmitArgs {
+                                        ctx: args.ctx,
+                                        sess: args.sess,
+                                        builder: args.builder,
+                                    },
+                                    &bindings,
+                                    body,
+                                    &mut work,
+                                    tail_ctx,
                                 )?;
                                 break; // exit inner loop
                             }
                             // All non-Let nodes: delegate to stack-safe hylomorphism
                             _ => {
                                 if tail_ctx.is_tail()
-                                    && matches!(sess.tree.nodes[idx], CoreFrame::App { .. })
+                                    && matches!(args.sess.tree.nodes[idx], CoreFrame::App { .. })
                                 {
-                                    let result = self.emit_tail_app(sess, builder, idx)?;
+                                    let result = Self::emit_tail_app(
+                                        EmitArgs {
+                                            ctx: args.ctx,
+                                            sess: args.sess,
+                                            builder: args.builder,
+                                        },
+                                        idx,
+                                    )?;
                                     vals.push(result);
                                 } else {
                                     let result =
-                                        emit_subtree_with_tail(self, sess, builder, idx, tail_ctx)?;
+                                        emit_subtree_with_tail(
+                                            EmitArgs {
+                                                ctx: args.ctx,
+                                                sess: args.sess,
+                                                builder: args.builder,
+                                            },
+                                            idx,
+                                            tail_ctx,
+                                        )?;
                                     vals.push(result);
                                 }
                                 break;
@@ -1329,34 +1506,49 @@ impl EmitContext {
                     let val = vals.pop().ok_or_else(|| {
                         EmitError::InternalError("Bind: empty value stack".into())
                     })?;
-                    self.trace_scope(&format!("insert LetNonRec {:?}", binder));
-                    self.env.insert(binder, val);
+                    args.ctx.trace_scope(&format!("insert LetNonRec {:?}", binder));
+                    args.ctx.env.insert(binder, val);
                 }
                 EmitWork::LetRecPostSimple { binder, state_idx } => {
                     let val = vals.pop().ok_or_else(|| {
                         EmitError::InternalError("LetRecPostSimple: empty value stack".into())
                     })?;
-                    self.trace_scope(&format!("insert LetRec(simple) {:?}", binder));
-                    self.env.insert(binder, val);
-                    self.letrec_post_simple_step(sess, builder, &binder, state_idx)?;
+                    args.ctx.trace_scope(&format!("insert LetRec(simple) {:?}", binder));
+                    args.ctx.env.insert(binder, val);
+                    Self::letrec_post_simple_step(
+                        EmitArgs {
+                            ctx: args.ctx,
+                            sess: args.sess,
+                            builder: args.builder,
+                        },
+                        &binder,
+                        state_idx,
+                    )?;
                 }
                 EmitWork::LetRecFinish {
                     body,
                     state_idx,
                     tail,
                 } => {
-                    self.letrec_finish_phases(sess, builder, state_idx)?;
+                    Self::letrec_finish_phases(
+                        EmitArgs {
+                            ctx: args.ctx,
+                            sess: args.sess,
+                            builder: args.builder,
+                        },
+                        state_idx,
+                    )?;
                     // Push body evaluation
                     work.push(EmitWork::Eval(body, tail));
                 }
                 EmitWork::LetCleanupMark(cleanup) => match cleanup {
                     LetCleanup::Single(var, old_val) => {
-                        self.trace_scope(&format!("restore LetCleanup {:?}", var));
-                        self.env.restore(var, old_val);
+                        args.ctx.trace_scope(&format!("restore LetCleanup {:?}", var));
+                        args.ctx.env.restore(var, old_val);
                     }
                     LetCleanup::Rec(scope) => {
-                        self.trace_scope("restore LetCleanup(rec)");
-                        self.env.restore_scope(scope);
+                        args.ctx.trace_scope("restore LetCleanup(rec)");
+                        args.ctx.env.restore_scope(scope);
                     }
                 },
             }
@@ -1367,38 +1559,57 @@ impl EmitContext {
     }
 
     fn emit_tail_app(
-        &mut self,
-        sess: &mut EmitSession,
-        builder: &mut FunctionBuilder,
+        args: EmitArgs,
         idx: usize,
     ) -> Result<SsaVal, EmitError> {
-        let (fun_idx, arg_idx) = match &sess.tree.nodes[idx] {
+        let (fun_idx, arg_idx) = match &args.sess.tree.nodes[idx] {
             CoreFrame::App { fun, arg } => (*fun, *arg),
             _ => unreachable!(),
         };
 
         // Evaluate fun and arg in NON-tail position
-        let fun_val = emit_subtree(self, sess, builder, fun_idx)?;
-        let arg_val = emit_subtree(self, sess, builder, arg_idx)?;
+        let fun_val = emit_subtree(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            fun_idx,
+        )?;
+        let arg_val = emit_subtree(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            arg_idx,
+        )?;
 
         let raw_fun_ptr = fun_val.value();
-        let arg_ptr = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, arg_val);
+        let arg_ptr = ensure_heap_ptr(
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
+            arg_val,
+        );
 
         // Force thunked function (same as regular App path)
-        let fun_tag = builder
+        let fun_tag = args
+            .builder
             .ins()
             .load(types::I8, MemFlags::trusted(), raw_fun_ptr, 0);
-        let is_thunk = builder.ins().icmp_imm(
+        let is_thunk = args.builder.ins().icmp_imm(
             IntCC::Equal,
             fun_tag,
             tidepool_heap::layout::TAG_THUNK as i64,
         );
 
-        let force_fun_block = builder.create_block();
-        let fun_ready_block = builder.create_block();
-        builder.append_block_param(fun_ready_block, types::I64);
+        let force_fun_block = args.builder.create_block();
+        let fun_ready_block = args.builder.create_block();
+        args.builder.append_block_param(fun_ready_block, types::I64);
 
-        builder.ins().brif(
+        args.builder.ins().brif(
             is_thunk,
             force_fun_block,
             &[],
@@ -1406,107 +1617,111 @@ impl EmitContext {
             &[BlockArg::Value(raw_fun_ptr)],
         );
 
-        builder.switch_to_block(force_fun_block);
-        builder.seal_block(force_fun_block);
+        args.builder.switch_to_block(force_fun_block);
+        args.builder.seal_block(force_fun_block);
 
-        let force_fn = sess
+        let force_fn = args
+            .sess
             .pipeline
             .module
             .declare_function("heap_force", Linkage::Import, &{
-                let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+                let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
                 sig.params.push(AbiParam::new(types::I64));
                 sig.params.push(AbiParam::new(types::I64));
                 sig.returns.push(AbiParam::new(types::I64));
                 sig
             })
             .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-        let force_ref = sess
+        let force_ref = args
+            .sess
             .pipeline
             .module
-            .declare_func_in_func(force_fn, builder.func);
-        let force_call = builder.ins().call(force_ref, &[sess.vmctx, raw_fun_ptr]);
-        let forced_fun = builder.inst_results(force_call)[0];
-        builder.declare_value_needs_stack_map(forced_fun);
-        builder
+            .declare_func_in_func(force_fn, args.builder.func);
+        let force_call = args
+            .builder
+            .ins()
+            .call(force_ref, &[args.sess.vmctx, raw_fun_ptr]);
+        let forced_fun = args.builder.inst_results(force_call)[0];
+        args.builder.declare_value_needs_stack_map(forced_fun);
+        args.builder
             .ins()
             .jump(fun_ready_block, &[BlockArg::Value(forced_fun)]);
 
-        builder.switch_to_block(fun_ready_block);
-        builder.seal_block(fun_ready_block);
-        let fun_ptr = builder.block_params(fun_ready_block)[0];
-        builder.declare_value_needs_stack_map(fun_ptr);
+        args.builder.switch_to_block(fun_ready_block);
+        args.builder.seal_block(fun_ready_block);
+        let fun_ptr = args.builder.block_params(fun_ready_block)[0];
+        args.builder.declare_value_needs_stack_map(fun_ptr);
 
         // Debug validation (same as regular App)
-        let check_fn = sess
+        let check_fn = args
+            .sess
             .pipeline
             .module
             .declare_function("debug_app_check", Linkage::Import, &{
-                let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+                let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
                 sig.params.push(AbiParam::new(types::I64));
                 sig.returns.push(AbiParam::new(types::I64));
                 sig
             })
             .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-        let check_ref = sess
+        let check_ref = args
+            .sess
             .pipeline
             .module
-            .declare_func_in_func(check_fn, builder.func);
-        let check_inst = builder.ins().call(check_ref, &[fun_ptr]);
-        let check_result = builder.inst_results(check_inst)[0];
+            .declare_func_in_func(check_fn, args.builder.func);
+        let check_inst = args.builder.ins().call(check_ref, &[fun_ptr]);
+        let check_result = args.builder.inst_results(check_inst)[0];
 
         // If debug_app_check returned non-zero (poison/error), return it directly
-        let store_block = builder.create_block();
-        let poison_block = builder.create_block();
+        let store_block = args.builder.create_block();
+        let poison_block = args.builder.create_block();
 
-        let is_zero = builder.ins().icmp_imm(IntCC::Equal, check_result, 0);
-        builder
+        let is_zero = args.builder.ins().icmp_imm(IntCC::Equal, check_result, 0);
+        args.builder
             .ins()
             .brif(is_zero, store_block, &[], poison_block, &[]);
 
         // poison_block: return poison (error already set by debug_app_check)
-        builder.switch_to_block(poison_block);
-        builder.seal_block(poison_block);
-        builder.ins().return_(&[check_result]);
+        args.builder.switch_to_block(poison_block);
+        args.builder.seal_block(poison_block);
+        args.builder.ins().return_(&[check_result]);
 
         // store_block: store callee+arg to VMContext, return null
-        builder.switch_to_block(store_block);
-        builder.seal_block(store_block);
+        args.builder.switch_to_block(store_block);
+        args.builder.seal_block(store_block);
 
         // Store fun_ptr (closure) to VMContext.tail_callee (offset 24)
-        builder.ins().store(
+        args.builder.ins().store(
             MemFlags::trusted(),
             fun_ptr,
-            sess.vmctx,
+            args.sess.vmctx,
             VMCTX_TAIL_CALLEE_OFFSET,
         );
         // Store arg_ptr to VMContext.tail_arg (offset 32)
-        builder.ins().store(
+        args.builder.ins().store(
             MemFlags::trusted(),
             arg_ptr,
-            sess.vmctx,
+            args.sess.vmctx,
             VMCTX_TAIL_ARG_OFFSET,
         );
 
         // Return null to signal tail call
-        let null_val = builder.ins().iconst(types::I64, 0);
-        builder.ins().return_(&[null_val]);
+        let null_val = args.builder.ins().iconst(types::I64, 0);
+        args.builder.ins().return_(&[null_val]);
 
         // Dead block for subsequent code
-        let dead_block = builder.create_block();
-        builder.switch_to_block(dead_block);
-        builder.seal_block(dead_block);
+        let dead_block = args.builder.create_block();
+        args.builder.switch_to_block(dead_block);
+        args.builder.seal_block(dead_block);
 
-        let dummy = builder.ins().iconst(types::I64, 0);
+        let dummy = args.builder.ins().iconst(types::I64, 0);
         Ok(SsaVal::HeapPtr(dummy))
     }
 
     /// Execute LetRec phases 1-3a inline, then push deferred-simple evals
     /// and finish onto the work stack.
-    #[allow(clippy::too_many_arguments)]
     fn emit_letrec_phases(
-        &mut self,
-        sess: &mut EmitSession,
-        builder: &mut FunctionBuilder,
+        args: EmitArgs,
         bindings: &[(VarId, usize)],
         body: usize,
         work: &mut Vec<EmitWork>,
@@ -1517,7 +1732,7 @@ impl EmitContext {
         let (rec_bindings, simple_bindings): (Vec<_>, Vec<_>) =
             bindings.iter().partition(|(_, rhs_idx)| {
                 matches!(
-                    &sess.tree.nodes[*rhs_idx],
+                    &args.sess.tree.nodes[*rhs_idx],
                     CoreFrame::Lam { .. } | CoreFrame::Con { .. }
                 )
             });
@@ -1525,7 +1740,7 @@ impl EmitContext {
         // If no recursive bindings, push simple evals onto work stack
         if rec_bindings.is_empty() {
             // Store empty deferred state for post-simple steps
-            let state_idx = self.push_letrec_state(LetRecDeferredState {
+            let state_idx = args.ctx.push_letrec_state(LetRecDeferredState {
                 pending_capture_updates: std::collections::HashMap::new(),
                 deferred_con_deps: Vec::new(),
             });
@@ -1537,11 +1752,11 @@ impl EmitContext {
                 tail,
             });
             for (binder, rhs_idx) in simple_bindings.iter().rev() {
-                if Self::rhs_is_error_call(sess.tree, *rhs_idx) {
-                    let poison_addr = self.emit_error_poison(sess.tree, *rhs_idx);
-                    let poison_val = builder.ins().iconst(types::I64, poison_addr);
-                    self.trace_scope(&format!("defer error LetRec(simple) {:?}", binder));
-                    self.env.insert(*binder, SsaVal::HeapPtr(poison_val));
+                if EmitContext::rhs_is_error_call(args.sess.tree, *rhs_idx) {
+                    let poison_addr = args.ctx.emit_error_poison(args.sess.tree, *rhs_idx);
+                    let poison_val = args.builder.ins().iconst(types::I64, poison_addr);
+                    args.ctx.trace_scope(&format!("defer error LetRec(simple) {:?}", binder));
+                    args.ctx.env.insert(*binder, SsaVal::HeapPtr(poison_val));
                 } else {
                     work.push(EmitWork::LetRecPostSimple {
                         binder: *binder,
@@ -1570,25 +1785,25 @@ impl EmitContext {
         let mut pre_allocs = Vec::with_capacity(rec_bindings.len());
 
         for (binder, rhs_idx) in &rec_bindings {
-            match &sess.tree.nodes[*rhs_idx] {
+            match &args.sess.tree.nodes[*rhs_idx] {
                 CoreFrame::Lam {
                     binder: lam_binder,
                     body: lam_body,
                 } => {
-                    let lam_body_tree = sess.tree.extract_subtree(*lam_body);
+                    let lam_body_tree = args.sess.tree.extract_subtree(*lam_body);
                     let mut fvs = tidepool_repr::free_vars::free_vars(&lam_body_tree);
                     fvs.remove(lam_binder);
                     let dropped_fvs: Vec<VarId> = fvs
                         .iter()
                         .filter(|v| {
-                            !self.env.contains_key(v)
+                            !args.ctx.env.contains_key(v)
                                 && !rec_bindings.iter().any(|(b, _)| b == *v)
                                 && !simple_bindings.iter().any(|(b, _)| b == *v)
                         })
                         .copied()
                         .collect();
                     if !dropped_fvs.is_empty() {
-                        self.trace_scope(&format!(
+                        args.ctx.trace_scope(&format!(
                             "LetRec lam {:?}: dropped FVs {:?}",
                             binder, dropped_fvs
                         ));
@@ -1596,7 +1811,7 @@ impl EmitContext {
                     let mut sorted_fvs: Vec<VarId> = fvs
                         .into_iter()
                         .filter(|v| {
-                            self.env.contains_key(v)
+                            args.ctx.env.contains_key(v)
                                 || rec_bindings.iter().any(|(b, _)| b == v)
                                 || simple_bindings.iter().any(|(b, _)| b == v)
                         })
@@ -1606,30 +1821,30 @@ impl EmitContext {
                     let num_captures = sorted_fvs.len();
                     let closure_size = 24 + 8 * num_captures as u64;
                     let closure_ptr = emit_alloc_fast_path(
-                        builder,
-                        sess.vmctx,
+                        args.builder,
+                        args.sess.vmctx,
                         closure_size,
-                        sess.gc_sig,
-                        sess.oom_func,
+                        args.sess.gc_sig,
+                        args.sess.oom_func,
                     );
 
-                    let tag_val = builder.ins().iconst(types::I8, layout::TAG_CLOSURE as i64);
-                    builder
+                    let tag_val = args.builder.ins().iconst(types::I8, layout::TAG_CLOSURE as i64);
+                    args.builder
                         .ins()
                         .store(MemFlags::trusted(), tag_val, closure_ptr, 0);
-                    let size_val = builder.ins().iconst(types::I16, closure_size as i64);
-                    builder
+                    let size_val = args.builder.ins().iconst(types::I16, closure_size as i64);
+                    args.builder
                         .ins()
                         .store(MemFlags::trusted(), size_val, closure_ptr, 1);
-                    let num_cap_val = builder.ins().iconst(types::I16, num_captures as i64);
-                    builder.ins().store(
+                    let num_cap_val = args.builder.ins().iconst(types::I16, num_captures as i64);
+                    args.builder.ins().store(
                         MemFlags::trusted(),
                         num_cap_val,
                         closure_ptr,
                         CLOSURE_NUM_CAPTURED_OFFSET,
                     );
 
-                    builder.declare_value_needs_stack_map(closure_ptr);
+                    args.builder.declare_value_needs_stack_map(closure_ptr);
                     pre_allocs.push(PreAlloc::Lam {
                         binder: *binder,
                         ptr: closure_ptr,
@@ -1640,19 +1855,28 @@ impl EmitContext {
                 CoreFrame::Con { tag, fields } => {
                     let num_fields = fields.len();
                     let size = 24 + 8 * num_fields as u64;
-                    let ptr =
-                        emit_alloc_fast_path(builder, sess.vmctx, size, sess.gc_sig, sess.oom_func);
+                    let ptr = emit_alloc_fast_path(
+                        args.builder,
+                        args.sess.vmctx,
+                        size,
+                        args.sess.gc_sig,
+                        args.sess.oom_func,
+                    );
 
-                    let tag_val = builder.ins().iconst(types::I8, layout::TAG_CON as i64);
-                    builder.ins().store(MemFlags::trusted(), tag_val, ptr, 0);
-                    let size_val = builder.ins().iconst(types::I16, size as i64);
-                    builder.ins().store(MemFlags::trusted(), size_val, ptr, 1);
-                    let con_tag_val = builder.ins().iconst(types::I64, tag.0 as i64);
-                    builder
+                    let tag_val = args.builder.ins().iconst(types::I8, layout::TAG_CON as i64);
+                    args.builder
+                        .ins()
+                        .store(MemFlags::trusted(), tag_val, ptr, 0);
+                    let size_val = args.builder.ins().iconst(types::I16, size as i64);
+                    args.builder
+                        .ins()
+                        .store(MemFlags::trusted(), size_val, ptr, 1);
+                    let con_tag_val = args.builder.ins().iconst(types::I64, tag.0 as i64);
+                    args.builder
                         .ins()
                         .store(MemFlags::trusted(), con_tag_val, ptr, CON_TAG_OFFSET);
-                    let num_fields_val = builder.ins().iconst(types::I16, num_fields as i64);
-                    builder.ins().store(
+                    let num_fields_val = args.builder.ins().iconst(types::I16, num_fields as i64);
+                    args.builder.ins().store(
                         MemFlags::trusted(),
                         num_fields_val,
                         ptr,
@@ -1661,15 +1885,15 @@ impl EmitContext {
 
                     // Zero-initialize Con fields so GC doesn't trace garbage
                     // if triggered before Phase 3b/3d.
-                    let null_val = builder.ins().iconst(types::I64, 0);
+                    let null_val = args.builder.ins().iconst(types::I64, 0);
                     for i in 0..num_fields {
                         let offset = CON_FIELDS_OFFSET + 8 * i as i32;
-                        builder
+                        args.builder
                             .ins()
                             .store(MemFlags::trusted(), null_val, ptr, offset);
                     }
 
-                    builder.declare_value_needs_stack_map(ptr);
+                    args.builder.declare_value_needs_stack_map(ptr);
                     pre_allocs.push(PreAlloc::Con {
                         binder: *binder,
                         ptr,
@@ -1691,8 +1915,8 @@ impl EmitContext {
                 PreAlloc::Lam { binder, ptr, .. } => (*binder, *ptr),
                 PreAlloc::Con { binder, ptr, .. } => (*binder, *ptr),
             };
-            self.trace_scope(&format!("insert LetRec(rec) {:?}", binder));
-            self.env.insert(binder, SsaVal::HeapPtr(ptr));
+            args.ctx.trace_scope(&format!("insert LetRec(rec) {:?}", binder));
+            args.ctx.env.insert(binder, SsaVal::HeapPtr(ptr));
         }
 
         // Phase 2.5: Evaluate trivial simple bindings (Var aliases) before
@@ -1700,23 +1924,30 @@ impl EmitContext {
         // on closure code pointers.
         let mut deferred_simple = Vec::with_capacity(simple_bindings.len());
         for (binder, rhs_idx) in &simple_bindings {
-            if Self::rhs_is_error_call(sess.tree, *rhs_idx) {
-                let poison_addr = self.emit_error_poison(sess.tree, *rhs_idx);
-                let poison_val = builder.ins().iconst(types::I64, poison_addr);
-                self.trace_scope(&format!("defer error LetRec(trivial) {:?}", binder));
-                self.env.insert(*binder, SsaVal::HeapPtr(poison_val));
-            } else if matches!(&sess.tree.nodes[*rhs_idx], CoreFrame::Var(_)) {
-                // Var aliases are trivial — just an env lookup via emit_subtree
-                let rhs_val = emit_subtree(self, sess, builder, *rhs_idx)?;
-                self.trace_scope(&format!("insert LetRec(trivial) {:?}", binder));
-                self.env.insert(*binder, rhs_val);
+            if EmitContext::rhs_is_error_call(args.sess.tree, *rhs_idx) {
+                let poison_addr = args.ctx.emit_error_poison(args.sess.tree, *rhs_idx);
+                let poison_val = args.builder.ins().iconst(types::I64, poison_addr);
+                args.ctx.trace_scope(&format!("defer error LetRec(trivial) {:?}", binder));
+                args.ctx.env.insert(*binder, SsaVal::HeapPtr(poison_val));
+            } else if matches!(&args.sess.tree.nodes[*rhs_idx], CoreFrame::Var(_)) {
+                // Var aliases are trivial \u2014 just an env lookup via emit_subtree
+                let rhs_val = emit_subtree(
+                    EmitArgs {
+                        ctx: args.ctx,
+                        sess: args.sess,
+                        builder: args.builder,
+                    },
+                    *rhs_idx,
+                )?;
+                args.ctx.trace_scope(&format!("insert LetRec(trivial) {:?}", binder));
+                args.ctx.env.insert(*binder, rhs_val);
             } else {
                 deferred_simple.push((*binder, *rhs_idx));
             }
         }
 
         // Phase 3a: Compile Lam bodies and set code pointers.
-        // Capture VALUES are NOT filled here — some captures reference
+        // Capture VALUES are NOT filled here \u2014 some captures reference
         // deferred simple bindings (Phase 3c) that aren't in env yet.
         let mut pending_capture_updates: std::collections::HashMap<VarId, Vec<ClosureCaptureSlot>> =
             std::collections::HashMap::with_capacity(rec_bindings.len());
@@ -1728,7 +1959,7 @@ impl EmitContext {
                 } => (*ptr, fvs, *rhs_idx),
                 PreAlloc::Con { .. } => continue,
             };
-            let (lam_binder, lam_body) = match &sess.tree.nodes[rhs_idx] {
+            let (lam_binder, lam_body) = match &args.sess.tree.nodes[rhs_idx] {
                 CoreFrame::Lam { binder, body } => (*binder, *body),
                 other => {
                     return Err(EmitError::InternalError(format!(
@@ -1737,21 +1968,23 @@ impl EmitContext {
                     )))
                 }
             };
-            let lam_body_tree = sess.tree.extract_subtree(lam_body);
+            let lam_body_tree = args.sess.tree.extract_subtree(lam_body);
 
-            let lambda_name = self.next_lambda_name();
-            let mut closure_sig = Signature::new(sess.pipeline.isa.default_call_conv());
+            let lambda_name = args.ctx.next_lambda_name();
+            let mut closure_sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
             closure_sig.params.push(AbiParam::new(types::I64));
             closure_sig.params.push(AbiParam::new(types::I64));
             closure_sig.params.push(AbiParam::new(types::I64));
             closure_sig.returns.push(AbiParam::new(types::I64));
 
-            let lambda_func_id = sess
+            let lambda_func_id = args
+                .sess
                 .pipeline
                 .module
                 .declare_function(&lambda_name, Linkage::Local, &closure_sig)
                 .map_err(|e| EmitError::CraneliftError(e.to_string()))?;
-            sess.pipeline
+            args.sess
+                .pipeline
                 .register_lambda(lambda_func_id, lambda_name.clone());
 
             let mut inner_ctx = Context::new();
@@ -1772,25 +2005,27 @@ impl EmitContext {
             inner_builder.declare_value_needs_stack_map(inner_self);
             inner_builder.declare_value_needs_stack_map(inner_arg);
 
-            let mut inner_gc_sig = Signature::new(sess.pipeline.isa.default_call_conv());
+            let mut inner_gc_sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
             inner_gc_sig.params.push(AbiParam::new(types::I64));
             let inner_gc_sig_ref = inner_builder.import_signature(inner_gc_sig);
 
             let inner_oom_func = {
-                let mut sig = Signature::new(sess.pipeline.isa.default_call_conv());
+                let mut sig = Signature::new(args.sess.pipeline.isa.default_call_conv());
                 sig.returns.push(AbiParam::new(types::I64));
-                let func_id = sess
+                let func_id = args
+                    .sess
                     .pipeline
                     .module
                     .declare_function("runtime_oom", Linkage::Import, &sig)
                     .map_err(|e| EmitError::CraneliftError(format!("declare runtime_oom: {e}")))?;
-                sess.pipeline
+                args.sess
+                    .pipeline
                     .module
                     .declare_func_in_func(func_id, inner_builder.func)
             };
 
-            let mut inner_emit = EmitContext::new(self.prefix.clone());
-            inner_emit.lambda_counter = self.lambda_counter;
+            let mut inner_emit = EmitContext::new(args.ctx.prefix.clone());
+            inner_emit.lambda_counter = args.ctx.lambda_counter;
             inner_emit
                 .env
                 .insert(lam_binder, SsaVal::HeapPtr(inner_arg));
@@ -1808,15 +2043,18 @@ impl EmitContext {
 
             let body_root = lam_body_tree.nodes.len() - 1;
             let mut inner_sess = EmitSession {
-                pipeline: sess.pipeline,
+                pipeline: args.sess.pipeline,
                 vmctx: inner_vmctx,
                 gc_sig: inner_gc_sig_ref,
                 oom_func: inner_oom_func,
                 tree: &lam_body_tree,
             };
-            let body_result = inner_emit.emit_node(
-                &mut inner_sess,
-                &mut inner_builder,
+            let body_result = EmitContext::emit_node(
+                EmitArgs {
+                    ctx: &mut inner_emit,
+                    sess: &mut inner_sess,
+                    builder: &mut inner_builder,
+                },
                 body_root,
                 TailCtx::Tail,
             )?;
@@ -1831,17 +2069,19 @@ impl EmitContext {
             inner_builder.ins().return_(&[ret_val]);
             inner_builder.finalize();
 
-            self.lambda_counter = inner_emit.lambda_counter;
+            args.ctx.lambda_counter = inner_emit.lambda_counter;
 
-            sess.pipeline
+            args.sess
+                .pipeline
                 .define_function(lambda_func_id, &mut inner_ctx)?;
 
-            let func_ref = sess
+            let func_ref = args
+                .sess
                 .pipeline
                 .module
-                .declare_func_in_func(lambda_func_id, builder.func);
-            let code_ptr = builder.ins().func_addr(types::I64, func_ref);
-            builder.ins().store(
+                .declare_func_in_func(lambda_func_id, args.builder.func);
+            let code_ptr = args.builder.ins().func_addr(types::I64, func_ref);
+            args.builder.ins().store(
                 MemFlags::trusted(),
                 code_ptr,
                 closure_ptr,
@@ -1849,10 +2089,10 @@ impl EmitContext {
             );
 
             // Zero-initialize capture slots so GC doesn't trace garbage
-            let null_val = builder.ins().iconst(types::I64, 0);
+            let null_val = args.builder.ins().iconst(types::I64, 0);
             for i in 0..sorted_fvs.len() {
                 let offset = CLOSURE_CAPTURED_OFFSET + 8 * i as i32;
-                builder
+                args.builder
                     .ins()
                     .store(MemFlags::trusted(), null_val, closure_ptr, offset);
             }
@@ -1860,10 +2100,15 @@ impl EmitContext {
             // Fill captures already in env. Defer those referencing deferred simple bindings.
             for (i, var_id) in sorted_fvs.iter().enumerate() {
                 let offset = CLOSURE_CAPTURED_OFFSET + 8 * i as i32;
-                if let Some(ssaval) = self.env.get(var_id) {
-                    let cap_val =
-                        ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *ssaval);
-                    builder
+                if let Some(ssaval) = args.ctx.env.get(var_id) {
+                    let cap_val = ensure_heap_ptr(
+                        args.builder,
+                        args.sess.vmctx,
+                        args.sess.gc_sig,
+                        args.sess.oom_func,
+                        *ssaval,
+                    );
+                    args.builder
                         .ins()
                         .store(MemFlags::trusted(), cap_val, closure_ptr, offset);
                 } else {
@@ -1891,20 +2136,40 @@ impl EmitContext {
             } = pa
             {
                 let needs_simple = field_indices.iter().any(|&f_idx| {
-                    matches!(&sess.tree.nodes[f_idx], CoreFrame::Var(v) if simple_binder_set.contains(v))
+                    matches!(&args.sess.tree.nodes[f_idx], CoreFrame::Var(v) if simple_binder_set.contains(v))
                 });
                 if needs_simple {
                     deferred_cons.push((*binder, *ptr, field_indices.clone()));
                 } else {
                     for (i, &f_idx) in field_indices.iter().enumerate() {
-                        let field_val = if is_trivial_field(f_idx, sess.tree) {
-                            let val = emit_subtree(self, sess, builder, f_idx)?;
-                            ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, val)
+                        let field_val = if is_trivial_field(f_idx, args.sess.tree) {
+                            let val = emit_subtree(
+                                EmitArgs {
+                                    ctx: args.ctx,
+                                    sess: args.sess,
+                                    builder: args.builder,
+                                },
+                                f_idx,
+                            )?;
+                            ensure_heap_ptr(
+                                args.builder,
+                                args.sess.vmctx,
+                                args.sess.gc_sig,
+                                args.sess.oom_func,
+                                val,
+                            )
                         } else {
-                            let thunk_val = emit_thunk(self, sess, builder, f_idx)?;
+                            let thunk_val = emit_thunk(
+                                EmitArgs {
+                                    ctx: args.ctx,
+                                    sess: args.sess,
+                                    builder: args.builder,
+                                },
+                                f_idx,
+                            )?;
                             thunk_val.value()
                         };
-                        builder.ins().store(
+                        args.builder.ins().store(
                             MemFlags::trusted(),
                             field_val,
                             *ptr,
@@ -1923,7 +2188,8 @@ impl EmitContext {
             let mut direct_deps: std::collections::HashMap<VarId, Vec<VarId>> =
                 std::collections::HashMap::with_capacity(bindings.len());
             for (binder, rhs_idx) in bindings {
-                let fvs = tidepool_repr::free_vars::free_vars(&sess.tree.extract_subtree(*rhs_idx));
+                let fvs =
+                    tidepool_repr::free_vars::free_vars(&args.sess.tree.extract_subtree(*rhs_idx));
                 direct_deps.insert(*binder, fvs.into_iter().collect());
             }
 
@@ -1981,7 +2247,7 @@ impl EmitContext {
             let deps: std::collections::HashSet<VarId> = field_indices
                 .iter()
                 .filter_map(|&f_idx| {
-                    if let CoreFrame::Var(v) = &sess.tree.nodes[f_idx] {
+                    if let CoreFrame::Var(v) = &args.sess.tree.nodes[f_idx] {
                         if simple_binder_set.contains(v) {
                             return Some(*v);
                         }
@@ -1997,7 +2263,7 @@ impl EmitContext {
         }
 
         // Store deferred state for LetRecSimpleEval/LetRecPostSimple/LetRecFinish
-        let state_idx = self.push_letrec_state(LetRecDeferredState {
+        let state_idx = args.ctx.push_letrec_state(LetRecDeferredState {
             pending_capture_updates,
             deferred_con_deps,
         });
@@ -2010,19 +2276,27 @@ impl EmitContext {
         });
 
         for (binder, rhs_idx) in deferred_simple.iter().rev() {
-            if Self::rhs_is_error_call(sess.tree, *rhs_idx) {
-                let poison_addr = self.emit_error_poison(sess.tree, *rhs_idx);
-                let poison_val = builder.ins().iconst(types::I64, poison_addr);
-                self.trace_scope(&format!("defer error LetRec(deferred) {:?}", binder));
-                self.env.insert(*binder, SsaVal::HeapPtr(poison_val));
+            if EmitContext::rhs_is_error_call(args.sess.tree, *rhs_idx) {
+                let poison_addr = args.ctx.emit_error_poison(args.sess.tree, *rhs_idx);
+                let poison_val = args.builder.ins().iconst(types::I64, poison_addr);
+                args.ctx.trace_scope(&format!("defer error LetRec(deferred) {:?}", binder));
+                args.ctx.env.insert(*binder, SsaVal::HeapPtr(poison_val));
                 // Run post-step inline: closures may capture error-poisoned
                 // bindings, and deferred Cons may depend on them. Without this,
-                // capture slots stay zero-initialized → SIGSEGV instead of
+                // capture slots stay zero-initialized \u2192 SIGSEGV instead of
                 // clean poison closure invocation.
-                self.letrec_post_simple_step(sess, builder, binder, state_idx)?;
+                Self::letrec_post_simple_step(
+                    EmitArgs {
+                        ctx: args.ctx,
+                        sess: args.sess,
+                        builder: args.builder,
+                    },
+                    binder,
+                    state_idx,
+                )?;
             } else {
-                let refs_deferred_con = !self.letrec_state(state_idx).deferred_con_deps.is_empty()
-                    && self
+                let refs_deferred_con = !args.ctx.letrec_state(state_idx).deferred_con_deps.is_empty()
+                    && args.ctx
                         .letrec_state(state_idx)
                         .deferred_con_deps
                         .iter()
@@ -2030,23 +2304,38 @@ impl EmitContext {
                 // Check if thunkification would drop sibling deps: emit_thunk
                 // creates a fresh EmitContext and only captures vars in the
                 // current env. Sibling deferred simple bindings not yet in env
-                // would be dropped from captures → unresolved var at runtime.
+                // would be dropped from captures \u2192 unresolved var at runtime.
                 let can_thunkify = if refs_deferred_con {
-                    let body_tree = sess.tree.extract_subtree(*rhs_idx);
+                    let body_tree = args.sess.tree.extract_subtree(*rhs_idx);
                     let fvs = tidepool_repr::free_vars::free_vars(&body_tree);
                     !fvs.iter().any(|v| {
-                        !self.env.contains_key(v) && deferred_simple.iter().any(|(b, _)| b == v)
+                        !args.ctx.env.contains_key(v) && deferred_simple.iter().any(|(b, _)| b == v)
                     })
                 } else {
                     false
                 };
                 if can_thunkify {
                     // Thunked: compile as thunk inline (no work stack needed,
-                    // emit_thunk creates a new EmitContext — bounded recursion).
-                    let thunk_val = emit_thunk(self, sess, builder, *rhs_idx)?;
-                    self.trace_scope(&format!("insert LetRec(simple) {:?}", binder));
-                    self.env.insert(*binder, thunk_val);
-                    self.letrec_post_simple_step(sess, builder, binder, state_idx)?;
+                    // emit_thunk creates a new EmitContext \u2014 bounded recursion).
+                    let thunk_val = emit_thunk(
+                        EmitArgs {
+                            ctx: args.ctx,
+                            sess: args.sess,
+                            builder: args.builder,
+                        },
+                        *rhs_idx,
+                    )?;
+                    args.ctx.trace_scope(&format!("insert LetRec(simple) {:?}", binder));
+                    args.ctx.env.insert(*binder, thunk_val);
+                    Self::letrec_post_simple_step(
+                        EmitArgs {
+                            ctx: args.ctx,
+                            sess: args.sess,
+                            builder: args.builder,
+                        },
+                        binder,
+                        state_idx,
+                    )?;
                 } else {
                     // Non-thunked: push eval + post-step onto work stack
                     work.push(EmitWork::LetRecPostSimple {
@@ -2063,25 +2352,22 @@ impl EmitContext {
 
     /// Post-step after evaluating a deferred simple binding: fill pending
     /// captures and incrementally fill deferred Con fields.
-    #[allow(clippy::too_many_arguments)]
     fn letrec_post_simple_step(
-        &mut self,
-        sess: &mut EmitSession,
-        builder: &mut FunctionBuilder,
+        args: EmitArgs,
         binder: &VarId,
         state_idx: LetRecStateId,
     ) -> Result<(), EmitError> {
-        // Fill pending captures — take updates out to avoid borrowing self
-        let updates = self
+        // Fill pending captures \u2014 take updates out to avoid borrowing self
+        let updates = args.ctx
             .letrec_state_mut(state_idx)
             .pending_capture_updates
             .remove(binder);
         if let Some(updates) = updates {
-            if let Some(ssaval) = self.env.get(binder) {
+            if let Some(ssaval) = args.ctx.env.get(binder) {
                 let cap_val =
-                    ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *ssaval);
+                    ensure_heap_ptr(args.builder, args.sess.vmctx, args.sess.gc_sig, args.sess.oom_func, *ssaval);
                 for slot in updates {
-                    builder.ins().store(
+                    args.builder.ins().store(
                         MemFlags::trusted(),
                         cap_val,
                         slot.closure_ptr,
@@ -2094,19 +2380,33 @@ impl EmitContext {
         // Incrementally fill deferred Cons whose deps are all satisfied.
         // Take out deferred_con_deps to avoid double-borrowing self
         // (emit_subtree/emit_thunk need &mut self).
-        let mut con_deps = std::mem::take(&mut self.letrec_state_mut(state_idx).deferred_con_deps);
+        let mut con_deps = std::mem::take(&mut args.ctx.letrec_state_mut(state_idx).deferred_con_deps);
         for dep in con_deps.iter_mut() {
             dep.remaining_deps.remove(binder);
             if dep.remaining_deps.is_empty() && !dep.field_indices.is_empty() {
                 for (i, &f_idx) in dep.field_indices.iter().enumerate() {
-                    let field_val = if is_trivial_field(f_idx, sess.tree) {
-                        let val = emit_subtree(self, sess, builder, f_idx)?;
-                        ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, val)
+                    let field_val = if is_trivial_field(f_idx, args.sess.tree) {
+                        let val = emit_subtree(
+                            EmitArgs {
+                                ctx: args.ctx,
+                                sess: args.sess,
+                                builder: args.builder,
+                            },
+                            f_idx,
+                        )?;
+                        ensure_heap_ptr(args.builder, args.sess.vmctx, args.sess.gc_sig, args.sess.oom_func, val)
                     } else {
-                        let thunk_val = emit_thunk(self, sess, builder, f_idx)?;
+                        let thunk_val = emit_thunk(
+                            EmitArgs {
+                                ctx: args.ctx,
+                                sess: args.sess,
+                                builder: args.builder,
+                            },
+                            f_idx,
+                        )?;
                         thunk_val.value()
                     };
-                    builder.ins().store(
+                    args.builder.ins().store(
                         MemFlags::trusted(),
                         field_val,
                         dep.ptr,
@@ -2116,48 +2416,59 @@ impl EmitContext {
                 dep.field_indices.clear();
             }
         }
-        self.letrec_state_mut(state_idx).deferred_con_deps = con_deps;
+        args.ctx.letrec_state_mut(state_idx).deferred_con_deps = con_deps;
 
         Ok(())
     }
 
     /// LetRec phases 3a' and 3d: fill remaining captures and Con fields.
-    #[allow(clippy::too_many_arguments)]
     fn letrec_finish_phases(
-        &mut self,
-        sess: &mut EmitSession,
-        builder: &mut FunctionBuilder,
+        args: EmitArgs,
         state_idx: LetRecStateId,
     ) -> Result<(), EmitError> {
         // Phase 3a': Fill any remaining closure capture slots.
-        let pending = std::mem::take(&mut self.letrec_state_mut(state_idx).pending_capture_updates);
+        let pending = std::mem::take(&mut args.ctx.letrec_state_mut(state_idx).pending_capture_updates);
         for (var_id, updates) in pending {
-            let ssaval = self.env.get(&var_id).ok_or_else(|| {
+            let ssaval = args.ctx.env.get(&var_id).ok_or_else(|| {
                 EmitError::MissingCaptureVar(
                     var_id,
                     "LetRec Phase 3a' capture fill: not in env after Phase 3c".into(),
                 )
             })?;
-            let cap_val = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, *ssaval);
+            let cap_val = ensure_heap_ptr(args.builder, args.sess.vmctx, args.sess.gc_sig, args.sess.oom_func, *ssaval);
             for slot in updates {
-                builder
+                args.builder
                     .ins()
                     .store(MemFlags::trusted(), cap_val, slot.closure_ptr, slot.offset);
             }
         }
 
         // Phase 3d: Fill any deferred Con fields not already filled.
-        let con_deps = std::mem::take(&mut self.letrec_state_mut(state_idx).deferred_con_deps);
+        let con_deps = std::mem::take(&mut args.ctx.letrec_state_mut(state_idx).deferred_con_deps);
         for dep in &con_deps {
             for (i, &f_idx) in dep.field_indices.iter().enumerate() {
-                let field_val = if is_trivial_field(f_idx, sess.tree) {
-                    let val = emit_subtree(self, sess, builder, f_idx)?;
-                    ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, val)
+                let field_val = if is_trivial_field(f_idx, args.sess.tree) {
+                    let val = emit_subtree(
+                        EmitArgs {
+                            ctx: args.ctx,
+                            sess: args.sess,
+                            builder: args.builder,
+                        },
+                        f_idx,
+                    )?;
+                    ensure_heap_ptr(args.builder, args.sess.vmctx, args.sess.gc_sig, args.sess.oom_func, val)
                 } else {
-                    let thunk_val = emit_thunk(self, sess, builder, f_idx)?;
+                    let thunk_val = emit_thunk(
+                        EmitArgs {
+                            ctx: args.ctx,
+                            sess: args.sess,
+                            builder: args.builder,
+                        },
+                        f_idx,
+                    )?;
                     thunk_val.value()
                 };
-                builder.ins().store(
+                args.builder.ins().store(
                     MemFlags::trusted(),
                     field_val,
                     dep.ptr,
@@ -2190,7 +2501,7 @@ pub(crate) struct LetRecStateId(usize);
 /// Work items for the emit_node trampoline. Replaces recursive calls
 /// with an explicit LIFO stack.
 enum EmitWork {
-    /// Evaluate node at tree index with given tail context → push result onto value stack
+    /// Evaluate node at tree index with given tail context \u2192 push result onto value stack
     Eval(usize, TailCtx),
     /// Pop value stack, bind to env
     Bind(VarId),

--- a/tidepool-codegen/src/emit/join.rs
+++ b/tidepool-codegen/src/emit/join.rs
@@ -1,38 +1,34 @@
 use crate::emit::expr::ensure_heap_ptr;
 use crate::emit::*;
 use cranelift_codegen::ir::{types, BlockArg, InstBuilder, Value};
-use cranelift_frontend::FunctionBuilder;
 use tidepool_repr::*;
 
 /// Emits a Join expression.
 /// Join { label, params, rhs, body } creates a join point (a parameterized block)
 /// that can be jumped to from within the body.
-#[allow(clippy::too_many_arguments)]
 pub fn emit_join(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     label: &JoinId,
     params: &[VarId],
     rhs_idx: usize,
     body_idx: usize,
 ) -> Result<SsaVal, EmitError> {
     // 1. Create a new block for the join point
-    let join_block = builder.create_block();
+    let join_block = args.builder.create_block();
 
     // 2. Add block params — one I64 param per join parameter
     for _ in params {
-        builder.append_block_param(join_block, types::I64);
+        args.builder.append_block_param(join_block, types::I64);
     }
 
     // 3. Create a continuation/merge block for the result
-    let merge_block = builder.create_block();
-    builder.append_block_param(merge_block, types::I64); // result
+    let merge_block = args.builder.create_block();
+    args.builder.append_block_param(merge_block, types::I64); // result
 
     // 4. Register the join point in ctx
     // We use a dummy Value(0) for param_types since Jump just needs to know they are heap pointers.
     let dummy_val = Value::from_u32(0);
-    ctx.join_blocks.register(
+    args.ctx.join_blocks.register(
         *label,
         JoinInfo {
             block: join_block,
@@ -41,47 +37,78 @@ pub fn emit_join(
     );
 
     // 5. Emit body (the continuation that may contain Jumps)
-    let body_result = ctx.emit_node(sess, builder, body_idx, TailCtx::NonTail)?;
-    let body_val = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, body_result);
-    builder
+    let body_result = EmitContext::emit_node(
+        EmitArgs {
+            ctx: args.ctx,
+            sess: args.sess,
+            builder: args.builder,
+        },
+        body_idx,
+        TailCtx::NonTail,
+    )?;
+    let body_val = ensure_heap_ptr(
+        args.builder,
+        args.sess.vmctx,
+        args.sess.gc_sig,
+        args.sess.oom_func,
+        body_result,
+    );
+    args.builder
         .ins()
         .jump(merge_block, &[BlockArg::Value(body_val)]);
 
     // 6. Switch to join block, emit rhs
-    builder.switch_to_block(join_block);
-    ctx.declare_env(builder);
+    args.builder.switch_to_block(join_block);
+    args.ctx.declare_env(args.builder);
 
     // Bind params to block params
-    let block_params = builder.block_params(join_block).to_vec();
+    let block_params = args.builder.block_params(join_block).to_vec();
     let mut scope = EnvScope::new();
     // NOTE: EnvGuard cannot be used here because it would borrow ctx.env mutably,
     // preventing the use of ctx in emit_node.
     for (i, param_var) in params.iter().enumerate() {
         let val = block_params[i];
-        builder.declare_value_needs_stack_map(val); // CRITICAL
-        ctx.env
+        args.builder.declare_value_needs_stack_map(val); // CRITICAL
+        args.ctx
+            .env
             .insert_scoped(&mut scope, *param_var, SsaVal::HeapPtr(val));
     }
 
-    let rhs_result = ctx.emit_node(sess, builder, rhs_idx, TailCtx::NonTail)?;
-    let rhs_val = ensure_heap_ptr(builder, sess.vmctx, sess.gc_sig, sess.oom_func, rhs_result);
-    builder.ins().jump(merge_block, &[BlockArg::Value(rhs_val)]);
+    let rhs_result = EmitContext::emit_node(
+        EmitArgs {
+            ctx: args.ctx,
+            sess: args.sess,
+            builder: args.builder,
+        },
+        rhs_idx,
+        TailCtx::NonTail,
+    )?;
+    let rhs_val = ensure_heap_ptr(
+        args.builder,
+        args.sess.vmctx,
+        args.sess.gc_sig,
+        args.sess.oom_func,
+        rhs_result,
+    );
+    args.builder
+        .ins()
+        .jump(merge_block, &[BlockArg::Value(rhs_val)]);
 
     // 7. Seal blocks
     // Body is emitted, so all Jumps to join_block are known.
-    builder.seal_block(join_block);
+    args.builder.seal_block(join_block);
     // Both body and rhs paths to merge_block are known.
-    builder.seal_block(merge_block);
+    args.builder.seal_block(merge_block);
 
     // 8. Switch to merge block, get result
-    builder.switch_to_block(merge_block);
-    let result = builder.block_params(merge_block)[0];
-    builder.declare_value_needs_stack_map(result); // CRITICAL
-    ctx.declare_env(builder);
+    args.builder.switch_to_block(merge_block);
+    let result = args.builder.block_params(merge_block)[0];
+    args.builder.declare_value_needs_stack_map(result); // CRITICAL
+    args.ctx.declare_env(args.builder);
 
     // 9. Clean up
-    ctx.join_blocks.remove(label);
-    ctx.env.restore_scope(scope);
+    args.ctx.join_blocks.remove(label);
+    args.ctx.env.restore_scope(scope);
 
     // 10. Return result
     Ok(SsaVal::HeapPtr(result))
@@ -89,16 +116,13 @@ pub fn emit_join(
 
 /// Emits a Jump expression.
 /// Jump { label, args } transfers control to the join point block.
-#[allow(clippy::too_many_arguments)]
 pub fn emit_jump(
-    ctx: &mut EmitContext,
-    sess: &mut EmitSession,
-    builder: &mut FunctionBuilder,
+    args: EmitArgs,
     label: &JoinId,
     arg_indices: &[usize],
 ) -> Result<SsaVal, EmitError> {
     // 1. Look up label in ctx.join_blocks
-    let join_block = ctx.join_blocks.get(label)?.block;
+    let join_block = args.ctx.join_blocks.get(label)?.block;
 
     // 2. Emit each arg
     let mut arg_values: Vec<BlockArg> = Vec::new();
@@ -106,29 +130,37 @@ pub fn emit_jump(
         // Jump arguments are always evaluated before we emit the jump terminator,
         // so they are not in tail position. Do NOT propagate any surrounding tail
         // context into these expressions: they must always be emitted as NonTail.
-        let val = ctx.emit_node(sess, builder, arg_idx, TailCtx::NonTail)?;
+        let val = EmitContext::emit_node(
+            EmitArgs {
+                ctx: args.ctx,
+                sess: args.sess,
+                builder: args.builder,
+            },
+            arg_idx,
+            TailCtx::NonTail,
+        )?;
         // 3. Ensure all args are HeapPtr
         arg_values.push(BlockArg::Value(ensure_heap_ptr(
-            builder,
-            sess.vmctx,
-            sess.gc_sig,
-            sess.oom_func,
+            args.builder,
+            args.sess.vmctx,
+            args.sess.gc_sig,
+            args.sess.oom_func,
             val,
         )));
     }
 
     // 4. Jump
-    builder.ins().jump(join_block, &arg_values);
+    args.builder.ins().jump(join_block, &arg_values);
 
     // 5. After a jump, the current block is terminated.
     // Create a new unreachable block so Cranelift doesn't complain about instructions after a terminator.
-    let unreachable_block = builder.create_block();
-    builder.switch_to_block(unreachable_block);
-    builder.seal_block(unreachable_block);
+    let unreachable_block = args.builder.create_block();
+    args.builder.switch_to_block(unreachable_block);
+    args.builder.seal_block(unreachable_block);
 
     // 6. Return a dummy SsaVal (dead code)
     Ok(SsaVal::Raw(
-        builder.ins().iconst(types::I64, 0),
+        args.builder.ins().iconst(types::I64, 0),
         LIT_TAG_INT,
     ))
 }

--- a/tidepool-codegen/src/emit/mod.rs
+++ b/tidepool-codegen/src/emit/mod.rs
@@ -138,6 +138,14 @@ pub struct EmitContext {
     pub(crate) letrec_states: Vec<crate::emit::expr::LetRecDeferredState>,
 }
 
+/// Bundles the three most common parameters for emission functions to reduce
+/// argument count and satisfy clippy::too_many_arguments.
+pub struct EmitArgs<'a, 'b, 'c> {
+    pub ctx: &'a mut EmitContext,
+    pub sess: &'a mut EmitSession<'b>,
+    pub builder: &'a mut cranelift_frontend::FunctionBuilder<'c>,
+}
+
 pub(crate) struct JoinPointRegistry {
     blocks: HashMap<JoinId, JoinInfo>,
 }


### PR DESCRIPTION
This PR reduces `too_many_arguments` clippy suppressions in `tidepool-codegen/src/emit/*.rs` by bundling the three most repeated parameters (`EmitContext`, `EmitSession`, and `FunctionBuilder`) into a new `EmitArgs` struct.

### Changes:
- Added `EmitArgs` struct in `tidepool-codegen/src/emit/mod.rs`.
- Refactored `collapse_frame`, `emit_subtree`, `emit_lam`, `emit_thunk`, `emit_node`, `emit_letrec_phases`, and related functions in `expr.rs`, `case.rs`, and `join.rs` to take `EmitArgs` instead of individual parameters.
- Removed all `#[allow(clippy::too_many_arguments)]` suppressions in the affected files.
- Ensured all tests pass and clippy is happy with the new structure.

No logic or behavior changes were made.