### PR TITLE
docs: add comprehensive doc comments to tidepool-repr and tidepool-eval

### DIFF
--- a/tidepool-eval/src/env.rs
+++ b/tidepool-eval/src/env.rs
@@ -4,8 +4,10 @@ use crate::value::Value;
 use im::HashMap;
 use tidepool_repr::VarId;
 
-/// Evaluation environment: variable bindings.
-/// Uses im::HashMap for O(1) clone (structural sharing).
+/// Evaluation environment: mapping from [`VarId`] to [`Value`].
+///
+/// Uses an `im::HashMap` for efficient structural sharing, allowing
+/// closures to capture their environment with minimal overhead.
 pub type Env = HashMap<VarId, Value>;
 
 #[cfg(test)]

--- a/tidepool-eval/src/error.rs
+++ b/tidepool-eval/src/error.rs
@@ -30,7 +30,9 @@ impl std::fmt::Display for ValueKind {
     }
 }
 
-/// Evaluation error.
+/// Errors that can occur during interpretation.
+///
+/// Includes runtime type errors, unbound variables, and arity mismatches.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum EvalError {
     /// Variable not found in environment

--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -75,11 +75,13 @@ pub fn force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
     }
 }
 
-/// Iteratively evaluate a value to full normal form.
+/// Iteratively evaluate a value through constructor structure.
 ///
 /// Unlike [`force`], which stops at the outermost constructor (WHNF),
-/// `deep_force` traverses the entire value tree and evaluates all nested
-/// thunks. Returns a tree where no thunk references remain.
+/// `deep_force` recursively traverses constructor fields and `ConFun`
+/// accumulated arguments, forcing any nested thunks found there.
+/// Other value forms (such as captured environments inside closures or
+/// continuations) are treated as opaque and returned unchanged.
 ///
 /// Uses an explicit work stack instead of recursion to handle deep
 /// structures (e.g., long lists) without overflowing the Rust stack.

--- a/tidepool-eval/src/eval.rs
+++ b/tidepool-eval/src/eval.rs
@@ -28,7 +28,11 @@ pub fn env_from_datacon_table(table: &DataConTable) -> Env {
         .collect()
 }
 
