### PR TITLE
fix(test): update JIT tests to use renamed effect helpers

### DIFF
--- a/tidepool/src/main.rs
+++ b/tidepool/src/main.rs
@@ -1874,7 +1874,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_jit_console_roundtrip() {
-        let result = jit_eval(&["say \"hello from JIT\"", "pure (toJSON True)"]);
+        let result = jit_eval(&["putStrLn \"hello from JIT\"", "pure (toJSON True)"]);
         assert_eq!(result, serde_json::json!(true));
     }
 
@@ -1890,14 +1890,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_jit_fs_exists_roundtrip() {
-        let result = jit_eval(&["b <- fsExists \"Cargo.toml\"", "pure (toJSON b)"]);
+        let result = jit_eval(&["b <- doesFileExist \"Cargo.toml\"", "pure (toJSON b)"]);
         assert_eq!(result, serde_json::json!(true));
     }
 
     #[tokio::test]
     async fn test_jit_fs_listdir_roundtrip() {
         let result = jit_eval(&[
-            "entries <- fsListDir \".\"",
+            "entries <- listDirectory \".\"",
             "pure (toJSON (length entries > 0))",
         ]);
         assert_eq!(result, serde_json::json!(true));


### PR DESCRIPTION
## Summary

Three JIT roundtrip tests in `tidepool/src/main.rs` were using the old effect helper names and failing after commit 7873bda (`feat(mcp): rename effect helpers to standard Haskell names`):

| Old name | New name |
|---|---|
| `say` | `putStrLn` |
| `fsExists` | `doesFileExist` |
| `fsListDir` | `listDirectory` |

Affected tests:
- `test_jit_console_roundtrip`
- `test_jit_fs_exists_roundtrip`
- `test_jit_fs_listdir_roundtrip`

## Test plan

- [x] `cargo test -p tidepool --bin tidepool tests::test_jit` — 4 passed, 0 failed
- [x] `cargo test --workspace --no-fail-fast` — 1505 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)