### PR TITLE
perf: optimize GC trace and compact passes

### DIFF
--- a/tidepool-eval/src/heap.rs
+++ b/tidepool-eval/src/heap.rs
@@ -46,15 +46,20 @@ impl VecHeap {
     }
 
     fn collect_thunk_refs(val: &Value) -> Vec<ThunkId> {
-        match val {
-            Value::ThunkRef(id) => vec![*id],
-            Value::Con(_, fields) => fields.iter().flat_map(Self::collect_thunk_refs).collect(),
-            Value::ConFun(_, _, args) => args.iter().flat_map(Self::collect_thunk_refs).collect(),
-            Value::Closure(env, _, _) => env.values().flat_map(Self::collect_thunk_refs).collect(),
-            Value::JoinCont(_, _, env) => env.values().flat_map(Self::collect_thunk_refs).collect(),
-            Value::Lit(_) => vec![],
-            Value::ByteArray(_) => vec![],
+        let mut refs = Vec::new();
+        let mut stack = vec![val];
+        while let Some(v) = stack.pop() {
+            match v {
+                Value::ThunkRef(id) => refs.push(*id),
+                Value::Con(_, fields) => stack.extend(fields.iter().rev()),
+                Value::ConFun(_, _, args) => stack.extend(args.iter().rev()),
+                Value::Closure(env, _, _) => stack.extend(env.values()),
+                Value::JoinCont(_, _, env) => stack.extend(env.values()),
+                Value::Lit(_) => {}
+                Value::ByteArray(_) => {}
+            }
         }
+        refs
     }
 }
 

