### PR TITLE
feat: add comprehensive benchmarks for GC, JIT, and optimization pipeline

### DIFF
--- a/tidepool-testing/Cargo.toml
+++ b/tidepool-testing/Cargo.toml
@@ -29,3 +29,7 @@ harness = false
 [[bench]]
 name = "heap"
 harness = false
+
+[[bench]]
+name = "codegen"
+harness = false

--- a/tidepool-testing/benches/codegen.rs
+++ b/tidepool-testing/benches/codegen.rs
@@ -1,0 +1,68 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tidepool_codegen::jit_machine::JitEffectMachine;
+use tidepool_repr::{CoreExpr, CoreFrame, DataConTable, Literal, PrimOpKind, TreeBuilder, VarId};
+
+/// Builds a simple arithmetic expression tree of given size.
+/// result = (((1 + 0) + 1) + 2) + ...
+fn build_expr(size: usize) -> CoreExpr {
+    let mut b = TreeBuilder::new();
+    let mut current = b.push(CoreFrame::Lit(Literal::LitInt(1)));
+    for i in 0..((size - 1) / 2) {
+        let next = b.push(CoreFrame::Lit(Literal::LitInt(i as i64)));
+        current = b.push(CoreFrame::PrimOp {
+            op: PrimOpKind::IntAdd,
+            args: vec![current, next],
+        });
+    }
+    // If size is not odd, we might be slightly off, but it's fine for a benchmark scale.
+    b.build()
+}
+
+/// Builds a tree with many let-bindings.
+fn build_let_expr(size: usize) -> CoreExpr {
+    let mut b = TreeBuilder::new();
+    let mut current_body = b.push(CoreFrame::Var(VarId(0)));
+    for i in 1..size {
+        let binder = VarId(i as u64);
+        let rhs = b.push(CoreFrame::Lit(Literal::LitInt(i as i64)));
+        current_body = b.push(CoreFrame::LetNonRec {
+            binder,
+            rhs,
+            body: current_body,
+        });
+    }
+    b.build()
+}
+
+fn bench_codegen(c: &mut Criterion) {
+    let table = DataConTable::new();
+    
+    // 1. Compilation latency (Arithmetic tree)
+    let mut group = c.benchmark_group("codegen_compile_arith");
+    for &size in &[50, 200, 500] {
+        let expr = build_expr(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.iter(|| {
+                let machine = JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+                black_box(machine)
+            });
+        });
+    }
+    group.finish();
+
+    // 2. Compilation latency (Let chain)
+    let mut group = c.benchmark_group("codegen_compile_let");
+    for &size in &[50, 200, 500] {
+        let expr = build_let_expr(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.iter(|| {
+                let machine = JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+                black_box(machine)
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_codegen);
+criterion_main!(benches);

--- a/tidepool-testing/benches/codegen.rs
+++ b/tidepool-testing/benches/codegen.rs
@@ -5,9 +5,10 @@ use tidepool_repr::{CoreExpr, CoreFrame, DataConTable, Literal, PrimOpKind, Tree
 /// Builds a simple arithmetic expression tree of given size.
 /// result = (((1 + 0) + 1) + 2) + ...
 fn build_expr(size: usize) -> CoreExpr {
+    assert!(size > 0, "size must be > 0");
     let mut b = TreeBuilder::new();
     let mut current = b.push(CoreFrame::Lit(Literal::LitInt(1)));
-    for i in 0..((size - 1) / 2) {
+    for i in 0..((size.saturating_sub(1)) / 2) {
         let next = b.push(CoreFrame::Lit(Literal::LitInt(i as i64)));
         current = b.push(CoreFrame::PrimOp {
             op: PrimOpKind::IntAdd,
@@ -21,8 +22,9 @@ fn build_expr(size: usize) -> CoreExpr {
 /// Builds a tree with many let-bindings.
 fn build_let_expr(size: usize) -> CoreExpr {
     let mut b = TreeBuilder::new();
-    let mut current_body = b.push(CoreFrame::Var(VarId(0)));
-    for i in 1..size {
+    // Start with a literal to avoid unbound variables
+    let mut current_body = b.push(CoreFrame::Lit(Literal::LitInt(0)));
+    for i in 1..=size {
         let binder = VarId(i as u64);
         let rhs = b.push(CoreFrame::Lit(Literal::LitInt(i as i64)));
         current_body = b.push(CoreFrame::LetNonRec {

--- a/tidepool-testing/benches/heap.rs
+++ b/tidepool-testing/benches/heap.rs
@@ -97,7 +97,8 @@ fn bench_heap(c: &mut Criterion) {
                         let mut heap = ArenaHeap::with_capacity(depth * 256);
                         let mut last_id = heap.alloc(env.clone(), expr.clone());
 
-                        for _ in 0..depth {
+                        // Loop depth-1 times to produce exactly depth total thunks
+                        for _ in 0..depth.saturating_sub(1) {
                             let mut next_env = Env::new();
                             next_env.insert(VarId(0), tidepool_eval::value::Value::ThunkRef(last_id));
                             last_id = heap.alloc(next_env, expr.clone());

--- a/tidepool-testing/benches/heap.rs
+++ b/tidepool-testing/benches/heap.rs
@@ -55,25 +55,63 @@ fn bench_heap(c: &mut Criterion) {
     }
     group.finish();
 
-    // 4. GC cycle
-    c.bench_function("gc_cycle_1000_500", |b| {
-        b.iter_with_setup(
-            || {
-                let mut heap = ArenaHeap::new();
-                let mut roots = Vec::new();
-                for i in 0..1000 {
-                    let id = heap.alloc(env.clone(), expr.clone());
-                    if i % 2 == 0 {
-                        roots.push(id);
-                    }
-                }
-                (heap, roots)
-            },
-            |(mut heap, roots)| {
-                black_box(heap.collect_garbage(&roots));
+    // 4. GC stress test
+    let mut group = c.benchmark_group("gc_stress");
+    for &size in &[1000, 10000, 100000] {
+        for &ratio in &[10, 50, 90] {
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{}_{}%", size, ratio)),
+                &(size, ratio),
+                |b, &(size, ratio)| {
+                    b.iter_with_setup(
+                        || {
+                            let mut heap = ArenaHeap::with_capacity(size * 256); // Plenty of space
+                            let mut roots = Vec::new();
+                            for i in 0..size {
+                                let id = heap.alloc(env.clone(), expr.clone());
+                                if (i * 100 / size) < ratio {
+                                    roots.push(id);
+                                }
+                            }
+                            (heap, roots)
+                        },
+                        |(mut heap, roots)| {
+                            black_box(heap.collect_garbage(&roots));
+                        },
+                    );
+                },
+            );
+        }
+    }
+    group.finish();
+
+    // 5. GC deep nested structure
+    let mut group = c.benchmark_group("gc_deep_nested");
+    for &depth in &[1000, 5000, 10000] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(depth),
+            &depth,
+            |b, &depth| {
+                b.iter_with_setup(
+                    || {
+                        let mut heap = ArenaHeap::with_capacity(depth * 256);
+                        let mut last_id = heap.alloc(env.clone(), expr.clone());
+
+                        for _ in 0..depth {
+                            let mut next_env = Env::new();
+                            next_env.insert(VarId(0), tidepool_eval::value::Value::ThunkRef(last_id));
+                            last_id = heap.alloc(next_env, expr.clone());
+                        }
+                        (heap, vec![last_id])
+                    },
+                    |(mut heap, roots)| {
+                        black_box(heap.collect_garbage(&roots));
+                    },
+                );
             },
         );
-    });
+    }
+    group.finish();
 }
 
 criterion_group!(benches, bench_heap);

--- a/tidepool-testing/benches/optimize.rs
+++ b/tidepool-testing/benches/optimize.rs
@@ -103,6 +103,7 @@ fn convergence_expr(depth: usize) -> CoreExpr {
 
 fn bench_optimize(c: &mut Criterion) {
     let expr = reducible_expr();
+    let passes = default_passes();
 
     c.bench_function("opt_beta_reduce", |b| {
         b.iter(|| {
@@ -135,19 +136,17 @@ fn bench_optimize(c: &mut Criterion) {
     c.bench_function("opt_full_pipeline", |b| {
         b.iter(|| {
             let mut e = expr.clone();
-            let passes = default_passes();
-            black_box(run_pipeline(&passes, &mut e).unwrap())
+            black_box(run_pipeline(&passes, &mut e).expect("Optimization pipeline failed"))
         })
     });
 
     // Pipeline on already optimized expr
     let mut optimized = expr.clone();
-    run_pipeline(&default_passes(), &mut optimized).unwrap();
+    run_pipeline(&passes, &mut optimized).expect("Optimization pipeline failed");
     c.bench_function("opt_pipeline_already_optimized", |b| {
         b.iter(|| {
             let mut e = optimized.clone();
-            let passes = default_passes();
-            black_box(run_pipeline(&passes, &mut e).unwrap())
+            black_box(run_pipeline(&passes, &mut e).expect("Optimization pipeline failed"))
         })
     });
 
@@ -158,8 +157,7 @@ fn bench_optimize(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(depth), &depth, |b, _| {
             b.iter(|| {
                 let mut e = e.clone();
-                let passes = default_passes();
-                black_box(run_pipeline(&passes, &mut e).unwrap())
+                black_box(run_pipeline(&passes, &mut e).expect("Optimization pipeline failed"))
             })
         });
     }

--- a/tidepool-testing/benches/optimize.rs
+++ b/tidepool-testing/benches/optimize.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use tidepool_eval::pass::Pass;
 use tidepool_optimize::beta::BetaReduce;
 use tidepool_optimize::case_reduce::CaseReduce;
@@ -6,7 +6,7 @@ use tidepool_optimize::dce::Dce;
 use tidepool_optimize::inline::Inline;
 use tidepool_optimize::pipeline::{default_passes, run_pipeline};
 use tidepool_repr::{
-    Alt, AltCon, CoreExpr, CoreFrame, DataConId, Literal, PrimOpKind, RecursiveTree, VarId,
+    Alt, AltCon, CoreExpr, CoreFrame, DataConId, Literal, PrimOpKind, RecursiveTree, TreeBuilder, VarId,
 };
 
 /// Builds a reducible expression (~30 nodes).
@@ -76,6 +76,31 @@ fn reducible_expr() -> CoreExpr {
     RecursiveTree { nodes }
 }
 
+/// Builds an expression that requires multiple optimization passes.
+/// Result = (\xN -> ... (\x1 -> x1 + 1) x2 ... ) (41 + 1)
+fn convergence_expr(depth: usize) -> CoreExpr {
+    let mut b = TreeBuilder::new();
+    
+    let one = b.push(CoreFrame::Lit(Literal::LitInt(1)));
+    let var1 = b.push(CoreFrame::Var(VarId(1)));
+    let mut current = b.push(CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![var1, one] });
+    
+    for i in 1..depth {
+        let binder = VarId(i as u64);
+        let lam = b.push(CoreFrame::Lam { binder, body: current });
+        let arg_var = b.push(CoreFrame::Var(VarId(i as u64 + 1)));
+        current = b.push(CoreFrame::App { fun: lam, arg: arg_var });
+    }
+    
+    let lit41 = b.push(CoreFrame::Lit(Literal::LitInt(41)));
+    let reducible_arg = b.push(CoreFrame::PrimOp { op: PrimOpKind::IntAdd, args: vec![lit41, one] });
+    
+    let final_lam = b.push(CoreFrame::Lam { binder: VarId(depth as u64), body: current });
+    let _root = b.push(CoreFrame::App { fun: final_lam, arg: reducible_arg });
+    
+    b.build()
+}
+
 fn bench_optimize(c: &mut Criterion) {
     let expr = reducible_expr();
 
@@ -111,20 +136,34 @@ fn bench_optimize(c: &mut Criterion) {
         b.iter(|| {
             let mut e = expr.clone();
             let passes = default_passes();
-            black_box(run_pipeline(&passes, &mut e))
+            black_box(run_pipeline(&passes, &mut e).unwrap())
         })
     });
 
     // Pipeline on already optimized expr
     let mut optimized = expr.clone();
-    run_pipeline(&default_passes(), &mut optimized);
+    run_pipeline(&default_passes(), &mut optimized).unwrap();
     c.bench_function("opt_pipeline_already_optimized", |b| {
         b.iter(|| {
             let mut e = optimized.clone();
             let passes = default_passes();
-            black_box(run_pipeline(&passes, &mut e))
+            black_box(run_pipeline(&passes, &mut e).unwrap())
         })
     });
+
+    // Pipeline convergence
+    let mut group = c.benchmark_group("opt_pipeline_convergence");
+    for &depth in &[10, 50, 100] {
+        let e = convergence_expr(depth);
+        group.bench_with_input(BenchmarkId::from_parameter(depth), &depth, |b, _| {
+            b.iter(|| {
+                let mut e = e.clone();
+                let passes = default_passes();
+                black_box(run_pipeline(&passes, &mut e).unwrap())
+            })
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(benches, bench_optimize);


### PR DESCRIPTION
This PR adds several new Criterion benchmarks to the `tidepool-testing` crate to improve our measurement of the system's performance characteristics.

### New Benchmarks:
1.  **GC Stress Test** (`benches/heap.rs`): 
    - Measures `gc_cycle` time at scales of 1K, 10K, and 100K thunk allocations.
    - Tests varying liveness ratios (10%, 50%, 90%) to simulate different memory pressures.
2.  **Deep Nested Structure** (`benches/heap.rs`):
    - Builds linked lists of thunks with depths of 1K, 5K, and 10K.
    - Exercises the recursive thunk reference collection during GC trace.
3.  **JIT Compilation Latency** (`benches/codegen.rs`):
    - Measures the time to compile `CoreExpr` trees of varying sizes (50, 200, 500 nodes).
    - Includes benchmarks for both arithmetic trees and long let chains.
4.  **Optimization Pipeline Convergence** (`benches/optimize.rs`):
    - Measures the total pipeline time for expressions that require multiple passes to reach a fixed point.
    - Uses deeply nested lambda/app/let structures of depths 10, 50, and 100.

### Addressed Copilot Review:
- **`codegen` benchmark**: Fixed an unbound variable in `build_let_expr` and added a guard against `size=0` in `build_expr`.
- **`heap` benchmark**: Adjusted `gc_deep_nested` to produce exactly `depth` chain.
- **`optimize` benchmark**: Moved optimization pass construction out of the iteration loop for more accurate measurements and replaced `.unwrap()` with `.expect()` for better diagnostics.

### Verification:
- `cargo bench -p tidepool-testing -- --test` passed, ensuring all new benchmarks run correctly.
- `cargo test -p tidepool-testing` passed.
- `cargo clippy -p tidepool-testing` passed without warnings.