### PR TITLE
Refactor: implement sealed trait pattern for FromCore/ToCore (v4)

### DIFF
--- a/tidepool-bridge-derive/src/codegen.rs
+++ b/tidepool-bridge-derive/src/codegen.rs
@@ -116,7 +116,7 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
-        impl #impl_generics tidepool_bridge::sealed::FromCoreSealed for #name #ty_generics #where_clause {}
+        impl #impl_generics tidepool_bridge::__private::SealedInternal<tidepool_bridge::__private::FromCoreMarker> for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
@@ -187,7 +187,7 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
     }
 
     quote! {
-        impl #impl_generics tidepool_bridge::sealed::ToCoreSealed for #name #ty_generics #where_clause {}
+        impl #impl_generics tidepool_bridge::__private::SealedInternal<tidepool_bridge::__private::ToCoreMarker> for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
@@ -232,7 +232,7 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
-        impl #impl_generics tidepool_bridge::sealed::FromCoreSealed for #name #ty_generics #where_clause {}
+        impl #impl_generics tidepool_bridge::__private::SealedInternal<tidepool_bridge::__private::FromCoreMarker> for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::FromCore for #name #ty_generics #where_clause {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
@@ -302,7 +302,7 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
     };
 
     quote! {
-        impl #impl_generics tidepool_bridge::sealed::ToCoreSealed for #name #ty_generics #where_clause {}
+        impl #impl_generics tidepool_bridge::__private::SealedInternal<tidepool_bridge::__private::ToCoreMarker> for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -1,5 +1,5 @@
 use crate::error::BridgeError;
-use crate::traits::{sealed::{FromCoreSealed, ToCoreSealed}, FromCore, ToCore};
+use crate::traits::{FromCore, ToCore};
 use std::sync::{Arc, Mutex};
 use tidepool_eval::Value;
 use tidepool_repr::{DataConId, DataConTable, Literal};
@@ -29,8 +29,8 @@ fn type_mismatch(expected: &str, got: &Value) -> BridgeError {
     }
 }
 
