### PR TITLE
test: add binary fingerprint cache invalidation tests

### DIFF
--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -32,3 +32,4 @@ tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-mcp = { path = "../tidepool-mcp" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 serial_test = "3"
+filetime = "0.2"

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -137,9 +137,11 @@ pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
 
     #[test]
+    #[serial]
     fn test_cache_key_determinism() {
         let source = "main = print 42";
         let target = "main";
@@ -152,6 +154,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_cache_roundtrip() {
         let temp_dir = TempDir::new().unwrap();
         std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
@@ -167,6 +170,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_cache_key_include_fingerprint() {
         let include_dir = TempDir::new().unwrap();
         let hs_file = include_dir.path().join("Lib.hs");
@@ -187,5 +191,86 @@ mod tests {
             k1, k2,
             "Cache key should change when dependency file changes"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_key_binary_fingerprint_mtime() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let bin_path = temp_dir.path().join("fake-extract");
+        fs::write(&bin_path, b"#!/bin/sh\n").unwrap();
+        fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let old_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut paths = std::env::split_paths(&old_path).collect::<Vec<_>>();
+        paths.insert(0, temp_dir.path().to_path_buf());
+        let new_path_os = std::env::join_paths(paths).unwrap();
+
+        let old_extract = std::env::var_os("TIDEPOOL_EXTRACT");
+
+        std::env::set_var("PATH", new_path_os);
+        std::env::set_var("TIDEPOOL_EXTRACT", "fake-extract");
+
+        let k1 = cache_key("source", "target", &[]);
+
+        // Change mtime
+        let past = filetime::FileTime::from_unix_time(100, 0);
+        filetime::set_file_mtime(&bin_path, past).unwrap();
+
+        let k2 = cache_key("source", "target", &[]);
+        assert_ne!(k1, k2, "Cache key should change when binary mtime changes");
+
+        // Restore env
+        std::env::set_var("PATH", old_path);
+        if let Some(val) = old_extract {
+            std::env::set_var("TIDEPOOL_EXTRACT", val);
+        } else {
+            std::env::remove_var("TIDEPOOL_EXTRACT");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_key_binary_fingerprint_size() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::io::Write;
+
+        let temp_dir = TempDir::new().unwrap();
+        let bin_path = temp_dir.path().join("fake-extract-size");
+        fs::write(&bin_path, b"#!/bin/sh\n").unwrap();
+        fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let old_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut paths = std::env::split_paths(&old_path).collect::<Vec<_>>();
+        paths.insert(0, temp_dir.path().to_path_buf());
+        let new_path_os = std::env::join_paths(paths).unwrap();
+
+        let old_extract = std::env::var_os("TIDEPOOL_EXTRACT");
+
+        std::env::set_var("PATH", new_path_os);
+        std::env::set_var("TIDEPOOL_EXTRACT", "fake-extract-size");
+
+        let k1 = cache_key("source", "target", &[]);
+
+        // Change size
+        let mut file = fs::OpenOptions::new()
+            .append(true)
+            .open(&bin_path)
+            .unwrap();
+        file.write_all(b"extra").unwrap();
+        drop(file);
+
+        let k2 = cache_key("source", "target", &[]);
+        assert_ne!(k1, k2, "Cache key should change when binary size changes");
+
+        // Restore env
+        std::env::set_var("PATH", old_path);
+        if let Some(val) = old_extract {
+            std::env::set_var("TIDEPOOL_EXTRACT", val);
+        } else {
+            std::env::remove_var("TIDEPOOL_EXTRACT");
+        }
     }
 }

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -140,6 +140,30 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
+    /// RAII guard to safely set and restore environment variables in tests.
+    struct EnvGuard {
+        key: &'static str,
+        old_value: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn new(key: &'static str, new_value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let old_value = std::env::var_os(key);
+            std::env::set_var(key, new_value);
+            Self { key, old_value }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(ref old) = self.old_value {
+                std::env::set_var(self.key, old);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
     #[test]
     #[serial]
     fn test_cache_key_determinism() {
@@ -157,7 +181,7 @@ mod tests {
     #[serial]
     fn test_cache_roundtrip() {
         let temp_dir = TempDir::new().unwrap();
-        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+        let _guard = EnvGuard::new("XDG_CACHE_HOME", temp_dir.path());
 
         let key = "test-key";
         let expr = b"expr-data";
@@ -203,15 +227,8 @@ mod tests {
         fs::write(&bin_path, b"#!/bin/sh\n").unwrap();
         fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let old_path = std::env::var_os("PATH").unwrap_or_default();
-        let mut paths = std::env::split_paths(&old_path).collect::<Vec<_>>();
-        paths.insert(0, temp_dir.path().to_path_buf());
-        let new_path_os = std::env::join_paths(paths).unwrap();
-
-        let old_extract = std::env::var_os("TIDEPOOL_EXTRACT");
-
-        std::env::set_var("PATH", new_path_os);
-        std::env::set_var("TIDEPOOL_EXTRACT", "fake-extract");
+        // Point directly to the binary to avoid PATH mutation
+        let _guard = EnvGuard::new("TIDEPOOL_EXTRACT", &bin_path);
 
         let k1 = cache_key("source", "target", &[]);
 
@@ -221,14 +238,6 @@ mod tests {
 
         let k2 = cache_key("source", "target", &[]);
         assert_ne!(k1, k2, "Cache key should change when binary mtime changes");
-
-        // Restore env
-        std::env::set_var("PATH", old_path);
-        if let Some(val) = old_extract {
-            std::env::set_var("TIDEPOOL_EXTRACT", val);
-        } else {
-            std::env::remove_var("TIDEPOOL_EXTRACT");
-        }
     }
 
     #[test]
@@ -242,15 +251,8 @@ mod tests {
         fs::write(&bin_path, b"#!/bin/sh\n").unwrap();
         fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let old_path = std::env::var_os("PATH").unwrap_or_default();
-        let mut paths = std::env::split_paths(&old_path).collect::<Vec<_>>();
-        paths.insert(0, temp_dir.path().to_path_buf());
-        let new_path_os = std::env::join_paths(paths).unwrap();
-
-        let old_extract = std::env::var_os("TIDEPOOL_EXTRACT");
-
-        std::env::set_var("PATH", new_path_os);
-        std::env::set_var("TIDEPOOL_EXTRACT", "fake-extract-size");
+        // Point directly to the binary to avoid PATH mutation
+        let _guard = EnvGuard::new("TIDEPOOL_EXTRACT", &bin_path);
 
         let k1 = cache_key("source", "target", &[]);
 
@@ -264,13 +266,5 @@ mod tests {
 
         let k2 = cache_key("source", "target", &[]);
         assert_ne!(k1, k2, "Cache key should change when binary size changes");
-
-        // Restore env
-        std::env::set_var("PATH", old_path);
-        if let Some(val) = old_extract {
-            std::env::set_var("TIDEPOOL_EXTRACT", val);
-        } else {
-            std::env::remove_var("TIDEPOOL_EXTRACT");
-        }
     }
 }

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -264,6 +264,7 @@ pub fn compile_and_run<U, H: DispatchEffect<U>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     /// Set up TIDEPOOL_EXTRACT env var and check GHC availability.
     /// Returns false if GHC is not available (test should skip).
@@ -289,6 +290,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_compile_identity() {
         if !ensure_extract_available() {
             eprintln!("Skipping: GHC not available (run inside `nix develop`)");
@@ -303,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_compile_error() {
         if !ensure_extract_available() {
             eprintln!("Skipping: GHC not available (run inside `nix develop`)");


### PR DESCRIPTION
This PR adds two new tests to `tidepool-runtime/src/cache.rs` to verify that the cache key correctly invalidates when the `tidepool-extract` binary's modification time or size changes.

Specifically:
- Added `test_cache_key_binary_fingerprint_mtime`: Creates a fake binary, computes the cache key, updates the mtime using `filetime`, and asserts the key changes.
- Added `test_cache_key_binary_fingerprint_size`: Creates a fake binary, computes the cache key, appends bytes to change its size, and asserts the key changes.
- Added `filetime = "0.2"` to `[dev-dependencies]` in `tidepool-runtime/Cargo.toml`.
- Marked all tests in `tidepool-runtime/src/cache.rs` as `#[serial]` to prevent race conditions with environment variables (`PATH`, `TIDEPOOL_EXTRACT`, `XDG_CACHE_HOME`).

Verified with `cargo test -p tidepool-runtime --lib` and `cargo clippy -p tidepool-runtime --no-deps -- -D warnings`.