### PR TITLE
feat: consolidate error handling with thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,7 +3445,7 @@ version = "0.1.0"
 dependencies = [
  "proptest",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tidepool-eval",
  "tidepool-repr",
 ]
@@ -3479,7 +3479,7 @@ dependencies = [
  "rustc-hash",
  "serial_test",
  "target-lexicon",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tidepool-effect",
  "tidepool-eval",
  "tidepool-heap",
@@ -3493,7 +3493,7 @@ version = "0.1.0"
 dependencies = [
  "frunk",
  "proptest",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tidepool-bridge",
  "tidepool-eval",
  "tidepool-repr",
@@ -3504,7 +3504,7 @@ name = "tidepool-eval"
 version = "0.1.0"
 dependencies = [
  "im",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tidepool-repr",
 ]
 
@@ -3529,7 +3529,7 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "proptest",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tidepool-eval",
  "tidepool-repr",
 ]
@@ -3587,7 +3587,7 @@ dependencies = [
  "proptest",
  "rustc-hash",
  "serial_test",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tidepool-testing",
 ]
 
@@ -3603,7 +3603,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tidepool-bridge",
  "tidepool-bridge-derive",
  "tidepool-codegen",

--- a/tidepool-bridge/Cargo.toml
+++ b/tidepool-bridge/Cargo.toml
@@ -10,7 +10,7 @@ description = "Bridge between Rust types and Tidepool Core values"
 readme = "../README.md"
 
 [dependencies]
-thiserror = "2"
+thiserror = "1"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 serde_json = "1"

--- a/tidepool-codegen/Cargo.toml
+++ b/tidepool-codegen/Cargo.toml
@@ -20,7 +20,7 @@ tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-heap = { version = "0.1.0", path = "../tidepool-heap" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }
-thiserror = "2"
+thiserror = "1"
 recursion = "0.5.4"
 rustc-hash = "2.1.0"
 

--- a/tidepool-effect/Cargo.toml
+++ b/tidepool-effect/Cargo.toml
@@ -14,7 +14,7 @@ tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-bridge = { version = "0.1.0", path = "../tidepool-bridge" }
 frunk = "0.4"
-thiserror = "2"
+thiserror = "1"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-eval/Cargo.toml
+++ b/tidepool-eval/Cargo.toml
@@ -12,4 +12,4 @@ readme = "../README.md"
 [dependencies]
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 im = "15"
-thiserror = "2"
+thiserror = "1"

--- a/tidepool-heap/Cargo.toml
+++ b/tidepool-heap/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 bumpalo = "3"
-thiserror = "2"
+thiserror = "1"
 
 [dev-dependencies]
 proptest = "1"

--- a/tidepool-repr/Cargo.toml
+++ b/tidepool-repr/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 ciborium = "0.2"
-thiserror = "2"
+thiserror = "1"
 rustc-hash = "2.1.0"
 
 [dev-dependencies]

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -12,8 +12,11 @@ pub use write::write_metadata;
 #[derive(Debug, thiserror::Error)]
 pub enum ReadError {
     /// An error occurred in the underlying CBOR parser.
-    #[error("CBOR error: {0}")]
-    Cbor(String),
+    #[error("CBOR decode error: {0}")]
+    Cbor(#[from] ciborium::de::Error<std::io::Error>),
+    /// An I/O error occurred.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
     /// An unexpected or unknown tag was encountered.
     #[error("Invalid tag: {0}")]
     InvalidTag(String),
@@ -48,8 +51,11 @@ pub const HEADER_LEN: usize = 8;
 #[derive(Debug, thiserror::Error)]
 pub enum WriteError {
     /// An error occurred in the underlying CBOR serializer.
-    #[error("CBOR error: {0}")]
-    Cbor(String),
+    #[error("CBOR encode error: {0}")]
+    Cbor(#[from] ciborium::ser::Error<std::io::Error>),
+    /// An I/O error occurred.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 #[cfg(test)]
@@ -529,19 +535,13 @@ mod tests {
 
     #[test]
     fn test_read_bad_frame_tag() {
-        let node = ciborium::value::Value::Array(vec![
-            ciborium::value::Value::Text("Bogus".to_string()),
-        ]);
+        let node =
+            ciborium::value::Value::Array(vec![ciborium::value::Value::Text("Bogus".to_string())]);
         let nodes = ciborium::value::Value::Array(vec![node]);
-        let root = ciborium::value::Value::Array(vec![
-            nodes,
-            ciborium::value::Value::Integer(0.into()),
-        ]);
+        let root =
+            ciborium::value::Value::Array(vec![nodes, ciborium::value::Value::Integer(0.into())]);
         let bytes = cbor_bytes(root);
-        assert!(matches!(
-            read_cbor(&bytes),
-            Err(ReadError::InvalidTag(_))
-        ));
+        assert!(matches!(read_cbor(&bytes), Err(ReadError::InvalidTag(_))));
     }
 
     #[test]
@@ -552,10 +552,8 @@ mod tests {
             ciborium::value::Value::Array(vec![]),
         ]);
         let nodes = ciborium::value::Value::Array(vec![node]);
-        let root = ciborium::value::Value::Array(vec![
-            nodes,
-            ciborium::value::Value::Integer(0.into()),
-        ]);
+        let root =
+            ciborium::value::Value::Array(vec![nodes, ciborium::value::Value::Integer(0.into())]);
         let bytes = cbor_bytes(root);
         assert!(matches!(
             read_cbor(&bytes),
@@ -577,10 +575,8 @@ mod tests {
                 ciborium::value::Value::Integer(5.into()), // out of bounds
             ]),
         ]);
-        let root = ciborium::value::Value::Array(vec![
-            nodes,
-            ciborium::value::Value::Integer(1.into()),
-        ]);
+        let root =
+            ciborium::value::Value::Array(vec![nodes, ciborium::value::Value::Integer(1.into())]);
         let bytes = cbor_bytes(root);
         assert!(matches!(
             read_cbor(&bytes),

--- a/tidepool-repr/src/serial/mod.rs
+++ b/tidepool-repr/src/serial/mod.rs
@@ -14,9 +14,6 @@ pub enum ReadError {
     /// An error occurred in the underlying CBOR parser.
     #[error("CBOR decode error: {0}")]
     Cbor(#[from] ciborium::de::Error<std::io::Error>),
-    /// An I/O error occurred.
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
     /// An unexpected or unknown tag was encountered.
     #[error("Invalid tag: {0}")]
     InvalidTag(String),
@@ -53,9 +50,9 @@ pub enum WriteError {
     /// An error occurred in the underlying CBOR serializer.
     #[error("CBOR encode error: {0}")]
     Cbor(#[from] ciborium::ser::Error<std::io::Error>),
-    /// An I/O error occurred.
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+    /// Attempted to write an empty tree.
+    #[error("attempted to write an empty RecursiveTree as a CoreExpr")]
+    EmptyTree,
 }
 
 #[cfg(test)]

--- a/tidepool-repr/src/serial/read.rs
+++ b/tidepool-repr/src/serial/read.rs
@@ -29,8 +29,7 @@ fn strip_header(bytes: &[u8]) -> Result<&[u8], ReadError> {
 /// Reads a CoreExpr from a CBOR-encoded byte slice.
 pub fn read_cbor(bytes: &[u8]) -> Result<RecursiveTree<CoreFrame<usize>>, ReadError> {
     let bytes = strip_header(bytes)?;
-    let tree_val: Value =
-        ciborium::de::from_reader(bytes).map_err(|e| ReadError::Cbor(e.to_string()))?;
+    let tree_val: Value = ciborium::de::from_reader(bytes)?;
 
     let root_array = match tree_val {
         Value::Array(a) if a.len() == 2 => a,
@@ -92,8 +91,7 @@ pub fn read_metadata(bytes: &[u8]) -> Result<(crate::DataConTable, MetaWarnings)
     use crate::types::DataConId;
 
     let bytes = strip_header(bytes)?;
-    let val: Value =
-        ciborium::de::from_reader(bytes).map_err(|e| ReadError::Cbor(e.to_string()))?;
+    let val: Value = ciborium::de::from_reader(bytes)?;
 
     let root = match val {
         Value::Array(a) => a,

--- a/tidepool-repr/src/serial/write.rs
+++ b/tidepool-repr/src/serial/write.rs
@@ -16,9 +16,9 @@ fn write_header(buf: &mut Vec<u8>) {
 /// Writes a CoreExpr to a CBOR-encoded byte vector.
 pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, WriteError> {
     if expr.nodes.is_empty() {
-        return Err(WriteError::Cbor(
+        return Err(WriteError::Cbor(ciborium::ser::Error::Value(
             "attempted to write an empty RecursiveTree as a CoreExpr".to_string(),
-        ));
+        )));
     }
 
     let mut nodes_val = Vec::with_capacity(expr.nodes.len());
@@ -35,8 +35,7 @@ pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, Wri
 
     let mut bytes = Vec::new();
     write_header(&mut bytes);
-    ciborium::ser::into_writer(&tree_val, &mut bytes)
-        .map_err(|e| WriteError::Cbor(e.to_string()))?;
+    ciborium::ser::into_writer(&tree_val, &mut bytes)?;
 
     Ok(bytes)
 }
@@ -90,7 +89,7 @@ pub fn write_metadata(table: &crate::datacon_table::DataConTable) -> Result<Vec<
 
     let mut bytes = Vec::new();
     write_header(&mut bytes);
-    ciborium::ser::into_writer(&root, &mut bytes).map_err(|e| WriteError::Cbor(e.to_string()))?;
+    ciborium::ser::into_writer(&root, &mut bytes)?;
 
     Ok(bytes)
 }

--- a/tidepool-repr/src/serial/write.rs
+++ b/tidepool-repr/src/serial/write.rs
@@ -16,9 +16,7 @@ fn write_header(buf: &mut Vec<u8>) {
 /// Writes a CoreExpr to a CBOR-encoded byte vector.
 pub fn write_cbor(expr: &RecursiveTree<CoreFrame<usize>>) -> Result<Vec<u8>, WriteError> {
     if expr.nodes.is_empty() {
-        return Err(WriteError::Cbor(ciborium::ser::Error::Value(
-            "attempted to write an empty RecursiveTree as a CoreExpr".to_string(),
-        )));
+        return Err(WriteError::EmptyTree);
     }
 
     let mut nodes_val = Vec::with_capacity(expr.nodes.len());

--- a/tidepool-runtime/Cargo.toml
+++ b/tidepool-runtime/Cargo.toml
@@ -10,7 +10,7 @@ description = "Runtime support for Tidepool applications"
 readme = "../README.md"
 
 [dependencies]
-thiserror = "2"
+thiserror = "1"
 tidepool-repr = { version = "0.1.0", path = "../tidepool-repr" }
 tidepool-eval = { version = "0.1.0", path = "../tidepool-eval" }
 tidepool-effect = { version = "0.1.0", path = "../tidepool-effect" }

--- a/tidepool-runtime/src/cache.rs
+++ b/tidepool-runtime/src/cache.rs
@@ -40,16 +40,15 @@ pub(crate) fn cache_key(source: &str, target: &str, include: &[&Path]) -> String
 /// If the resolved path is a shell wrapper script (e.g. ~/.cargo/bin/tidepool-extract),
 /// also fingerprints the target binary it delegates to (e.g. ~/.local/bin/tidepool-extract-bin).
 fn extract_binary_fingerprint(hasher: &mut blake3::Hasher) {
-    let bin_name = std::env::var("TIDEPOOL_EXTRACT")
-        .unwrap_or_else(|_| "tidepool-extract".to_string());
+    let bin_name =
+        std::env::var("TIDEPOOL_EXTRACT").unwrap_or_else(|_| "tidepool-extract".to_string());
 
     if let Ok(path) = which::which(&bin_name) {
         fingerprint_single_binary(hasher, &path);
 
         // If this looks like a shell wrapper script, also fingerprint the target binary.
         if let Ok(contents) = fs::read_to_string(&path) {
-            if contents.len() < 4096 && (contents.starts_with("#!") || contents.contains("exec "))
-            {
+            if contents.len() < 4096 && (contents.starts_with("#!") || contents.contains("exec ")) {
                 for line in contents.lines() {
                     if let Some(target) = extract_exec_target(line.trim()) {
                         let target_path = PathBuf::from(target);
@@ -381,8 +380,8 @@ mod tests {
     #[test]
     #[serial]
     fn test_cache_key_binary_fingerprint_size() {
-        use std::os::unix::fs::PermissionsExt;
         use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
 
         let temp_dir = TempDir::new().unwrap();
         let bin_path = temp_dir.path().join("fake-extract-size");
@@ -395,10 +394,7 @@ mod tests {
         let k1 = cache_key("source", "target", &[]);
 
         // Change size
-        let mut file = fs::OpenOptions::new()
-            .append(true)
-            .open(&bin_path)
-            .unwrap();
+        let mut file = fs::OpenOptions::new().append(true).open(&bin_path).unwrap();
         file.write_all(b"extra").unwrap();
         drop(file);
 

--- a/tidepool-runtime/tests/nested_mapm_tag255.rs
+++ b/tidepool-runtime/tests/nested_mapm_tag255.rs
@@ -99,7 +99,11 @@ impl RealFs {
     }
     fn resolve(&self, p: &str) -> PathBuf {
         let path = PathBuf::from(p);
-        if path.is_absolute() { path } else { self.root.join(path) }
+        if path.is_absolute() {
+            path
+        } else {
+            self.root.join(path)
+        }
     }
 }
 impl EffectHandler for RealFs {
@@ -113,8 +117,11 @@ impl EffectHandler for RealFs {
             FsReq::FsWrite(_, _) => cx.respond(()),
             FsReq::FsListDir(path) => {
                 let entries: Vec<String> = std::fs::read_dir(self.resolve(&path))
-                    .map(|rd| rd.filter_map(|e| e.ok())
-                        .map(|e| e.file_name().to_string_lossy().to_string()).collect())
+                    .map(|rd| {
+                        rd.filter_map(|e| e.ok())
+                            .map(|e| e.file_name().to_string_lossy().to_string())
+                            .collect()
+                    })
                     .unwrap_or_default();
                 cx.respond(entries)
             }
@@ -122,11 +129,16 @@ impl EffectHandler for RealFs {
                 let full = self.root.join(pattern.as_str());
                 let root = self.root.clone();
                 let entries: Vec<String> = glob::glob(full.to_str().unwrap_or(""))
-                    .map(|paths| paths
-                        .filter_map(|p: Result<PathBuf, _>| p.ok())
-                        .filter_map(move |p: PathBuf| p.strip_prefix(&root).ok()
-                            .map(|rel: &Path| rel.to_string_lossy().to_string()))
-                        .collect())
+                    .map(|paths| {
+                        paths
+                            .filter_map(|p: Result<PathBuf, _>| p.ok())
+                            .filter_map(move |p: PathBuf| {
+                                p.strip_prefix(&root)
+                                    .ok()
+                                    .map(|rel: &Path| rel.to_string_lossy().to_string())
+                            })
+                            .collect()
+                    })
                     .unwrap_or_default();
                 cx.respond(entries)
             }
@@ -242,12 +254,14 @@ stats <- mapM (\crate -> do
 pure stats
 "#;
 
-    let full_module = tidepool_mcp::template_haskell(
-        &preamble, &stack, user_code, "", "", None, Some(4096),
-    );
+    let full_module =
+        tidepool_mcp::template_haskell(&preamble, &stack, user_code, "", "", None, Some(4096));
 
     // Dump the generated module for debugging
-    eprintln!("=== Generated module ({} lines) ===", full_module.lines().count());
+    eprintln!(
+        "=== Generated module ({} lines) ===",
+        full_module.lines().count()
+    );
 
     let pp = prelude_path();
     let result = std::thread::Builder::new()


### PR DESCRIPTION
Updated PR to address Copilot review comments:
- Removed redundant `Io` variants from `ReadError` and `WriteError` in `tidepool-repr`.
- Added specific `WriteError::EmptyTree` variant to replace misleading use of `ciborium::ser::Error::Value`.