-/// Evaluate a CoreExpr to a Value.
+/// Evaluate a [`CoreExpr`] to a [`Value`] under a given environment and heap.
+///
+/// Returns a value in Weak Head Normal Form (WHNF). This only forces the
+/// top-level constructor or closure; use [`deep_force`] to fully evaluate
+/// all fields.
 pub fn eval(expr: &CoreExpr, env: &Env, heap: &mut dyn Heap) -> Result<Value, EvalError> {
     if expr.nodes.is_empty() {
         return Err(EvalError::TypeMismatch {
@@ -40,7 +44,10 @@ pub fn eval(expr: &CoreExpr, env: &Env, heap: &mut dyn Heap) -> Result<Value, Ev
     force(res, heap)
 }
 
-/// Force a thunk to a value.
+/// Force a value to Weak Head Normal Form (WHNF).
+///
+/// If the value is a thunk, it is evaluated and stored back into the heap.
+/// If it is already a constructor, literal, or closure, it is returned as-is.
 pub fn force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
     match val {
         Value::ThunkRef(id) => {
@@ -68,10 +75,14 @@ pub fn force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
     }
 }
 
-/// Iteratively force a value — forces all thunks inside constructors,
-/// producing a fully-evaluated tree with no `ThunkRef` values.
+/// Iteratively evaluate a value to full normal form.
+///
+/// Unlike [`force`], which stops at the outermost constructor (WHNF),
+/// `deep_force` traverses the entire value tree and evaluates all nested
+/// thunks. Returns a tree where no thunk references remain.
+///
 /// Uses an explicit work stack instead of recursion to handle deep
-/// structures (e.g. 1000-element lists) without overflowing the Rust stack.
+/// structures (e.g., long lists) without overflowing the Rust stack.
 pub fn deep_force(val: Value, heap: &mut dyn Heap) -> Result<Value, EvalError> {
     use tidepool_repr::DataConId;
 

--- a/tidepool-eval/src/heap.rs
+++ b/tidepool-eval/src/heap.rs
@@ -4,18 +4,24 @@ use crate::env::Env;
 use crate::value::{ThunkId, Value};
 use tidepool_repr::CoreExpr;
 
-/// State of a thunk in the thunk store.
+/// The evaluation state of a lazy thunk.
+///
+/// Follows the standard GHC lifecycle: `Unevaluated` -> `BlackHole` -> `Evaluated`.
 #[derive(Debug, Clone)]
 pub enum ThunkState {
-    /// Initial state: captured environment and expression.
+    /// Initial state: captured environment and expression to be evaluated.
     Unevaluated(Env, CoreExpr),
-    /// Under evaluation: used for infinite loop (cycle) detection.
+    /// Under evaluation: used to detect infinite loops (circular dependencies).
     BlackHole,
-    /// Final state: successfully evaluated to WHNF.
+    /// Final state: has been successfully evaluated to WHNF.
     Evaluated(Value),
 }
 
-/// Heap trait: abstraction for thunk storage.
+/// Abstract storage for thunks.
+///
+/// Decouples the interpreter from the concrete memory management strategy,
+/// allowing for simple vector-backed heaps or more complex garbage-collected
+/// arenas.
 pub trait Heap {
     /// Reserve an ID and store an unevaluated expression.
     fn alloc(&mut self, env: Env, expr: CoreExpr) -> ThunkId;

--- a/tidepool-eval/src/lib.rs
+++ b/tidepool-eval/src/lib.rs
@@ -1,7 +1,8 @@
 //! Tree-walking interpreter for Tidepool Core expressions.
 //!
-//! Provides `Value`, environment management, thunk allocation, and a lazy
-//! evaluator that reduces `CoreExpr` to `Value`.
+//! Provides a lazy, big-step evaluator for [`tidepool_repr::CoreExpr`].
+//! Includes runtime representations ([`Value`]), environment management ([`Env`]),
+//! and thunk storage ([`Heap`]).
 
 pub mod env;
 pub mod error;

--- a/tidepool-eval/src/value.rs
+++ b/tidepool-eval/src/value.rs
@@ -11,6 +11,10 @@ use tidepool_repr::{CoreExpr, DataConId, Literal, VarId};
 pub type SharedByteArray = Arc<Mutex<Vec<u8>>>;
 
 /// Runtime value for the tree-walking interpreter.
+///
+/// Represents an object in Weak Head Normal Form (WHNF). This includes
+/// fully-applied constructors, closures, literals, and references to
+/// lazy thunks.
 #[derive(Debug, Clone)]
 pub enum Value {
     /// Primitive literal value (Int#, Word#, Char#, String#, Float#, Double#).

--- a/tidepool-optimize/src/beta.rs
+++ b/tidepool-optimize/src/beta.rs
@@ -3,8 +3,10 @@
 use tidepool_eval::{Changed, Pass};
 use tidepool_repr::{replace_subtree, CoreExpr, CoreFrame};
 
-/// Beta reduction pass: find `App { fun, arg }` where `fun` is a `Lam { binder, body }`.
-/// Replaces it with `subst(body, binder, arg)`.
+/// Optimization pass: beta reduction.
+///
+/// Replaces function applications `(\x -> body) arg` with the body where
+/// `x` is substituted for `arg`.
 pub struct BetaReduce;
 
 impl Pass for BetaReduce {

--- a/tidepool-repr/src/free_vars.rs
+++ b/tidepool-repr/src/free_vars.rs
@@ -4,7 +4,7 @@ use crate::{CoreExpr, CoreFrame, VarId};
 use rustc_hash::FxHashSet;
 
 /// Collect all free variables in the expression rooted at the given node.
-/// Returns a sorted, deduplicated Vec<VarId> for efficient access and minimal allocation.
+/// Returns a sorted, deduplicated `Vec<VarId>` for efficient access and minimal allocation.
 pub fn free_vars(tree: &CoreExpr) -> Vec<VarId> {
     if tree.nodes.is_empty() {
         return Vec::new();

--- a/tidepool-repr/src/free_vars.rs
+++ b/tidepool-repr/src/free_vars.rs
@@ -3,7 +3,7 @@
 use crate::{CoreExpr, CoreFrame, VarId};
 use rustc_hash::FxHashSet;
 
-/// Collect all free variables in the expression rooted at the given node.
+/// Collect all free variables in the expression rooted at this tree's root node.
 /// Returns a sorted, deduplicated `Vec<VarId>` for efficient access and minimal allocation.
 pub fn free_vars(tree: &CoreExpr) -> Vec<VarId> {
     if tree.nodes.is_empty() {

--- a/tidepool-repr/src/lib.rs
+++ b/tidepool-repr/src/lib.rs
@@ -1,7 +1,9 @@
 //! Core representation types for Tidepool's GHC Core IR.
 //!
-//! Defines `CoreExpr` (a recursive tree of `CoreFrame` nodes), `DataConTable`,
-//! literals, variables, and CBOR serialization.
+//! Provides the primary intermediate representation (IR) used by Tidepool.
+//! The IR is a recursive tree of [`CoreFrame`] nodes, typically manipulated
+//! as a [`CoreExpr`]. It also defines identifiers, literals, and a
+//! [`DataConTable`] for constructor metadata.
 
 pub mod builder;
 pub mod datacon;
@@ -21,5 +23,9 @@ pub use frame::*;
 pub use tree::*;
 pub use types::*;
 
-/// A complete Core expression, stored as a flat recursive tree.
+/// Core IR expression: a recursion scheme over [`CoreFrame`] nodes.
+///
+/// This is the primary interchange format between the Haskell frontend
+/// (which translates GHC Core into this tree) and the Rust backend
+/// (which optimizes it or compiles it into machine code).
 pub type CoreExpr = RecursiveTree<CoreFrame<usize>>;

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -1,4 +1,8 @@
-//! Serialization and deserialization for Tidepool IR using CBOR.
+//! CBOR serialization and deserialization for Tidepool IR.
+//!
+//! Provides the binary format for transferring IR from the Haskell frontend
+//! to the Rust runtime. Includes serialization for both expressions and
+//! constructor metadata tables.
 
 pub mod read;
 pub mod write;
@@ -9,6 +13,8 @@ pub use write::write_cbor;
 pub use write::write_metadata;
 
 /// Errors that can occur during CBOR deserialization of Tidepool IR.
+///
+/// Wraps underlying `ciborium` errors and adds structural context.
 #[derive(Debug, thiserror::Error)]
 pub enum ReadError {
     /// An error occurred in the underlying CBOR parser.
@@ -529,19 +535,13 @@ mod tests {
 
     #[test]
     fn test_read_bad_frame_tag() {
-        let node = ciborium::value::Value::Array(vec![
-            ciborium::value::Value::Text("Bogus".to_string()),
-        ]);
+        let node =
+            ciborium::value::Value::Array(vec![ciborium::value::Value::Text("Bogus".to_string())]);
         let nodes = ciborium::value::Value::Array(vec![node]);
-        let root = ciborium::value::Value::Array(vec![
-            nodes,
-            ciborium::value::Value::Integer(0.into()),
-        ]);
+        let root =
+            ciborium::value::Value::Array(vec![nodes, ciborium::value::Value::Integer(0.into())]);
         let bytes = cbor_bytes(root);
-        assert!(matches!(
-            read_cbor(&bytes),
-            Err(ReadError::InvalidTag(_))
-        ));
+        assert!(matches!(read_cbor(&bytes), Err(ReadError::InvalidTag(_))));
     }
 
     #[test]
@@ -552,10 +552,8 @@ mod tests {
             ciborium::value::Value::Array(vec![]),
         ]);
         let nodes = ciborium::value::Value::Array(vec![node]);
-        let root = ciborium::value::Value::Array(vec![
-            nodes,
-            ciborium::value::Value::Integer(0.into()),
-        ]);
+        let root =
+            ciborium::value::Value::Array(vec![nodes, ciborium::value::Value::Integer(0.into())]);
         let bytes = cbor_bytes(root);
         assert!(matches!(
             read_cbor(&bytes),
@@ -577,10 +575,8 @@ mod tests {
                 ciborium::value::Value::Integer(5.into()), // out of bounds
             ]),
         ]);
-        let root = ciborium::value::Value::Array(vec![
-            nodes,
-            ciborium::value::Value::Integer(1.into()),
-        ]);
+        let root =
+            ciborium::value::Value::Array(vec![nodes, ciborium::value::Value::Integer(1.into())]);
         let bytes = cbor_bytes(root);
         assert!(matches!(
             read_cbor(&bytes),

--- a/tidepool-repr/src/serial/read.rs
+++ b/tidepool-repr/src/serial/read.rs
@@ -28,8 +28,9 @@ fn strip_header(bytes: &[u8]) -> Result<&[u8], ReadError> {
 
 /// Reads a [`crate::CoreExpr`] from a CBOR-encoded byte slice.
 ///
-/// Decodes the binary representation of a Core expression tree, which
-/// is expected to be preceded by the `TPLR` magic header.
+/// Decodes the binary representation of a Core expression tree. The input may
+/// be preceded by the `TPLR` magic/version header; for backward compatibility,
+/// legacy headerless CBOR is also accepted.
 pub fn read_cbor(bytes: &[u8]) -> Result<RecursiveTree<CoreFrame<usize>>, ReadError> {
     let bytes = strip_header(bytes)?;
     let tree_val: Value =

--- a/tidepool-repr/src/serial/read.rs
+++ b/tidepool-repr/src/serial/read.rs
@@ -26,7 +26,10 @@ fn strip_header(bytes: &[u8]) -> Result<&[u8], ReadError> {
     }
 }
 
-/// Reads a CoreExpr from a CBOR-encoded byte slice.
+/// Reads a [`crate::CoreExpr`] from a CBOR-encoded byte slice.
+///
+/// Decodes the binary representation of a Core expression tree, which
+/// is expected to be preceded by the `TPLR` magic header.
 pub fn read_cbor(bytes: &[u8]) -> Result<RecursiveTree<CoreFrame<usize>>, ReadError> {
     let bytes = strip_header(bytes)?;
     let tree_val: Value =

--- a/tidepool-repr/src/serial/write.rs
+++ b/tidepool-repr/src/serial/write.rs
@@ -13,7 +13,10 @@ fn write_header(buf: &mut Vec<u8>) {
     buf.extend_from_slice(&super::VERSION_MINOR.to_be_bytes());
 }
 
-/// Writes a CoreExpr to a CBOR-encoded byte vector.
+/// Writes a [`crate::CoreExpr`] to a CBOR-encoded byte vector.
+///
+/// Encodes a Core expression into the binary format, including the
+/// `TPLR` magic header and current version information.
 pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, WriteError> {
     if expr.nodes.is_empty() {
         return Err(WriteError::Cbor(

--- a/tidepool-repr/src/tree.rs
+++ b/tidepool-repr/src/tree.rs
@@ -6,7 +6,8 @@ use std::collections::HashMap;
 
 /// A tree stored as a flat vector of frames.
 ///
-/// Children are stored as `usize` indices into the `nodes` vector.
+/// In Tidepool's IR, [`crate::CoreExpr`] is a `RecursiveTree<CoreFrame<usize>>`
+/// where children are stored as `usize` indices into the `nodes` vector.
 /// This flat layout improves cache locality and allows for efficient
 /// serialization without pointer-based traversal.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tidepool-repr/src/tree.rs
+++ b/tidepool-repr/src/tree.rs
@@ -4,7 +4,11 @@ use crate::frame::CoreFrame;
 use crate::types::Alt;
 use std::collections::HashMap;
 
-/// A tree stored as a flat vector of frames. Children are `usize` indices into `nodes`.
+/// A tree stored as a flat vector of frames.
+///
+/// Children are stored as `usize` indices into the `nodes` vector.
+/// This flat layout improves cache locality and allows for efficient
+/// serialization without pointer-based traversal.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecursiveTree<F> {
     /// The nodes of the tree. The root is typically the last node.


### PR DESCRIPTION
This PR adds comprehensive `///` doc comments and `//!` module-level documentation to public items in `tidepool-repr` and `tidepool-eval` as per `plans/doc-pass.md`.

Updates in recent revisions:
- Addressed Copilot review comments (refined `RecursiveTree`, `read_cbor`, `free_vars`, and `deep_force` docs).
- Rebased onto `main` to pick up hardening changes in `tidepool-mcp`.

No code changes were made. All tests pass and documentation is verified with `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`.