### PR TITLE
Refactor: implement sealed trait pattern for FromCore/ToCore (v2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
  "ciborium",
  "proptest",
  "serial_test",
+ "thiserror 2.0.18",
  "tidepool-testing",
 ]
 
@@ -3605,7 +3606,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rustyline",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tidepool-bridge",
  "tidepool-bridge-derive",
  "tidepool-codegen",

--- a/tidepool-bridge-derive/src/codegen.rs
+++ b/tidepool-bridge-derive/src/codegen.rs
@@ -116,6 +116,8 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
+        impl #impl_generics tidepool_bridge::FromCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
                 match value {
@@ -185,6 +187,8 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
+        impl #impl_generics tidepool_bridge::ToCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
                 match self {
@@ -228,6 +232,8 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
+        impl #impl_generics tidepool_bridge::FromCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
                 match value {
@@ -296,6 +302,8 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
+        impl #impl_generics tidepool_bridge::ToCoreSealed for #name #ty_generics #where_clause {}
+
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
                 let #destructure = self;

--- a/tidepool-bridge-derive/src/codegen.rs
+++ b/tidepool-bridge-derive/src/codegen.rs
@@ -116,7 +116,7 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
-        impl #impl_generics tidepool_bridge::FromCoreSealed for #name #ty_generics #where_clause {}
+        impl #impl_generics tidepool_bridge::__private::Sealed<tidepool_bridge::FromCoreMarker> for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
@@ -187,7 +187,7 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
-        impl #impl_generics tidepool_bridge::ToCoreSealed for #name #ty_generics #where_clause {}
+        impl #impl_generics tidepool_bridge::__private::Sealed<tidepool_bridge::ToCoreMarker> for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
@@ -232,7 +232,7 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
-        impl #impl_generics tidepool_bridge::FromCoreSealed for #name #ty_generics #where_clause {}
+        impl #impl_generics tidepool_bridge::__private::Sealed<tidepool_bridge::FromCoreMarker> for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
@@ -302,7 +302,7 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
-        impl #impl_generics tidepool_bridge::ToCoreSealed for #name #ty_generics #where_clause {}
+        impl #impl_generics tidepool_bridge::__private::Sealed<tidepool_bridge::ToCoreMarker> for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -29,6 +29,9 @@ fn type_mismatch(expected: &str, got: &Value) -> BridgeError {
     }
 }
 
+impl<T> crate::traits::FromCoreSealed for std::marker::PhantomData<T> {}
+impl<T> crate::traits::ToCoreSealed for std::marker::PhantomData<T> {}
+
 impl<T> FromCore for std::marker::PhantomData<T> {
     fn from_value(value: &Value, _table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -60,6 +63,9 @@ impl<T> ToCore for std::marker::PhantomData<T> {
 
 // Box
 
+impl crate::traits::FromCoreSealed for Value {}
+impl crate::traits::ToCoreSealed for Value {}
+
 // Value identity — pass through without conversion.
 impl ToCore for Value {
     fn to_value(&self, _table: &DataConTable) -> Result<Value, BridgeError> {
@@ -72,6 +78,9 @@ impl FromCore for Value {
         Ok(value.clone())
     }
 }
+
+impl<T> crate::traits::FromCoreSealed for Box<T> {}
+impl<T> crate::traits::ToCoreSealed for Box<T> {}
 
 impl<T: FromCore> FromCore for Box<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -86,6 +95,9 @@ impl<T: ToCore> ToCore for Box<T> {
 }
 
 // Unit
+
+impl crate::traits::FromCoreSealed for () {}
+impl crate::traits::ToCoreSealed for () {}
 
 impl ToCore for () {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
@@ -106,6 +118,9 @@ impl FromCore for () {
 }
 
 // Primitives
+
+impl crate::traits::FromCoreSealed for i64 {}
+impl crate::traits::ToCoreSealed for i64 {}
 
 /// Bridges Rust `i64` to Haskell `Int#` literal.
 /// Also transparently unwraps `I#(n)` (boxed Int).
@@ -134,6 +149,9 @@ impl ToCore for i64 {
     }
 }
 
+impl crate::traits::FromCoreSealed for u64 {}
+impl crate::traits::ToCoreSealed for u64 {}
+
 /// Bridges Rust `u64` to Haskell `Word#` literal.
 /// Also transparently unwraps `W#(n)` (boxed Word).
 impl FromCore for u64 {
@@ -160,6 +178,9 @@ impl ToCore for u64 {
         Ok(Value::Con(id, vec![Value::Lit(Literal::LitWord(*self))]))
     }
 }
+
+impl crate::traits::FromCoreSealed for f64 {}
+impl crate::traits::ToCoreSealed for f64 {}
 
 /// Bridges Rust `f64` to Haskell `Double#` literal.
 /// Also transparently unwraps `D#(n)` (boxed Double).
@@ -191,6 +212,9 @@ impl ToCore for f64 {
     }
 }
 
+impl crate::traits::FromCoreSealed for i32 {}
+impl crate::traits::ToCoreSealed for i32 {}
+
 /// Bridges Rust `i32` to Haskell `Int#` literal.
 /// Returns error on overflow/underflow.
 impl FromCore for i32 {
@@ -211,6 +235,9 @@ impl ToCore for i32 {
         (*self as i64).to_value(table)
     }
 }
+
+impl crate::traits::FromCoreSealed for bool {}
+impl crate::traits::ToCoreSealed for bool {}
 
 /// Bridges Rust `bool` to Haskell `Bool` (True/False constructors).
 impl FromCore for bool {
@@ -263,6 +290,9 @@ impl ToCore for bool {
     }
 }
 
+impl crate::traits::FromCoreSealed for char {}
+impl crate::traits::ToCoreSealed for char {}
+
 /// Also transparently unwraps `C#(c)` (boxed Char).
 impl FromCore for char {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -288,6 +318,9 @@ impl ToCore for char {
         Ok(Value::Con(id, vec![Value::Lit(Literal::LitChar(*self))]))
     }
 }
+
+impl crate::traits::FromCoreSealed for String {}
+impl crate::traits::ToCoreSealed for String {}
 
 impl FromCore for String {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -405,6 +438,9 @@ impl ToCore for String {
 
 // Containers
 
+impl<T> crate::traits::FromCoreSealed for Option<T> {}
+impl<T> crate::traits::ToCoreSealed for Option<T> {}
+
 impl<T: FromCore> FromCore for Option<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -463,6 +499,9 @@ impl<T: ToCore> ToCore for Option<T> {
         }
     }
 }
+
+impl<T> crate::traits::FromCoreSealed for Vec<T> {}
+impl<T> crate::traits::ToCoreSealed for Vec<T> {}
 
 impl<T: FromCore> FromCore for Vec<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -529,6 +568,9 @@ impl<T: ToCore> ToCore for Vec<T> {
     }
 }
 
+impl<T, E> crate::traits::FromCoreSealed for Result<T, E> {}
+impl<T, E> crate::traits::ToCoreSealed for Result<T, E> {}
+
 impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -594,6 +636,9 @@ impl<T: ToCore, E: ToCore> ToCore for Result<T, E> {
 
 // Tuples
 
+impl<A, B> crate::traits::FromCoreSealed for (A, B) {}
+impl<A, B> crate::traits::ToCoreSealed for (A, B) {}
+
 impl<A: FromCore, B: FromCore> FromCore for (A, B) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -634,6 +679,9 @@ impl<A: ToCore, B: ToCore> ToCore for (A, B) {
         ))
     }
 }
+
+impl<A, B, C> crate::traits::FromCoreSealed for (A, B, C) {}
+impl<A, B, C> crate::traits::ToCoreSealed for (A, B, C) {}
 
 impl<A: FromCore, B: FromCore, C: FromCore> FromCore for (A, B, C) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -29,8 +29,8 @@ fn type_mismatch(expected: &str, got: &Value) -> BridgeError {
     }
 }
 