--- a/tidepool-heap/src/arena.rs
+++ b/tidepool-heap/src/arena.rs
@@ -124,7 +124,7 @@ impl ArenaHeap {
         let (new_heap, table) = crate::gc::collect(roots, self);
 
         // Replace thunk store with compacted thunks via Heap trait
-        let reachable_count = table.reachable_count;
+        let reachable_count = table.reachable_count();
         self.thunks.clear();
         for i in 0..reachable_count {
             self.thunks.push(new_heap.read(ThunkId(i as u32)).clone());

--- a/tidepool-heap/src/arena.rs
+++ b/tidepool-heap/src/arena.rs
@@ -124,7 +124,7 @@ impl ArenaHeap {
         let (new_heap, table) = crate::gc::collect(roots, self);
 
         // Replace thunk store with compacted thunks via Heap trait
-        let reachable_count = table.mapping.iter().flatten().count();
+        let reachable_count = table.reachable_count;
         self.thunks.clear();
         for i in 0..reachable_count {
             self.thunks.push(new_heap.read(ThunkId(i as u32)).clone());
@@ -151,15 +151,20 @@ impl ArenaHeap {
     }
 
     fn collect_thunk_refs(val: &Value) -> Vec<ThunkId> {
-        match val {
-            Value::ThunkRef(id) => vec![*id],
-            Value::Con(_, fields) => fields.iter().flat_map(Self::collect_thunk_refs).collect(),
-            Value::ConFun(_, _, args) => args.iter().flat_map(Self::collect_thunk_refs).collect(),
-            Value::Closure(env, _, _) => env.values().flat_map(Self::collect_thunk_refs).collect(),
-            Value::JoinCont(_, _, env) => env.values().flat_map(Self::collect_thunk_refs).collect(),
-            Value::Lit(_) => vec![],
-            Value::ByteArray(_) => vec![],
+        let mut refs = Vec::new();
+        let mut stack = vec![val];
+        while let Some(v) = stack.pop() {
+            match v {
+                Value::ThunkRef(id) => refs.push(*id),
+                Value::Con(_, fields) => stack.extend(fields.iter().rev()),
+                Value::ConFun(_, _, args) => stack.extend(args.iter().rev()),
+                Value::Closure(env, _, _) => stack.extend(env.values()),
+                Value::JoinCont(_, _, env) => stack.extend(env.values()),
+                Value::Lit(_) => {}
+                Value::ByteArray(_) => {}
+            }
         }
+        refs
     }
 }
 

--- a/tidepool-heap/src/gc/compact.rs
+++ b/tidepool-heap/src/gc/compact.rs
@@ -6,7 +6,7 @@ use tidepool_repr::{CoreFrame, RecursiveTree, VarId};
 
 /// Compact the heap by moving reachable thunks to a new VecHeap.
 pub fn compact(table: &ForwardingTable, old_heap: &dyn Heap) -> VecHeap {
-    let mut inverse = vec![ThunkId(0); table.reachable_count];
+    let mut inverse = vec![ThunkId(0); table.reachable_count()];
 
     for (old_idx, maybe_new_id) in table.mapping.iter().enumerate() {
         if let Some(new_id) = maybe_new_id {

--- a/tidepool-heap/src/gc/compact.rs
+++ b/tidepool-heap/src/gc/compact.rs
@@ -6,8 +6,7 @@ use tidepool_repr::{CoreFrame, RecursiveTree, VarId};
 
 /// Compact the heap by moving reachable thunks to a new VecHeap.
 pub fn compact(table: &ForwardingTable, old_heap: &dyn Heap) -> VecHeap {
-    let reachable_count = table.mapping.iter().flatten().count();
-    let mut inverse = vec![ThunkId(0); reachable_count];
+    let mut inverse = vec![ThunkId(0); table.reachable_count];
 
     for (old_idx, maybe_new_id) in table.mapping.iter().enumerate() {
         if let Some(new_id) = maybe_new_id {

--- a/tidepool-heap/src/gc/trace.rs
+++ b/tidepool-heap/src/gc/trace.rs
@@ -12,7 +12,7 @@ pub enum GcError {
 /// Maps old ThunkIds to new ThunkIds.
 pub struct ForwardingTable {
     pub(crate) mapping: Vec<Option<ThunkId>>,
-    pub(crate) reachable_count: usize,
+    reachable_count: usize,
 }
 
 impl ForwardingTable {
@@ -140,7 +140,7 @@ mod tests {
         assert_eq!(table.lookup(id_shared).unwrap(), ThunkId(2));
 
         // Ensure no other IDs are in the table (max 3 reachable)
-        assert_eq!(table.reachable_count, 3);
+        assert_eq!(table.reachable_count(), 3);
     }
 
     #[test]

--- a/tidepool-heap/src/gc/trace.rs
+++ b/tidepool-heap/src/gc/trace.rs
@@ -12,6 +12,7 @@ pub enum GcError {
 /// Maps old ThunkIds to new ThunkIds.
 pub struct ForwardingTable {
     pub(crate) mapping: Vec<Option<ThunkId>>,
+    pub(crate) reachable_count: usize,
 }
 
 impl ForwardingTable {
@@ -30,11 +31,21 @@ impl ForwardingTable {
         let idx = old_id.0 as usize;
         idx < self.mapping.len() && self.mapping[idx].is_some()
     }
+
+    /// Get the number of reachable thunks.
+    pub fn reachable_count(&self) -> usize {
+        self.reachable_count
+    }
 }
 
 /// Trace reachable thunks starting from roots.
 pub fn trace(roots: &[ThunkId], heap: &dyn Heap) -> ForwardingTable {
-    let mut mapping: Vec<Option<ThunkId>> = Vec::new();
+    let mut mapping: Vec<Option<ThunkId>> = if roots.is_empty() {
+        Vec::new()
+    } else {
+        let max_root = roots.iter().map(|id| id.0).max().unwrap_or(0) as usize;
+        vec![None; max_root.saturating_add(1)]
+    };
     let mut queue = VecDeque::new();
     let mut next_new_id = 0;
 
@@ -61,7 +72,10 @@ pub fn trace(roots: &[ThunkId], heap: &dyn Heap) -> ForwardingTable {
         }
     }
 
-    ForwardingTable { mapping }
+    ForwardingTable {
+        mapping,
+        reachable_count: next_new_id as usize,
+    }
 }
 
 #[cfg(test)]
@@ -126,8 +140,7 @@ mod tests {
         assert_eq!(table.lookup(id_shared).unwrap(), ThunkId(2));
 
         // Ensure no other IDs are in the table (max 3 reachable)
-        let reachable_count = table.mapping.iter().flatten().count();
-        assert_eq!(reachable_count, 3);
+        assert_eq!(table.reachable_count, 3);
     }
 
     #[test]


### PR DESCRIPTION
This PR introduces several performance optimizations in the `tidepool-heap` GC code:

1. **Iterative thunk reference collection**: Replaced the recursive `collect_thunk_refs` with an iterative work-stack approach in both `tidepool-eval` and `tidepool-heap`. This avoids O(n) intermediate Vec allocations and deep recursion for nested structures.
2. **Pre-allocated GC trace mapping**: The `mapping` Vec in `trace.rs` is now pre-allocated based on the maximum `ThunkId` seen in the root set, reducing repeated resize+copy operations.
3. **Eliminated double-pass in compact**: Added a `reachable_count` field to `ForwardingTable`, which is populated during the `trace` phase. This allows `compact.rs` and `ArenaHeap::collect_garbage` to skip the extra `.flatten().count()` pass over the mapping.

Correctness was verified through existing unit tests and proptests across `tidepool-eval` and `tidepool-heap`. Performance was checked with existing heap benchmarks.
