### PR TITLE
test: harden error paths with negative tests and document known limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,14 @@ cargo check --workspace  # Type check
 cargo test --workspace   # Run all tests
 ```
 
+## Known Limitations
+
+- **Stack overflow at ~50+ recursion depth (eval):** The tree-walking interpreter (`tidepool-eval`) uses Rust's call stack for recursion. Deeply recursive Haskell functions (>~50 frames) may overflow. The JIT backend (`tidepool-codegen`) supports TCO and handles deep recursion.
+- **`nub` crashes at ~31 elements with complex `Text`:** O(n²) equality comparisons on `Text` values can trigger "application of non-closure (tag=255)" around 31 elements. Use `nubBy` with simpler comparisons or shorter lists.
+- **`Text`, not `String`:** The JIT evaluates eagerly, making `String` (`[Char]`) expensive. The Prelude standardizes on `Text` — use it everywhere. `show` returns `Text`, `pack` is polymorphic, `error` takes `Text`.
+- **SIGILL = case trap, not missing primop:** All primop variants are implemented. `SIGILL` crashes come from Cranelift `trap` instructions on exhausted case branches (constructor tag mismatch, unexpected value shape). Check constructor tags and case coverage.
+- **No JSON parsing in Haskell:** `encode`/`decode` are removed. Use the `httpGet` effect (parsed on the Rust side via serde_json) or `run` with external tools.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/tidepool-effect/src/dispatch.rs
+++ b/tidepool-effect/src/dispatch.rs
@@ -104,3 +104,136 @@ impl<U, H: EffectHandler<U>, T: DispatchEffect<U>> DispatchEffect<U> for HCons<H
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use frunk::hlist;
+    use tidepool_repr::types::Literal;
+
+    /// Handler that adds 1 to a LitInt request.
+    struct AddOneHandler;
+    impl EffectHandler for AddOneHandler {
+        type Request = Value;
+        fn handle(&mut self, req: Value, _cx: &EffectContext) -> Result<Value, EffectError> {
+            match req {
+                Value::Lit(Literal::LitInt(n)) => Ok(Value::Lit(Literal::LitInt(n + 1))),
+                other => Err(EffectError::UnexpectedValue {
+                    context: "LitInt",
+                    got: format!("{other:?}"),
+                }),
+            }
+        }
+    }
+
+    /// Handler that doubles a LitInt request.
+    struct DoubleHandler;
+    impl EffectHandler for DoubleHandler {
+        type Request = Value;
+        fn handle(&mut self, req: Value, _cx: &EffectContext) -> Result<Value, EffectError> {
+            match req {
+                Value::Lit(Literal::LitInt(n)) => Ok(Value::Lit(Literal::LitInt(n * 2))),
+                other => Err(EffectError::UnexpectedValue {
+                    context: "LitInt",
+                    got: format!("{other:?}"),
+                }),
+            }
+        }
+    }
+
+    fn empty_table() -> DataConTable {
+        DataConTable::new()
+    }
+
+    fn make_cx(table: &DataConTable) -> EffectContext<'_> {
+        EffectContext::with_user(table, &())
+    }
+
+    fn lit_int(n: i64) -> Value {
+        Value::Lit(Literal::LitInt(n))
+    }
+
+    #[test]
+    fn hnil_rejects_all_tags() {
+        let table = empty_table();
+        let cx = make_cx(&table);
+        let result = HNil.dispatch(0, &lit_int(5), &cx);
+        match result {
+            Err(EffectError::UnhandledEffect { tag: 0 }) => {}
+            other => panic!("expected UnhandledEffect {{ tag: 0 }}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_handler_routes_tag_0() {
+        let table = empty_table();
+        let cx = make_cx(&table);
+        let mut handlers = hlist![AddOneHandler];
+        let result = handlers.dispatch(0, &lit_int(10), &cx).unwrap();
+        match result {
+            Value::Lit(Literal::LitInt(11)) => {}
+            other => panic!("expected LitInt(11), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_handler_rejects_tag_1() {
+        let table = empty_table();
+        let cx = make_cx(&table);
+        let mut handlers = hlist![AddOneHandler];
+        let result = handlers.dispatch(1, &lit_int(10), &cx);
+        match result {
+            Err(EffectError::UnhandledEffect { tag: 0 }) => {}
+            // tag is decremented per HCons layer, so HNil sees 0
+            other => panic!("expected UnhandledEffect {{ tag: 0 }}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn two_handlers_route_tag_0_to_head() {
+        let table = empty_table();
+        let cx = make_cx(&table);
+        let mut handlers = hlist![AddOneHandler, DoubleHandler];
+        let result = handlers.dispatch(0, &lit_int(5), &cx).unwrap();
+        match result {
+            Value::Lit(Literal::LitInt(6)) => {} // 5 + 1
+            other => panic!("expected LitInt(6), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn two_handlers_route_tag_1_to_tail() {
+        let table = empty_table();
+        let cx = make_cx(&table);
+        let mut handlers = hlist![AddOneHandler, DoubleHandler];
+        let result = handlers.dispatch(1, &lit_int(5), &cx).unwrap();
+        match result {
+            Value::Lit(Literal::LitInt(10)) => {} // 5 * 2
+            other => panic!("expected LitInt(10), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn two_handlers_reject_tag_2() {
+        let table = empty_table();
+        let cx = make_cx(&table);
+        let mut handlers = hlist![AddOneHandler, DoubleHandler];
+        let result = handlers.dispatch(2, &lit_int(5), &cx);
+        match result {
+            Err(EffectError::UnhandledEffect { tag: 0 }) => {}
+            // tag decremented by 2 (one per HCons), so HNil sees 0
+            other => panic!("expected UnhandledEffect {{ tag: 0 }}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn effect_context_respond_round_trips_value() {
+        let table = empty_table();
+        let cx = make_cx(&table);
+        let result = cx.respond(lit_int(42)).unwrap();
+        match result {
+            Value::Lit(Literal::LitInt(42)) => {}
+            other => panic!("expected LitInt(42), got {other:?}"),
+        }
+    }
+}

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -460,4 +460,142 @@ mod tests {
         // Nothing had no qualified name — should not be in the index
         assert_eq!(recovered.get(DataConId(2)).unwrap().qualified_name, None);
     }
+
+    // --- Negative tests: malformed CBOR → ReadError, not panic ---
+
+    fn cbor_bytes(val: ciborium::value::Value) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&val, &mut bytes).unwrap();
+        bytes
+    }
+
+    #[test]
+    fn test_read_empty_bytes() {
+        assert!(matches!(read_cbor(&[]), Err(ReadError::Cbor(_))));
+    }
+
+    #[test]
+    fn test_read_not_cbor() {
+        assert!(matches!(
+            read_cbor(&[0xFF, 0xFE, 0x00, 0xAB, 0xCD]),
+            Err(ReadError::Cbor(_))
+        ));
+    }
+
+    #[test]
+    fn test_read_wrong_root_type() {
+        let bytes = cbor_bytes(ciborium::value::Value::Integer(42.into()));
+        assert!(matches!(
+            read_cbor(&bytes),
+            Err(ReadError::InvalidStructure(_))
+        ));
+    }
+
+    #[test]
+    fn test_read_root_wrong_length() {
+        let root = ciborium::value::Value::Array(vec![ciborium::value::Value::Array(vec![])]);
+        let bytes = cbor_bytes(root);
+        assert!(matches!(
+            read_cbor(&bytes),
+            Err(ReadError::InvalidStructure(_))
+        ));
+    }
+
+    #[test]
+    fn test_read_empty_nodes() {
+        let root = ciborium::value::Value::Array(vec![
+            ciborium::value::Value::Array(vec![]),
+            ciborium::value::Value::Integer(0.into()),
+        ]);
+        let bytes = cbor_bytes(root);
+        assert!(matches!(
+            read_cbor(&bytes),
+            Err(ReadError::InvalidStructure(_))
+        ));
+    }
+
+    #[test]
+    fn test_read_bad_frame_tag() {
+        let node = ciborium::value::Value::Array(vec![
+            ciborium::value::Value::Text("Bogus".to_string()),
+        ]);
+        let nodes = ciborium::value::Value::Array(vec![node]);
+        let root = ciborium::value::Value::Array(vec![
+            nodes,
+            ciborium::value::Value::Integer(0.into()),
+        ]);
+        let bytes = cbor_bytes(root);
+        assert!(matches!(
+            read_cbor(&bytes),
+            Err(ReadError::InvalidTag(_))
+        ));
+    }
+
+    #[test]
+    fn test_read_bad_primop() {
+        let node = ciborium::value::Value::Array(vec![
+            ciborium::value::Value::Text("PrimOp".to_string()),
+            ciborium::value::Value::Text("NotARealOp".to_string()),
+            ciborium::value::Value::Array(vec![]),
+        ]);
+        let nodes = ciborium::value::Value::Array(vec![node]);
+        let root = ciborium::value::Value::Array(vec![
+            nodes,
+            ciborium::value::Value::Integer(0.into()),
+        ]);
+        let bytes = cbor_bytes(root);
+        assert!(matches!(
+            read_cbor(&bytes),
+            Err(ReadError::InvalidPrimOp(_))
+        ));
+    }
+
+    #[test]
+    fn test_read_index_out_of_bounds() {
+        // App referencing index 5 in a 2-node array
+        let nodes = ciborium::value::Value::Array(vec![
+            ciborium::value::Value::Array(vec![
+                ciborium::value::Value::Text("Var".to_string()),
+                ciborium::value::Value::Integer(1.into()),
+            ]),
+            ciborium::value::Value::Array(vec![
+                ciborium::value::Value::Text("App".to_string()),
+                ciborium::value::Value::Integer(0.into()),
+                ciborium::value::Value::Integer(5.into()), // out of bounds
+            ]),
+        ]);
+        let root = ciborium::value::Value::Array(vec![
+            nodes,
+            ciborium::value::Value::Integer(1.into()),
+        ]);
+        let bytes = cbor_bytes(root);
+        assert!(matches!(
+            read_cbor(&bytes),
+            Err(ReadError::InvalidStructure(_))
+        ));
+    }
+
+    #[test]
+    fn test_read_metadata_not_array() {
+        let bytes = cbor_bytes(ciborium::value::Value::Integer(99.into()));
+        assert!(matches!(
+            read_metadata(&bytes),
+            Err(ReadError::InvalidStructure(_))
+        ));
+    }
+
+    #[test]
+    fn test_read_metadata_bad_entry() {
+        // Entry with only 2 fields instead of 5
+        let bad_entry = ciborium::value::Value::Array(vec![
+            ciborium::value::Value::Integer(1.into()),
+            ciborium::value::Value::Text("Bad".to_string()),
+        ]);
+        let root = ciborium::value::Value::Array(vec![bad_entry]);
+        let bytes = cbor_bytes(root);
+        assert!(matches!(
+            read_metadata(&bytes),
+            Err(ReadError::InvalidStructure(_))
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Error-handling hardening across three fronts:

- **tidepool-repr**: +10 negative CBOR tests (+138 lines) verifying `ReadError` is returned (not panics) for corrupt inputs — empty bytes, non-CBOR garbage, wrong root type/length, empty nodes, bad frame tags, unknown primops, out-of-bounds indices, malformed metadata. Complements existing proptest fuzz coverage with targeted cases per `ReadError` variant.
- **tidepool-effect**: +7 smoke tests (+133 lines) for `dispatch.rs` — previously had no standalone tests for `DispatchEffect`. Covers `HNil` tag rejection, single/multi-handler HList routing, tag decrement on tail recursion, and `EffectContext::respond` round-trip.
- **README.md**: new "Known Limitations" section documenting the eval stack overflow threshold, `nub` crash at ~31 complex Text elements, Text-not-String convention, SIGILL case trap semantics, and removed in-Haskell JSON parsing.

No production code changes — all work is additive (tests + docs).

## Test plan

- [x] `cargo test -p tidepool-repr` — 96 unit + 9 proptest pass
- [x] `cargo test -p tidepool-effect` — 10 unit tests pass (7 new + 3 existing)
- [x] README renders cleanly as markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)