### PR TITLE
fix(prelude): add monomorphic insertWith shadow for Text-keyed Maps

### DIFF
--- a/haskell/lib/Tidepool/Prelude.hs
+++ b/haskell/lib/Tidepool/Prelude.hs
@@ -129,9 +129,9 @@ module Tidepool.Prelude
   , Map.singleton, Map.empty
   , Map.findWithDefault, Map.adjust
   , Map.unionWith, Map.intersectionWith
-    -- * Map insertWith (local impl — avoids GHC's internal unfolding timeout)
-  , insertWith
     -- * Set type (use qualified Set.xxx via preamble's `import qualified Data.Set as Set`)
+    -- * Map helpers (local impls — unqualified, unlike Map.* re-exports above)
+  , insertWith
   ) where
 
 import Prelude

--- a/haskell/lib/Tidepool/Prelude.hs
+++ b/haskell/lib/Tidepool/Prelude.hs
@@ -129,6 +129,8 @@ module Tidepool.Prelude
   , Map.singleton, Map.empty
   , Map.findWithDefault, Map.adjust
   , Map.unionWith, Map.intersectionWith
+    -- * Map insertWith (local impl — avoids GHC's internal unfolding timeout)
+  , insertWith
     -- * Set type (use qualified Set.xxx via preamble's `import qualified Data.Set as Set`)
   ) where
 
@@ -832,4 +834,19 @@ nubBy eq xs = go [] xs
 -- | Tail-recursive nub (uses nubBy).
 nub :: (Eq a) => [a] -> [a]
 nub = nubBy (==)
+
+-- ---------------------------------------------------------------------------
+-- Map insertWith (local impl — avoids GHC's internal unfolding)
+-- ---------------------------------------------------------------------------
+
+-- | @insertWith f key new m@ — if @key@ exists with value @old@, store @f new old@;
+-- otherwise insert @new@. Monomorphic on Text keys to avoid pulling in GHC's
+-- internal Data.Map.Strict.insertWith which causes timeout under the JIT
+-- (complex balance/rotation unfoldings + Ord dictionary re-evaluation).
+-- Uses Map.lookup + Map.insert which are known working.
+insertWith :: (a -> a -> a) -> Text -> a -> Map Text a -> Map Text a
+insertWith f k v m = case Map.lookup k m of
+  Just old -> let !combined = f v old in Map.insert k combined m
+  Nothing  -> Map.insert k v m
+{-# INLINE insertWith #-}
 


### PR DESCRIPTION
## Summary
- Adds `insertWith` to `Tidepool.Prelude` — monomorphic on `Text` keys
- Implements via `Map.lookup` + `Map.insert` (both already exported and working under the JIT)
- Uses bang pattern on combined value (`!combined`) to match `Data.Map.Strict` semantics and prevent thunk buildup
- `Map.insertWith` was deliberately excluded from exports due to GHC's internal unfolding causing timeout (~120s) on ~86+ elements

## Why
GHC's `Data.Map.Strict.insertWith` inlines to complex tree rebalancing unfoldings (`balanceL`/`balanceR`/`singleton`) that cause the JIT to timeout. The double-traversal approach (lookup then insert) trades ~2x comparisons per element for reliable completion — on 86 elements with tree depth ~7, this is ~1200 vs ~600 comparisons, completing in well under 1s.

## Test plan
- [x] `cabal build tidepool-extract-bin` succeeds
- [x] `cargo check --workspace` clean
- [ ] `cargo test --workspace` (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)