-impl<T> FromCoreSealed for std::marker::PhantomData<T> {}
-impl<T> ToCoreSealed for std::marker::PhantomData<T> {}
+impl<T> crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for std::marker::PhantomData<T> {}
+impl<T> crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for std::marker::PhantomData<T> {}
 
 impl<T> FromCore for std::marker::PhantomData<T> {
     fn from_value(value: &Value, _table: &DataConTable) -> Result<Self, BridgeError> {
@@ -63,10 +63,10 @@ impl<T> ToCore for std::marker::PhantomData<T> {
 
 // Box
 
-// Value identity — pass through without conversion.
-impl FromCoreSealed for Value {}
-impl ToCoreSealed for Value {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for Value {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for Value {}
 
+// Value identity — pass through without conversion.
 impl ToCore for Value {
     fn to_value(&self, _table: &DataConTable) -> Result<Value, BridgeError> {
         Ok(self.clone())
@@ -79,8 +79,8 @@ impl FromCore for Value {
     }
 }
 
-impl<T> FromCoreSealed for Box<T> {}
-impl<T> ToCoreSealed for Box<T> {}
+impl<T> crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for Box<T> {}
+impl<T> crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for Box<T> {}
 
 impl<T: FromCore> FromCore for Box<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -96,8 +96,8 @@ impl<T: ToCore> ToCore for Box<T> {
 
 // Unit
 
-impl FromCoreSealed for () {}
-impl ToCoreSealed for () {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for () {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for () {}
 
 impl ToCore for () {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
@@ -119,11 +119,11 @@ impl FromCore for () {
 
 // Primitives
 
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for i64 {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for i64 {}
+
 /// Bridges Rust `i64` to Haskell `Int#` literal.
 /// Also transparently unwraps `I#(n)` (boxed Int).
-impl FromCoreSealed for i64 {}
-impl ToCoreSealed for i64 {}
-
 impl FromCore for i64 {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -149,11 +149,11 @@ impl ToCore for i64 {
     }
 }
 
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for u64 {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for u64 {}
+
 /// Bridges Rust `u64` to Haskell `Word#` literal.
 /// Also transparently unwraps `W#(n)` (boxed Word).
-impl FromCoreSealed for u64 {}
-impl ToCoreSealed for u64 {}
-
 impl FromCore for u64 {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -179,11 +179,11 @@ impl ToCore for u64 {
     }
 }
 
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for f64 {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for f64 {}
+
 /// Bridges Rust `f64` to Haskell `Double#` literal.
 /// Also transparently unwraps `D#(n)` (boxed Double).
-impl FromCoreSealed for f64 {}
-impl ToCoreSealed for f64 {}
-
 impl FromCore for f64 {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -212,11 +212,11 @@ impl ToCore for f64 {
     }
 }
 
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for i32 {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for i32 {}
+
 /// Bridges Rust `i32` to Haskell `Int#` literal.
 /// Returns error on overflow/underflow.
-impl FromCoreSealed for i32 {}
-impl ToCoreSealed for i32 {}
-
 impl FromCore for i32 {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         let n = i64::from_value(value, table)?;
@@ -236,10 +236,10 @@ impl ToCore for i32 {
     }
 }
 
-/// Bridges Rust `bool` to Haskell `Bool` (True/False constructors).
-impl FromCoreSealed for bool {}
-impl ToCoreSealed for bool {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for bool {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for bool {}
 
+/// Bridges Rust `bool` to Haskell `Bool` (True/False constructors).
 impl FromCore for bool {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -290,10 +290,10 @@ impl ToCore for bool {
     }
 }
 
-/// Also transparently unwraps `C#(c)` (boxed Char).
-impl FromCoreSealed for char {}
-impl ToCoreSealed for char {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for char {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for char {}
 
+/// Also transparently unwraps `C#(c)` (boxed Char).
 impl FromCore for char {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         match value {
@@ -319,8 +319,8 @@ impl ToCore for char {
     }
 }
 
-impl FromCoreSealed for String {}
-impl ToCoreSealed for String {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for String {}
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for String {}
 
 impl FromCore for String {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -438,8 +438,8 @@ impl ToCore for String {
 
 // Containers
 
-impl<T> FromCoreSealed for Option<T> {}
-impl<T> ToCoreSealed for Option<T> {}
+impl<T> crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for Option<T> {}
+impl<T> crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for Option<T> {}
 
 impl<T: FromCore> FromCore for Option<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -500,8 +500,8 @@ impl<T: ToCore> ToCore for Option<T> {
     }
 }
 
-impl<T> FromCoreSealed for Vec<T> {}
-impl<T> ToCoreSealed for Vec<T> {}
+impl<T> crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for Vec<T> {}
+impl<T> crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for Vec<T> {}
 
 impl<T: FromCore> FromCore for Vec<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -568,8 +568,8 @@ impl<T: ToCore> ToCore for Vec<T> {
     }
 }
 
-impl<T, E> FromCoreSealed for Result<T, E> {}
-impl<T, E> ToCoreSealed for Result<T, E> {}
+impl<T, E> crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for Result<T, E> {}
+impl<T, E> crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for Result<T, E> {}
 
 impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -636,8 +636,8 @@ impl<T: ToCore, E: ToCore> ToCore for Result<T, E> {
 
 // Tuples
 
-impl<A, B> FromCoreSealed for (A, B) {}
-impl<A, B> ToCoreSealed for (A, B) {}
+impl<A, B> crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for (A, B) {}
+impl<A, B> crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for (A, B) {}
 
 impl<A: FromCore, B: FromCore> FromCore for (A, B) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
@@ -680,8 +680,8 @@ impl<A: ToCore, B: ToCore> ToCore for (A, B) {
     }
 }
 
-impl<A, B, C> FromCoreSealed for (A, B, C) {}
-impl<A, B, C> ToCoreSealed for (A, B, C) {}
+impl<A, B, C> crate::traits::__private::SealedInternal<crate::traits::__private::FromCoreMarker> for (A, B, C) {}
+impl<A, B, C> crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for (A, B, C) {}
 
 impl<A: FromCore, B: FromCore, C: FromCore> FromCore for (A, B, C) {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {

--- a/tidepool-bridge/src/json.rs
+++ b/tidepool-bridge/src/json.rs
@@ -8,17 +8,17 @@
 //! represented as balanced binary trees of (Key, Value) pairs.
 
 use crate::error::BridgeError;
-use crate::traits::{sealed::ToCoreSealed, ToCore};
+use crate::traits::ToCore;
 use tidepool_eval::Value;
 use tidepool_repr::{DataConTable, Literal};
+
+impl crate::traits::__private::SealedInternal<crate::traits::__private::ToCoreMarker> for serde_json::Value {}
 
 /// Convert a `serde_json::Value` to a Tidepool Core `Value` matching the
 /// vendored `Tidepool.Aeson.Value` Haskell type.
 ///
 /// The resulting Core value can be passed to Haskell code that expects
 /// `Value` (the aeson-compatible type) and accessed via lens combinators.
-impl ToCoreSealed for serde_json::Value {}
-
 impl ToCore for serde_json::Value {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
         // Use get_by_name_arity to disambiguate aeson Value constructors from

--- a/tidepool-bridge/src/lib.rs
+++ b/tidepool-bridge/src/lib.rs
@@ -9,4 +9,4 @@ pub mod json;
 pub mod traits;
 
 pub use error::*;
-pub use traits::*;
+pub use traits::{__private, FromCore, ToCore};

--- a/tidepool-bridge/src/traits.rs
+++ b/tidepool-bridge/src/traits.rs
@@ -2,18 +2,24 @@ use crate::error::BridgeError;
 use tidepool_eval::Value;
 use tidepool_repr::DataConTable;
 
-/// Implementation detail for sealing traits.
+/// Private module for internal traits. Implementation of these traits is only
+/// supported via the provided derive macros.
 #[doc(hidden)]
-pub mod sealed {
-    pub trait FromCoreSealed {}
-    pub trait ToCoreSealed {}
+pub mod __private {
+    pub trait SealedInternal<T: ?Sized> {}
+    pub struct FromCoreMarker;
+    pub struct ToCoreMarker;
 }
 
 /// Convert a Core Value (from evaluation) to a Rust type.
 ///
 /// This trait is used to extract native Rust values from evaluated Core expressions.
-/// Implementations should handle potential type mismatches and arity errors.
-pub trait FromCore: Sized + sealed::FromCoreSealed {
+///
+/// # Sealing
+///
+/// This trait is sealed and should only be implemented via `#[derive(FromCore)]`.
+/// Manual implementations are unsupported and may break in future versions.
+pub trait FromCore: Sized + __private::SealedInternal<__private::FromCoreMarker> {
     /// Convert a Value to this type using the provided DataConTable for lookups.
     ///
     /// # Errors
@@ -28,7 +34,12 @@ pub trait FromCore: Sized + sealed::FromCoreSealed {
 /// Convert a Rust type to a Core Value (for interpolation into CoreExpr or evaluation).
 ///
 /// This trait is used to inject Rust values into the Core evaluator.
-pub trait ToCore: sealed::ToCoreSealed {
+///
+/// # Sealing
+///
+/// This trait is sealed and should only be implemented via `#[derive(ToCore)]`.
+/// Manual implementations are unsupported and may break in future versions.
+pub trait ToCore: __private::SealedInternal<__private::ToCoreMarker> {
     /// Convert this type to a Value using the provided DataConTable for lookups.
     ///
     /// # Errors

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -240,6 +240,7 @@ fn perform_gc(fp: usize, vmctx: *mut VMContext) {
 }
 
 /// Set a hook to be called during gc_trigger with the collected roots.
+#[cfg(any(test, feature = "test-utils"))]
 pub(crate) fn set_gc_test_hook(hook: GcHook) {
     HOOK.with(|hook_cell| {
         *hook_cell.borrow_mut() = Some(hook);
@@ -247,6 +248,7 @@ pub(crate) fn set_gc_test_hook(hook: GcHook) {
 }
 
 /// Clear the GC test hook.
+#[cfg(any(test, feature = "test-utils"))]
 pub(crate) fn clear_gc_test_hook() {
     HOOK.with(|hook_cell| {
         *hook_cell.borrow_mut() = None;
@@ -272,6 +274,7 @@ pub fn clear_stack_map_registry() {
 }
 
 /// Get collected roots from the last gc_trigger call.
+#[cfg(any(test, feature = "test-utils"))]
 pub(crate) fn last_gc_roots() -> Vec<StackRoot> {
     LAST_ROOTS.with(|roots_cell| roots_cell.borrow().clone())
 }

--- a/tidepool-effect/src/machine.rs
+++ b/tidepool-effect/src/machine.rs
@@ -357,31 +357,13 @@ mod tests {
 
         // Simple handler: receives any value, returns Lit(100)
         use crate::dispatch::{EffectContext, EffectHandler};
-        use tidepool_bridge::FromCore;
-
-        struct TestReq(i64);
-        impl tidepool_bridge::sealed::FromCoreSealed for TestReq {}
-        impl FromCore for TestReq {
-            fn from_value(
-                value: &Value,
-                _table: &DataConTable,
-            ) -> Result<Self, tidepool_bridge::BridgeError> {
-                match value {
-                    Value::Lit(Literal::LitInt(n)) => Ok(TestReq(*n)),
-                    _ => Err(tidepool_bridge::BridgeError::TypeMismatch {
-                        expected: "LitInt".into(),
-                        got: format!("{:?}", value),
-                    }),
-                }
-            }
-        }
 
         struct TestHandler;
         impl EffectHandler for TestHandler {
-            type Request = TestReq;
-            fn handle(&mut self, req: TestReq, _cx: &EffectContext) -> Result<Value, EffectError> {
+            type Request = i64;
+            fn handle(&mut self, req: i64, _cx: &EffectContext) -> Result<Value, EffectError> {
                 // Echo back the request + 1
-                Ok(Value::Lit(Literal::LitInt(req.0 + 1)))
+                Ok(Value::Lit(Literal::LitInt(req + 1)))
             }
         }
 
@@ -430,24 +412,6 @@ mod tests {
         };
 
         use crate::dispatch::{EffectContext, EffectHandler};
-        use tidepool_bridge::FromCore;
-
-        struct TestReq(i64);
-        impl tidepool_bridge::sealed::FromCoreSealed for TestReq {}
-        impl FromCore for TestReq {
-            fn from_value(
-                value: &Value,
-                _table: &DataConTable,
-            ) -> Result<Self, tidepool_bridge::BridgeError> {
-                match value {
-                    Value::Lit(Literal::LitInt(n)) => Ok(TestReq(*n)),
-                    _ => Err(tidepool_bridge::BridgeError::TypeMismatch {
-                        expected: "LitInt".into(),
-                        got: format!("{:?}", value),
-                    }),
-                }
-            }
-        }
 
         struct UserData {
             multiplier: i64,
@@ -455,13 +419,13 @@ mod tests {
 
         struct UserHandler;
         impl EffectHandler<UserData> for UserHandler {
-            type Request = TestReq;
+            type Request = i64;
             fn handle(
                 &mut self,
-                req: TestReq,
+                req: i64,
                 cx: &EffectContext<'_, UserData>,
             ) -> Result<Value, EffectError> {
-                Ok(Value::Lit(Literal::LitInt(req.0 * cx.user().multiplier)))
+                Ok(Value::Lit(Literal::LitInt(req * cx.user().multiplier)))
             }
         }
 


### PR DESCRIPTION
This PR refines the implementation of the sealed trait pattern for `FromCore` and `ToCore` in the `tidepool-bridge` crate, addressing all feedback from previous reviews.

### Changes:
- **Refined Sealing**: Uses a generic `SealedInternal<T>` trait and marker types (`FromCoreMarker`, `ToCoreMarker`) strictly contained within a `#[doc(hidden)] pub mod __private` module.
- **Clean API**: Updated `tidepool-bridge/src/lib.rs` to only export necessary traits and the `__private` module, keeping the public namespace stable and avoiding collisions.
- **Visibility Control**: Gated GC test hooks (`set_gc_test_hook`, `clear_gc_test_hook`, `last_gc_roots`) in `tidepool-codegen/src/host_fns.rs` behind `#[cfg(any(test, feature = "test-utils"))]` to maintain a clean public API for the codegen crate.
- **Stable Representation**: Reverted `RawStackMap` and `RawStackMapEntry` to structs in `tidepool-codegen/src/stack_map.rs` to preserve a stable and readable public interface.
- **Test Cleanup**: Finalized removal of manual `FromCore` implementations in `tidepool-effect` tests by using `i64` as the request type.
- **Improved Documentation**: Added comprehensive warnings in doc comments regarding the sealing of `FromCore` and `ToCore`.

This approach ensures that the conversion traits are robustly sealed while still supporting cross-crate derivation via the provided macros.

Verified with `cargo test --workspace`. Rebased on `main`.