### PR TITLE
feat: auto-invalidate CBOR cache on tidepool-extract binary change

### DIFF
--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -32,3 +32,4 @@ tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-mcp = { path = "../tidepool-mcp" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 serial_test = "3"
+filetime = "0.2"

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -18,6 +18,7 @@ tidepool-codegen = { version = "0.1.0", path = "../tidepool-codegen" }
 serde_json = "1"
 tempfile = "3"
 blake3 = "1"
+which = "7"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -137,9 +137,35 @@ pub(crate) fn cache_store(key: &str, expr_bytes: &[u8], meta_bytes: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
 
+    /// RAII guard to safely set and restore environment variables in tests.
+    struct EnvGuard {
+        key: &'static str,
+        old_value: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn new(key: &'static str, new_value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let old_value = std::env::var_os(key);
+            std::env::set_var(key, new_value);
+            Self { key, old_value }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(ref old) = self.old_value {
+                std::env::set_var(self.key, old);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
     #[test]
+    #[serial]
     fn test_cache_key_determinism() {
         let source = "main = print 42";
         let target = "main";
@@ -152,9 +178,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_cache_roundtrip() {
         let temp_dir = TempDir::new().unwrap();
-        std::env::set_var("XDG_CACHE_HOME", temp_dir.path());
+        let _guard = EnvGuard::new("XDG_CACHE_HOME", temp_dir.path());
 
         let key = "test-key";
         let expr = b"expr-data";
@@ -167,6 +194,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_cache_key_include_fingerprint() {
         let include_dir = TempDir::new().unwrap();
         let hs_file = include_dir.path().join("Lib.hs");
@@ -187,5 +215,56 @@ mod tests {
             k1, k2,
             "Cache key should change when dependency file changes"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_key_binary_fingerprint_mtime() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let bin_path = temp_dir.path().join("fake-extract");
+        fs::write(&bin_path, b"#!/bin/sh\n").unwrap();
+        fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Point directly to the binary to avoid PATH mutation
+        let _guard = EnvGuard::new("TIDEPOOL_EXTRACT", &bin_path);
+
+        let k1 = cache_key("source", "target", &[]);
+
+        // Change mtime
+        let past = filetime::FileTime::from_unix_time(100, 0);
+        filetime::set_file_mtime(&bin_path, past).unwrap();
+
+        let k2 = cache_key("source", "target", &[]);
+        assert_ne!(k1, k2, "Cache key should change when binary mtime changes");
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_key_binary_fingerprint_size() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::io::Write;
+
+        let temp_dir = TempDir::new().unwrap();
+        let bin_path = temp_dir.path().join("fake-extract-size");
+        fs::write(&bin_path, b"#!/bin/sh\n").unwrap();
+        fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Point directly to the binary to avoid PATH mutation
+        let _guard = EnvGuard::new("TIDEPOOL_EXTRACT", &bin_path);
+
+        let k1 = cache_key("source", "target", &[]);
+
+        // Change size
+        let mut file = fs::OpenOptions::new()
+            .append(true)
+            .open(&bin_path)
+            .unwrap();
+        file.write_all(b"extra").unwrap();
+        drop(file);
+
+        let k2 = cache_key("source", "target", &[]);
+        assert_ne!(k1, k2, "Cache key should change when binary size changes");
     }
 }

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -42,7 +42,9 @@ fn extract_binary_fingerprint(hasher: &mut blake3::Hasher) {
         .unwrap_or_else(|_| "tidepool-extract".to_string());
 
     if let Ok(path) = which::which(bin_name) {
-        if let Ok(meta) = fs::metadata(path) {
+        hasher.update(path.as_os_str().as_encoded_bytes());
+        hasher.update(b"\0");
+        if let Ok(meta) = fs::metadata(&path) {
             hasher.update(&meta.len().to_le_bytes());
             if let Ok(mtime) = meta.modified() {
                 if let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH) {
@@ -217,6 +219,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     #[serial]
     fn test_cache_key_binary_fingerprint_mtime() {
@@ -240,6 +243,7 @@ mod tests {
         assert_ne!(k1, k2, "Cache key should change when binary mtime changes");
     }
 
+    #[cfg(unix)]
     #[test]
     #[serial]
     fn test_cache_key_binary_fingerprint_size() {

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -31,7 +31,26 @@ pub(crate) fn cache_key(source: &str, target: &str, include: &[&Path]) -> String
         fingerprint_dir(root, &mut hasher);
     }
 
+    extract_binary_fingerprint(&mut hasher);
+
     hasher.finalize().to_hex().to_string()
+}
+
+/// Fingerprints the compiler binary to ensure cache invalidation on upgrades.
+fn extract_binary_fingerprint(hasher: &mut blake3::Hasher) {
+    let bin_name = std::env::var("TIDEPOOL_EXTRACT")
+        .unwrap_or_else(|_| "tidepool-extract".to_string());
+
+    if let Ok(path) = which::which(bin_name) {
+        if let Ok(meta) = fs::metadata(path) {
+            hasher.update(&meta.len().to_le_bytes());
+            if let Ok(mtime) = meta.modified() {
+                if let Ok(dur) = mtime.duration_since(std::time::UNIX_EPOCH) {
+                    hasher.update(&dur.as_nanos().to_le_bytes());
+                }
+            }
+        }
+    }
 }
 
 /// Recursively walks a directory to fingerprint its contents.

--- a/tidepool-runtime/src/lib.rs
+++ b/tidepool-runtime/src/lib.rs
@@ -264,6 +264,7 @@ pub fn compile_and_run<U, H: DispatchEffect<U>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     /// Set up TIDEPOOL_EXTRACT env var and check GHC availability.
     /// Returns false if GHC is not available (test should skip).
@@ -289,6 +290,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_compile_identity() {
         if !ensure_extract_available() {
             eprintln!("Skipping: GHC not available (run inside `nix develop`)");
@@ -303,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_compile_error() {
         if !ensure_extract_available() {
             eprintln!("Skipping: GHC not available (run inside `nix develop`)");


### PR DESCRIPTION
## Summary
- Adds tidepool-extract binary fingerprint (mtime + file size) to the blake3 cache key in `tidepool-runtime/src/cache.rs`
- Locates binary via `TIDEPOOL_EXTRACT` env var with `which::which` fallback
- Graceful degradation: if binary not found, fingerprint is silently skipped
- New dependency: `which = "7"` in tidepool-runtime

## Tests
- `test_cache_key_binary_fingerprint_mtime` — changing binary mtime produces different cache key
- `test_cache_key_binary_fingerprint_size` — changing binary size produces different cache key
- All 17 tidepool-runtime lib tests pass

## Motivation
Previously, rebuilding `tidepool-extract` without clearing `~/.cache/tidepool/` would serve stale CBOR from the old binary. This was a recurring footgun (see CLAUDE.md item 16). The cache key now automatically incorporates the compiler binary's identity.