### PR TITLE
feat: add compiler binary fingerprint to cache key

### DIFF
--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -18,6 +18,7 @@ tidepool-codegen = { version = "0.1.0", path = "../tidepool-codegen" }
 serde_json = "1"
 tempfile = "3"
 blake3 = "1"
+which = "7"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -31,7 +31,28 @@ pub(crate) fn cache_key(source: &str, target: &str, include: &[&Path]) -> String
         fingerprint_dir(root, &mut hasher);
     }
 
+    extract_binary_fingerprint(&mut hasher);
+
     hasher.finalize().to_hex().to_string()
+}
+
+/// Fingerprints the compiler binary to ensure cache invalidation on upgrades.
+fn extract_binary_fingerprint(hasher: &mut blake3::Hasher) {
+    let extract_bin = std::env::var("TIDEPOOL_EXTRACT")
+        .map(PathBuf::from)
+        .or_else(|_| which::which("tidepool-extract"))
+        .ok();
+
+    if let Some(path) = extract_bin {
+        if let Ok(meta) = fs::metadata(path) {
+            hasher.update(&meta.len().to_le_bytes());
+            if let Ok(mtime) = meta.modified() {
+                if let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH) {
+                    hasher.update(&dur.as_nanos().to_le_bytes());
+                }
+            }
+        }
+    }
 }
 
 /// Recursively walks a directory to fingerprint its contents.

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -38,12 +38,10 @@ pub(crate) fn cache_key(source: &str, target: &str, include: &[&Path]) -> String
 
 /// Fingerprints the compiler binary to ensure cache invalidation on upgrades.
 fn extract_binary_fingerprint(hasher: &mut blake3::Hasher) {
-    let extract_bin = std::env::var("TIDEPOOL_EXTRACT")
-        .map(PathBuf::from)
-        .or_else(|_| which::which("tidepool-extract"))
-        .ok();
+    let bin_name = std::env::var("TIDEPOOL_EXTRACT")
+        .unwrap_or_else(|_| "tidepool-extract".to_string());
 
-    if let Some(path) = extract_bin {
+    if let Ok(path) = which::which(bin_name) {
         if let Ok(meta) = fs::metadata(path) {
             hasher.update(&meta.len().to_le_bytes());
             if let Ok(mtime) = meta.modified() {


### PR DESCRIPTION
Add tidepool-extract binary fingerprint (mtime + file size) to the blake3 cache key in tidepool-runtime/src/cache.rs. This ensures the CBOR cache auto-invalidates when the compiler binary changes.

Changes:
- Add `which = "7"` to `tidepool-runtime/Cargo.toml`.
- Add `extract_binary_fingerprint` helper in `tidepool-runtime/src/cache.rs`.
- Call `extract_binary_fingerprint` in `cache_key`.
- Fixed binary path resolution to use `which` even when `TIDEPOOL_EXTRACT` is just a command name, as requested in review.
- Graceful degradation if the binary cannot be found.
- Verified with tests, clippy, and cargo check.

Note: I did not add new unit tests as per the strict boundary "Do NOT add new tests — a separate leaf handles tests."