### PR TITLE
feat: add 8-byte version header to CBOR files

### DIFF
--- a/tidepool-repr/src/builder.rs
+++ b/tidepool-repr/src/builder.rs
@@ -40,10 +40,12 @@ impl TreeBuilder {
     /// Returns the offset of the first added node.
     pub fn push_tree(&mut self, other: TreeBuilder) -> usize {
         let offset = self.nodes.len();
-        self.nodes
-            .extend(other.nodes.into_iter().map(|node| {
-                node.map_layer(|idx| idx + offset)
-            }));
+        self.nodes.extend(
+            other
+                .nodes
+                .into_iter()
+                .map(|node| node.map_layer(|idx| idx + offset)),
+        );
         offset
     }
 

--- a/tidepool-repr/src/free_vars.rs
+++ b/tidepool-repr/src/free_vars.rs
@@ -9,7 +9,9 @@ pub fn free_vars(tree: &CoreExpr) -> Vec<VarId> {
     if tree.nodes.is_empty() {
         return Vec::new();
     }
-    let mut fvs: Vec<VarId> = free_vars_at(tree, tree.nodes.len() - 1).into_iter().collect();
+    let mut fvs: Vec<VarId> = free_vars_at(tree, tree.nodes.len() - 1)
+        .into_iter()
+        .collect();
     fvs.sort_unstable();
     fvs
 }
@@ -87,9 +89,7 @@ fn free_vars_at(tree: &CoreExpr, idx: usize) -> FxHashSet<VarId> {
             s.extend(body_fvs);
             s
         }
-        CoreFrame::Jump { args, .. } => {
-            args.iter().flat_map(|a| free_vars_at(tree, *a)).collect()
-        }
+        CoreFrame::Jump { args, .. } => args.iter().flat_map(|a| free_vars_at(tree, *a)).collect(),
         CoreFrame::PrimOp { args, .. } => {
             args.iter().flat_map(|a| free_vars_at(tree, *a)).collect()
         }
@@ -274,7 +274,10 @@ mod tests {
         let fvs = free_vars(&tree_expr);
         assert!(fvs.binary_search(&y).is_ok(), "y should be free");
         assert!(fvs.binary_search(&z).is_ok(), "z should be free");
-        assert!(fvs.binary_search(&x).is_err(), "x should be bound by join param");
+        assert!(
+            fvs.binary_search(&x).is_err(),
+            "x should be bound by join param"
+        );
     }
 
     #[test]

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -32,6 +32,9 @@ pub enum ReadError {
     /// Not a Tidepool CBOR file (bad magic bytes).
     #[error("Not a Tidepool CBOR file (bad magic bytes)")]
     InvalidMagic,
+    /// Truncated or incomplete Tidepool CBOR header.
+    #[error("Truncated or incomplete Tidepool CBOR header")]
+    TruncatedHeader,
     /// Unsupported CBOR version.
     #[error("Unsupported CBOR version {0}.{1}")]
     UnsupportedVersion(u16, u16),

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -29,7 +29,20 @@ pub enum ReadError {
     /// The structural layout of the CBOR data does not match Tidepool IR.
     #[error("Invalid structure: {0}")]
     InvalidStructure(String),
+    /// Not a Tidepool CBOR file (bad magic bytes).
+    #[error("Not a Tidepool CBOR file (bad magic bytes)")]
+    InvalidMagic,
+    /// Unsupported CBOR version.
+    #[error("Unsupported CBOR version {0}.{1}")]
+    UnsupportedVersion(u16, u16),
 }
+
+/// 4-byte magic: ASCII 'TPLR'
+pub const HEADER_MAGIC: [u8; 4] = [0x54, 0x50, 0x4C, 0x52];
+pub const VERSION_MAJOR: u16 = 1;
+pub const VERSION_MINOR: u16 = 0;
+/// Total header length in bytes.
+pub const HEADER_LEN: usize = 8;
 
 /// Errors that can occur during CBOR serialization of Tidepool IR.
 #[derive(Debug, thiserror::Error)]

--- a/tidepool-repr/src/serial/read.rs
+++ b/tidepool-repr/src/serial/read.rs
@@ -6,8 +6,28 @@ use crate::tree::RecursiveTree;
 use crate::types::{Alt, AltCon, DataConId, JoinId, Literal, PrimOpKind, VarId};
 use ciborium::value::Value;
 
+/// Strip and validate the 8-byte version header. Returns the CBOR payload slice.
+/// For backward compatibility, if the first 4 bytes are NOT the magic, assume
+/// legacy headerless format and return the entire slice.
+fn strip_header(bytes: &[u8]) -> Result<&[u8], ReadError> {
+    if bytes.len() >= super::HEADER_LEN && bytes[..4] == super::HEADER_MAGIC {
+        let major = u16::from_be_bytes([bytes[4], bytes[5]]);
+        let minor = u16::from_be_bytes([bytes[6], bytes[7]]);
+        if major != super::VERSION_MAJOR {
+            return Err(ReadError::UnsupportedVersion(major, minor));
+        }
+        Ok(&bytes[super::HEADER_LEN..])
+    } else if bytes.len() >= 4 && bytes[..4] == super::HEADER_MAGIC {
+        Err(ReadError::InvalidMagic)
+    } else {
+        // Legacy headerless CBOR — pass through
+        Ok(bytes)
+    }
+}
+
 /// Reads a CoreExpr from a CBOR-encoded byte slice.
 pub fn read_cbor(bytes: &[u8]) -> Result<RecursiveTree<CoreFrame<usize>>, ReadError> {
+    let bytes = strip_header(bytes)?;
     let tree_val: Value =
         ciborium::de::from_reader(bytes).map_err(|e| ReadError::Cbor(e.to_string()))?;
 
@@ -70,6 +90,7 @@ pub fn read_metadata(bytes: &[u8]) -> Result<(crate::DataConTable, MetaWarnings)
     use crate::datacon_table::DataConTable;
     use crate::types::DataConId;
 
+    let bytes = strip_header(bytes)?;
     let val: Value =
         ciborium::de::from_reader(bytes).map_err(|e| ReadError::Cbor(e.to_string()))?;
 

--- a/tidepool-repr/src/serial/read.rs
+++ b/tidepool-repr/src/serial/read.rs
@@ -10,15 +10,16 @@ use ciborium::value::Value;
 /// For backward compatibility, if the first 4 bytes are NOT the magic, assume
 /// legacy headerless format and return the entire slice.
 fn strip_header(bytes: &[u8]) -> Result<&[u8], ReadError> {
-    if bytes.len() >= super::HEADER_LEN && bytes[..4] == super::HEADER_MAGIC {
+    if bytes.len() >= 4 && bytes[..4] == super::HEADER_MAGIC {
+        if bytes.len() < super::HEADER_LEN {
+            return Err(ReadError::TruncatedHeader);
+        }
         let major = u16::from_be_bytes([bytes[4], bytes[5]]);
         let minor = u16::from_be_bytes([bytes[6], bytes[7]]);
-        if major != super::VERSION_MAJOR {
+        if major != super::VERSION_MAJOR || minor > super::VERSION_MINOR {
             return Err(ReadError::UnsupportedVersion(major, minor));
         }
         Ok(&bytes[super::HEADER_LEN..])
-    } else if bytes.len() >= 4 && bytes[..4] == super::HEADER_MAGIC {
-        Err(ReadError::InvalidMagic)
     } else {
         // Legacy headerless CBOR — pass through
         Ok(bytes)
@@ -561,5 +562,60 @@ fn expect_text(val: &Value) -> Result<&str, ReadError> {
     match val {
         Value::Text(t) => Ok(t.as_str()),
         _ => Err(ReadError::InvalidStructure("expected text".to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_header_valid() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&super::super::HEADER_MAGIC);
+        bytes.extend_from_slice(&super::super::VERSION_MAJOR.to_be_bytes());
+        bytes.extend_from_slice(&super::super::VERSION_MINOR.to_be_bytes());
+        bytes.push(0x80); // empty array in CBOR
+        let stripped = strip_header(&bytes).expect("should succeed");
+        assert_eq!(stripped, &[0x80]);
+    }
+
+    #[test]
+    fn test_strip_header_legacy() {
+        let bytes = [0x80];
+        let stripped = strip_header(&bytes).expect("should succeed");
+        assert_eq!(stripped, &[0x80]);
+    }
+
+    #[test]
+    fn test_strip_header_truncated() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&super::super::HEADER_MAGIC);
+        bytes.push(0x00);
+        let err = strip_header(&bytes).expect_err("should fail");
+        assert!(matches!(err, ReadError::TruncatedHeader));
+    }
+
+    #[test]
+    fn test_strip_header_unsupported_major() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&super::super::HEADER_MAGIC);
+        bytes.extend_from_slice(&2u16.to_be_bytes());
+        bytes.extend_from_slice(&0u16.to_be_bytes());
+        let err = strip_header(&bytes).expect_err("should fail");
+        assert!(matches!(err, ReadError::UnsupportedVersion(2, 0)));
+    }
+
+    #[test]
+    fn test_strip_header_unsupported_minor() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&super::super::HEADER_MAGIC);
+        bytes.extend_from_slice(&super::super::VERSION_MAJOR.to_be_bytes());
+        bytes.extend_from_slice(&(super::super::VERSION_MINOR + 1).to_be_bytes());
+        let err = strip_header(&bytes).expect_err("should fail");
+        assert!(matches!(
+            err,
+            ReadError::UnsupportedVersion(super::super::VERSION_MAJOR, m) if m == super::super::VERSION_MINOR + 1
+        ));
     }
 }

--- a/tidepool-repr/src/serial/write.rs
+++ b/tidepool-repr/src/serial/write.rs
@@ -29,7 +29,13 @@ pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, Wri
     let mut bytes = Vec::new();
     ciborium::ser::into_writer(&tree_val, &mut bytes)
         .map_err(|e| WriteError::Cbor(e.to_string()))?;
-    Ok(bytes)
+
+    let mut out = Vec::with_capacity(super::HEADER_LEN + bytes.len());
+    out.extend_from_slice(&super::HEADER_MAGIC);
+    out.extend_from_slice(&super::VERSION_MAJOR.to_be_bytes());
+    out.extend_from_slice(&super::VERSION_MINOR.to_be_bytes());
+    out.extend_from_slice(&bytes);
+    Ok(out)
 }
 
 /// Writes a DataConTable to CBOR-encoded metadata bytes (new format with warnings).
@@ -81,7 +87,13 @@ pub fn write_metadata(table: &crate::datacon_table::DataConTable) -> Result<Vec<
 
     let mut bytes = Vec::new();
     ciborium::ser::into_writer(&root, &mut bytes).map_err(|e| WriteError::Cbor(e.to_string()))?;
-    Ok(bytes)
+
+    let mut out = Vec::with_capacity(super::HEADER_LEN + bytes.len());
+    out.extend_from_slice(&super::HEADER_MAGIC);
+    out.extend_from_slice(&super::VERSION_MAJOR.to_be_bytes());
+    out.extend_from_slice(&super::VERSION_MINOR.to_be_bytes());
+    out.extend_from_slice(&bytes);
+    Ok(out)
 }
 
 fn encode_frame(frame: &CoreFrame<usize>) -> Value {

--- a/tidepool-repr/src/serial/write.rs
+++ b/tidepool-repr/src/serial/write.rs
@@ -6,6 +6,16 @@ use crate::tree::RecursiveTree;
 use crate::types::{Alt, AltCon, Literal, PrimOpKind};
 use ciborium::value::Value;
 
+/// Prepend the 8-byte version header to a CBOR payload.
+fn prepend_header(bytes: Vec<u8>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(super::HEADER_LEN + bytes.len());
+    out.extend_from_slice(&super::HEADER_MAGIC);
+    out.extend_from_slice(&super::VERSION_MAJOR.to_be_bytes());
+    out.extend_from_slice(&super::VERSION_MINOR.to_be_bytes());
+    out.extend_from_slice(&bytes);
+    out
+}
+
 /// Writes a CoreExpr to a CBOR-encoded byte vector.
 pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, WriteError> {
     if expr.nodes.is_empty() {
@@ -30,12 +40,7 @@ pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, Wri
     ciborium::ser::into_writer(&tree_val, &mut bytes)
         .map_err(|e| WriteError::Cbor(e.to_string()))?;
 
-    let mut out = Vec::with_capacity(super::HEADER_LEN + bytes.len());
-    out.extend_from_slice(&super::HEADER_MAGIC);
-    out.extend_from_slice(&super::VERSION_MAJOR.to_be_bytes());
-    out.extend_from_slice(&super::VERSION_MINOR.to_be_bytes());
-    out.extend_from_slice(&bytes);
-    Ok(out)
+    Ok(prepend_header(bytes))
 }
 
 /// Writes a DataConTable to CBOR-encoded metadata bytes (new format with warnings).
@@ -88,12 +93,7 @@ pub fn write_metadata(table: &crate::datacon_table::DataConTable) -> Result<Vec<
     let mut bytes = Vec::new();
     ciborium::ser::into_writer(&root, &mut bytes).map_err(|e| WriteError::Cbor(e.to_string()))?;
 
-    let mut out = Vec::with_capacity(super::HEADER_LEN + bytes.len());
-    out.extend_from_slice(&super::HEADER_MAGIC);
-    out.extend_from_slice(&super::VERSION_MAJOR.to_be_bytes());
-    out.extend_from_slice(&super::VERSION_MINOR.to_be_bytes());
-    out.extend_from_slice(&bytes);
-    Ok(out)
+    Ok(prepend_header(bytes))
 }
 
 fn encode_frame(frame: &CoreFrame<usize>) -> Value {

--- a/tidepool-repr/src/subst.rs
+++ b/tidepool-repr/src/subst.rs
@@ -76,7 +76,12 @@ fn find_max_var_id(tree: &CoreExpr) -> VarId {
 
 /// Recursive helper for substitution.
 /// `env` maps binders that have been renamed (due to capture avoidance) to their new IDs.
-fn subst_at(tree: &CoreExpr, idx: usize, ctx: &mut SubstCtx, env: &FxHashMap<VarId, VarId>) -> usize {
+fn subst_at(
+    tree: &CoreExpr,
+    idx: usize,
+    ctx: &mut SubstCtx,
+    env: &FxHashMap<VarId, VarId>,
+) -> usize {
     match &tree.nodes[idx] {
         CoreFrame::Var(v) => {
             let actual_v = env.get(v).copied().unwrap_or(*v);


### PR DESCRIPTION
This PR adds an 8-byte version header to all Tidepool CBOR files (both IR and metadata) in `tidepool-repr/src/serial/`.

- Header layout:
  - bytes 0-3: magic `0x54504C52` (ASCII 'TPLR')
  - bytes 4-5: major version `u16` big-endian (1)
  - bytes 6-7: minor version `u16` big-endian (0)
- Backward compatibility: `strip_header` falls back to legacy headerless format if the magic bytes are not found.
- Verification: Roundtrip tests in `tidepool-repr` pass. Haskell integration tests in `tidepool-eval` pass (using legacy fallback). Clippy and fmt pass.