-impl<T> crate::traits::FromCoreSealed for std::marker::PhantomData<T> {}
-impl<T> crate::traits::ToCoreSealed for std::marker::PhantomData<T> {}
+impl<T> crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for std::marker::PhantomData<T> {}
+impl<T> crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for std::marker::PhantomData<T> {}
 
 impl<T> FromCore for std::marker::PhantomData<T> {
     fn from_value(value: &Value, _table: &DataConTable) -> Result<Self, BridgeError> {
@@ -63,8 +63,8 @@ impl<T> ToCore for std::marker::PhantomData<T> {
 
 // Box
 
-impl crate::traits::FromCoreSealed for Value {}
-impl crate::traits::ToCoreSealed for Value {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for Value {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for Value {}
 
 // Value identity — pass through without conversion.
 impl ToCore for Value {
@@ -79,8 +79,8 @@ impl FromCore for Value {
     }
 }
 
-impl<T> crate::traits::FromCoreSealed for Box<T> {}
-impl<T> crate::traits::ToCoreSealed for Box<T> {}
+impl<T> crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for Box<T> {}
+impl<T> crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for Box<T> {}
 
 impl<T: FromCore> FromCore for Box<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -96,8 +96,8 @@ impl<T: ToCore> ToCore for Box<T> {
 
 // Unit
 
-impl crate::traits::FromCoreSealed for () {}
-impl crate::traits::ToCoreSealed for () {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for () {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for () {}
 
 impl ToCore for () {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
@@ -119,8 +119,8 @@ impl FromCore for () {
 
 // Primitives
 
-impl crate::traits::FromCoreSealed for i64 {}
-impl crate::traits::ToCoreSealed for i64 {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for i64 {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for i64 {}
 
 /// Bridges Rust `i64` to Haskell `Int#` literal.
 /// Also transparently unwraps `I#(n)` (boxed Int).
@@ -149,8 +149,8 @@ impl ToCore for i64 {
     }
 }
 
-impl crate::traits::FromCoreSealed for u64 {}
-impl crate::traits::ToCoreSealed for u64 {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for u64 {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for u64 {}
 
 /// Bridges Rust `u64` to Haskell `Word#` literal.
 /// Also transparently unwraps `W#(n)` (boxed Word).
@@ -179,8 +179,8 @@ impl ToCore for u64 {
     }
 }
 
-impl crate::traits::FromCoreSealed for f64 {}
-impl crate::traits::ToCoreSealed for f64 {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for f64 {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for f64 {}
 
 /// Bridges Rust `f64` to Haskell `Double#` literal.
 /// Also transparently unwraps `D#(n)` (boxed Double).
@@ -212,8 +212,8 @@ impl ToCore for f64 {
     }
 }
 
-impl crate::traits::FromCoreSealed for i32 {}
-impl crate::traits::ToCoreSealed for i32 {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for i32 {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for i32 {}
 
 /// Bridges Rust `i32` to Haskell `Int#` literal.
 /// Returns error on overflow/underflow.
@@ -236,8 +236,8 @@ impl ToCore for i32 {
     }
 }
 
-impl crate::traits::FromCoreSealed for bool {}
-impl crate::traits::ToCoreSealed for bool {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for bool {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for bool {}
 
 /// Bridges Rust `bool` to Haskell `Bool` (True/False constructors).
 impl FromCore for bool {
@@ -290,8 +290,8 @@ impl ToCore for bool {
     }
 }
 
-impl crate::traits::FromCoreSealed for char {}
-impl crate::traits::ToCoreSealed for char {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for char {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for char {}
 
 /// Also transparently unwraps `C#(c)` (boxed Char).
 impl FromCore for char {
@@ -319,8 +319,8 @@ impl ToCore for char {
     }
 }
 
-impl crate::traits::FromCoreSealed for String {}
-impl crate::traits::ToCoreSealed for String {}
+impl crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for String {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for String {}
 
 impl FromCore for String {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -438,8 +438,8 @@ impl ToCore for String {
 
 // Containers
 
-impl<T> crate::traits::FromCoreSealed for Option<T> {}
-impl<T> crate::traits::ToCoreSealed for Option<T> {}
+impl<T> crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for Option<T> {}
+impl<T> crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for Option<T> {}
 
 impl<T: FromCore> FromCore for Option<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -500,8 +500,8 @@ impl<T: ToCore> ToCore for Option<T> {
     }
 }
 
-impl<T> crate::traits::FromCoreSealed for Vec<T> {}
-impl<T> crate::traits::ToCoreSealed for Vec<T> {}
+impl<T> crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for Vec<T> {}
+impl<T> crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for Vec<T> {}
 
 impl<T: FromCore> FromCore for Vec<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -568,8 +568,8 @@ impl<T: ToCore> ToCore for Vec<T> {
     }
 }
 
-impl<T, E> crate::traits::FromCoreSealed for Result<T, E> {}
-impl<T, E> crate::traits::ToCoreSealed for Result<T, E> {}
+impl<T, E> crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for Result<T, E> {}
+impl<T, E> crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for Result<T, E> {}
 
 impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -636,8 +636,8 @@ impl<T: ToCore, E: ToCore> ToCore for Result<T, E> {
 
 // Tuples
 
-impl<A, B> crate::traits::FromCoreSealed for (A, B) {}
-impl<A, B> crate::traits::ToCoreSealed for (A, B) {}
+impl<A, B> crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for (A, B) {}
+impl<A, B> crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for (A, B) {}
 
 impl<A: FromCore, B: FromCore> FromCore for (A, B) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -680,8 +680,8 @@ impl<A: ToCore, B: ToCore> ToCore for (A, B) {
     }
 }
 
-impl<A, B, C> crate::traits::FromCoreSealed for (A, B, C) {}
-impl<A, B, C> crate::traits::ToCoreSealed for (A, B, C) {}
+impl<A, B, C> crate::traits::__private::Sealed<crate::traits::FromCoreMarker> for (A, B, C) {}
+impl<A, B, C> crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for (A, B, C) {}
 
 impl<A: FromCore, B: FromCore, C: FromCore> FromCore for (A, B, C) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {

--- a/tidepool-bridge/src/json.rs
+++ b/tidepool-bridge/src/json.rs
@@ -8,11 +8,11 @@
 //! represented as balanced binary trees of (Key, Value) pairs.
 
 use crate::error::BridgeError;
-use crate::traits::{ToCore, ToCoreSealed};
+use crate::traits::ToCore;
 use tidepool_eval::Value;
 use tidepool_repr::{DataConTable, Literal};
 
-impl ToCoreSealed for serde_json::Value {}
+impl crate::traits::__private::Sealed<crate::traits::ToCoreMarker> for serde_json::Value {}
 
 /// Convert a `serde_json::Value` to a Tidepool Core `Value` matching the
 /// vendored `Tidepool.Aeson.Value` Haskell type.

--- a/tidepool-bridge/src/json.rs
+++ b/tidepool-bridge/src/json.rs
@@ -8,9 +8,11 @@
 //! represented as balanced binary trees of (Key, Value) pairs.
 
 use crate::error::BridgeError;
-use crate::traits::ToCore;
+use crate::traits::{ToCore, ToCoreSealed};
 use tidepool_eval::Value;
 use tidepool_repr::{DataConTable, Literal};
+
+impl ToCoreSealed for serde_json::Value {}
 
 /// Convert a `serde_json::Value` to a Tidepool Core `Value` matching the
 /// vendored `Tidepool.Aeson.Value` Haskell type.

--- a/tidepool-bridge/src/traits.rs
+++ b/tidepool-bridge/src/traits.rs
@@ -2,16 +2,27 @@ use crate::error::BridgeError;
 use tidepool_eval::Value;
 use tidepool_repr::DataConTable;
 
-mod sealed {
-    pub trait FromCoreSealed {}
-    pub trait ToCoreSealed {}
+#[doc(hidden)]
+pub struct FromCoreMarker;
+#[doc(hidden)]
+pub struct ToCoreMarker;
+
+/// Private module for internal traits. Implementation of these traits is only
+/// supported via the provided derive macros.
+#[doc(hidden)]
+pub mod __private {
+    pub trait Sealed<T: ?Sized> {}
 }
 
 /// Convert a Core Value (from evaluation) to a Rust type.
 ///
 /// This trait is used to extract native Rust values from evaluated Core expressions.
-/// Implementations should handle potential type mismatches and arity errors.
-pub trait FromCore: Sized + sealed::FromCoreSealed {
+///
+/// # Sealing
+///
+/// This trait is sealed and should only be implemented via `#[derive(FromCore)]`.
+/// Manual implementations are unsupported and may break in future versions.
+pub trait FromCore: Sized + __private::Sealed<FromCoreMarker> {
     /// Convert a Value to this type using the provided DataConTable for lookups.
     ///
     /// # Errors
@@ -26,7 +37,12 @@ pub trait FromCore: Sized + sealed::FromCoreSealed {
 /// Convert a Rust type to a Core Value (for interpolation into CoreExpr or evaluation).
 ///
 /// This trait is used to inject Rust values into the Core evaluator.
-pub trait ToCore: sealed::ToCoreSealed {
+///
+/// # Sealing
+///
+/// This trait is sealed and should only be implemented via `#[derive(ToCore)]`.
+/// Manual implementations are unsupported and may break in future versions.
+pub trait ToCore: __private::Sealed<ToCoreMarker> {
     /// Convert this type to a Value using the provided DataConTable for lookups.
     ///
     /// # Errors
@@ -34,7 +50,3 @@ pub trait ToCore: sealed::ToCoreSealed {
     /// Returns `BridgeError::UnknownDataConName` if a required constructor is missing from the table.
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError>;
 }
-
-// Re-export Sealed traits for use in the derive macro, but keep them in a private-in-public path
-#[doc(hidden)]
-pub use sealed::{FromCoreSealed, ToCoreSealed};

--- a/tidepool-bridge/src/traits.rs
+++ b/tidepool-bridge/src/traits.rs
@@ -2,11 +2,16 @@ use crate::error::BridgeError;
 use tidepool_eval::Value;
 use tidepool_repr::DataConTable;
 
+mod sealed {
+    pub trait FromCoreSealed {}
+    pub trait ToCoreSealed {}
+}
+
 /// Convert a Core Value (from evaluation) to a Rust type.
 ///
 /// This trait is used to extract native Rust values from evaluated Core expressions.
 /// Implementations should handle potential type mismatches and arity errors.
-pub trait FromCore: Sized {
+pub trait FromCore: Sized + sealed::FromCoreSealed {
     /// Convert a Value to this type using the provided DataConTable for lookups.
     ///
     /// # Errors
@@ -21,7 +26,7 @@ pub trait FromCore: Sized {
 /// Convert a Rust type to a Core Value (for interpolation into CoreExpr or evaluation).
 ///
 /// This trait is used to inject Rust values into the Core evaluator.
-pub trait ToCore {
+pub trait ToCore: sealed::ToCoreSealed {
     /// Convert this type to a Value using the provided DataConTable for lookups.
     ///
     /// # Errors
@@ -29,3 +34,7 @@ pub trait ToCore {
     /// Returns `BridgeError::UnknownDataConName` if a required constructor is missing from the table.
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError>;
 }
+
+// Re-export Sealed traits for use in the derive macro, but keep them in a private-in-public path
+#[doc(hidden)]
+pub use sealed::{FromCoreSealed, ToCoreSealed};

--- a/tidepool-effect/src/machine.rs
+++ b/tidepool-effect/src/machine.rs
@@ -357,31 +357,13 @@ mod tests {
 
         // Simple handler: receives any value, returns Lit(100)
         use crate::dispatch::{EffectContext, EffectHandler};
-        use tidepool_bridge::FromCore;
-
-        struct TestReq(i64);
-        impl tidepool_bridge::FromCoreSealed for TestReq {}
-        impl FromCore for TestReq {
-            fn from_value(
-                value: &Value,
-                _table: &DataConTable,
-            ) -> Result<Self, tidepool_bridge::BridgeError> {
-                match value {
-                    Value::Lit(Literal::LitInt(n)) => Ok(TestReq(*n)),
-                    _ => Err(tidepool_bridge::BridgeError::TypeMismatch {
-                        expected: "LitInt".into(),
-                        got: format!("{:?}", value),
-                    }),
-                }
-            }
-        }
 
         struct TestHandler;
         impl EffectHandler for TestHandler {
-            type Request = TestReq;
-            fn handle(&mut self, req: TestReq, _cx: &EffectContext) -> Result<Value, EffectError> {
+            type Request = i64;
+            fn handle(&mut self, req: i64, _cx: &EffectContext) -> Result<Value, EffectError> {
                 // Echo back the request + 1
-                Ok(Value::Lit(Literal::LitInt(req.0 + 1)))
+                Ok(Value::Lit(Literal::LitInt(req + 1)))
             }
         }
 
@@ -430,24 +412,6 @@ mod tests {
         };
 
         use crate::dispatch::{EffectContext, EffectHandler};
-        use tidepool_bridge::FromCore;
-
-        struct TestReq(i64);
-        impl tidepool_bridge::FromCoreSealed for TestReq {}
-        impl FromCore for TestReq {
-            fn from_value(
-                value: &Value,
-                _table: &DataConTable,
-            ) -> Result<Self, tidepool_bridge::BridgeError> {
-                match value {
-                    Value::Lit(Literal::LitInt(n)) => Ok(TestReq(*n)),
-                    _ => Err(tidepool_bridge::BridgeError::TypeMismatch {
-                        expected: "LitInt".into(),
-                        got: format!("{:?}", value),
-                    }),
-                }
-            }
-        }
 
         struct UserData {
             multiplier: i64,
@@ -455,13 +419,13 @@ mod tests {
 
         struct UserHandler;
         impl EffectHandler<UserData> for UserHandler {
-            type Request = TestReq;
+            type Request = i64;
             fn handle(
                 &mut self,
-                req: TestReq,
+                req: i64,
                 cx: &EffectContext<'_, UserData>,
             ) -> Result<Value, EffectError> {
-                Ok(Value::Lit(Literal::LitInt(req.0 * cx.user().multiplier)))
+                Ok(Value::Lit(Literal::LitInt(req * cx.user().multiplier)))
             }
         }
 

--- a/tidepool-effect/src/machine.rs
+++ b/tidepool-effect/src/machine.rs
@@ -360,6 +360,7 @@ mod tests {
         use tidepool_bridge::FromCore;
 
         struct TestReq(i64);
+        impl tidepool_bridge::FromCoreSealed for TestReq {}
         impl FromCore for TestReq {
             fn from_value(
                 value: &Value,
@@ -432,6 +433,7 @@ mod tests {
         use tidepool_bridge::FromCore;
 
         struct TestReq(i64);
+        impl tidepool_bridge::FromCoreSealed for TestReq {}
         impl FromCore for TestReq {
             fn from_value(
                 value: &Value,


### PR DESCRIPTION
This PR implements the sealed trait pattern for `FromCore` and `ToCore` traits in the `tidepool-bridge` crate.

### Changes:
- **Improved Sealing**: Refactored the sealing mechanism to use a single generic `Sealed<T>` trait within a `#[doc(hidden)] pub mod __private` module.
- **Cycle Prevention**: Used `FromCoreMarker` and `ToCoreMarker` types to avoid compiler cycle errors in trait bounds.
- **Documentation**: Added clear documentation stating that `FromCore` and `ToCore` are sealed and should only be implemented via the provided derive macros.
- **Test Cleanup**: Replaced manual `FromCore` implementations in `tidepool-effect` tests with `i64` (which already implements the trait), eliminating the need for manual implementation of sealed traits in downstream crates.
- **Proc-macro Update**: Updated `tidepool-bridge-derive` to automatically generate implementations of the generic `Sealed` trait.
- **Audit**: Confirmed that `tidepool-runtime` error types correctly use `#[from]` where appropriate.

This implementation provides a strong convention-based seal that allows the derive macro to function across crate boundaries while discouraging manual implementations.

Verified with `cargo test --workspace`.