### PR TITLE
Some fixes and one feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,6 +3553,7 @@ dependencies = [
  "axum",
  "dyn-clone",
  "frunk",
+ "parking_lot",
  "rmcp",
  "schemars 1.2.1",
  "serde",

--- a/README.md
+++ b/README.md
@@ -178,6 +178,36 @@ let result = tidepool_runtime::compile_and_run(
 println!("{}", result.to_json());
 ```
 
+### Cancelling runaway programs
+
+`JitEffectMachine::cancel_handle()` returns a `Send + Sync + Clone`
+`CancelHandle` that any other thread (typically a watchdog) can use to abort
+a running program:
+
+```rust,ignore
+let mut vm = JitEffectMachine::compile(&expr, &table, 1 << 20)?;
+let handle = vm.cancel_handle();
+
+std::thread::spawn(move || {
+    std::thread::sleep(std::time::Duration::from_secs(5));
+    handle.cancel();
+});
+
+match vm.run_pure() {
+    Err(JitError::Yield(YieldError::Cancelled)) => {
+        // Watchdog fired — the program did not complete within the budget.
+    }
+    other => { /* normal result or different error */ }
+}
+```
+
+Cancellation is observed at the next GC safepoint (heap check) or tail-call
+trampoline iteration, whichever comes first. Both fire frequently enough
+that latency is essentially negligible — typically sub-millisecond.
+
+The flag is per-machine, not per-run. Call `handle.reset()` between runs if
+you intend to reuse the same `JitEffectMachine` after a cancellation.
+
 ### Key crates
 
 | Crate | Entry points |

--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -1035,6 +1035,18 @@ translateHead = \case
             -- Multi-element: must be a heap box, use FDataAlt to bind fields.
             recordDC dc
             emitNode $ NCase scrutIdx (varId b) [FlatAlt (FDataAlt (varId (dataConWorkId dc))) (map varId vBinders) bodyIdx]
+  -- unsafeEqualityProof: elide the case entirely.
+  -- GHC emits `case unsafeEqualityProof of UnsafeRefl -> body` for GADT evidence
+  -- (e.g. freer-simple's Member constraint). After cross-module inlining via
+  -- resolveExternals, these cases survive because GHC's optimizer ran before
+  -- the bindings were merged. The UnsafeRefl constructor always matches, so we
+  -- emit the body directly. Without this, the translator emits Con_unit for
+  -- unsafeEqualityProof but the case alt expects Con_UnsafeRefl, causing a
+  -- tag mismatch (CASE TRAP) at runtime.
+  Case scrut _b _alts_ty [Alt (DataAlt _dc) binders body]
+    | isUnsafeEqualityCase scrut -> do
+        let _typeEvidence = filter isTyVar binders
+        translate body
   Case scrut b _alts_ty alts -> do
     scrutIdx <- translate scrut
     altData <- mapM translateAlt alts
@@ -1479,6 +1491,15 @@ isRuntimeErrorVar v =
 isUnsafeEqualityProofVar :: Id -> Bool
 isUnsafeEqualityProofVar v =
   occNameString (nameOccName (idName v)) == "unsafeEqualityProof"
+
+-- | Check if a scrutinee expression is unsafeEqualityProof (possibly applied
+-- to type arguments and wrapped in ticks/casts). Used to elide
+-- case-on-UnsafeRefl at the Case level.
+isUnsafeEqualityCase :: CoreExpr -> Bool
+isUnsafeEqualityCase expr =
+  case fst (collectArgs (stripTicksAndCasts expr)) of
+    Var v -> isUnsafeEqualityProofVar v
+    _     -> False
 
 isRunRWVar :: Id -> Bool
 isRunRWVar v = occNameString (nameOccName (idName v)) == "runRW#"

--- a/tidepool-bridge-derive/src/codegen.rs
+++ b/tidepool-bridge-derive/src/codegen.rs
@@ -63,6 +63,42 @@ fn is_phantom_data(ty: &Type) -> bool {
     false
 }
 
+/// Emit the DataCon lookup expression for a derive site. When `module` is
+/// `Some`, the lookup uses `DataConTable::get_by_qualified_name` (full
+/// `Module.Constructor` path) and the error variant carries the qualified
+/// name. When `module` is `None`, it falls back to the existing
+/// name+arity lookup for backward compatibility. The lookup returns a
+/// `DataConId`; arity validation still happens at the call site via the
+/// existing field-count check so mismatched arities are surfaced as
+/// `ArityMismatch` (qualified-name lookup does not pre-filter by arity).
+fn emit_datacon_lookup(
+    module: Option<&String>,
+    core_name: &str,
+    core_arity_u32: u32,
+    core_arity_usize: usize,
+) -> TokenStream {
+    if let Some(module) = module {
+        let qualified = format!("{}.{}", module, core_name);
+        quote! {
+            table.get_by_qualified_name(#qualified)
+                .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConQualified {
+                    qualified_name: #qualified.to_string(),
+                })?
+        }
+    } else {
+        // Silence unused-var warnings in the `Some` branch where arity isn't
+        // consumed by the emitted code.
+        let _ = core_arity_usize;
+        quote! {
+            table.get_by_name_arity(#core_name, #core_arity_u32)
+                .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
+                    name: #core_name.to_string(),
+                    arity: #core_arity_u32 as usize,
+                })?
+        }
+    }
+}
+
 fn add_trait_bounds(
     generics: &mut syn::Generics,
     trait_path: &syn::Path,
@@ -100,6 +136,7 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
     for variant in &info.variants {
         let rust_name = &variant.rust_name;
         let core_name = &variant.core_name;
+        let core_module = variant.core_module.as_ref();
         let rust_arity = variant.fields.len();
 
         // Core arity excludes PhantomData fields — they have no Core
@@ -134,12 +171,10 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
             quote! { #name::#rust_name(#(#field_exprs),*) }
         };
 
+        let lookup = emit_datacon_lookup(core_module, core_name, core_arity_u32, core_arity);
+
         match_arms.push(quote! {
-            let variant_id = table.get_by_name_arity(#core_name, #core_arity_u32)
-                .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
-                    name: #core_name.to_string(),
-                    arity: #core_arity,
-                })?;
+            let variant_id = #lookup;
             if *id == variant_id {
                 if fields.len() != #core_arity {
                     return Err(tidepool_bridge::BridgeError::ArityMismatch {
@@ -202,6 +237,7 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
     for variant in &info.variants {
         let rust_name = &variant.rust_name;
         let core_name = &variant.core_name;
+        let core_module = variant.core_module.as_ref();
         let rust_arity = variant.fields.len();
 
         let core_arity: usize = variant
@@ -243,13 +279,11 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
                 quote! { tidepool_bridge::ToCore::to_value(#ident, table)? }
             });
 
+        let lookup = emit_datacon_lookup(core_module, core_name, core_arity_u32, core_arity);
+
         match_arms.push(quote! {
             #pattern => {
-                let id = table.get_by_name_arity(#core_name, #core_arity_u32)
-                    .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
-                        name: #core_name.to_string(),
-                        arity: #core_arity,
-                    })?;
+                let id = #lookup;
                 Ok(tidepool_eval::Value::Con(id, vec![#(#field_to_values),*]))
             }
         });
@@ -271,6 +305,7 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
 pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
     let name = &info.name;
     let core_name = &info.core_name;
+    let core_module = info.core_module.as_ref();
     let trait_path: syn::Path = parse_quote!(tidepool_bridge::FromCore);
     let mut generics = info.generics.clone();
 
@@ -314,6 +349,8 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
         quote! { #name { #(#field_constructions),* } }
     };
 
+    let lookup = emit_datacon_lookup(core_module, core_name, core_arity_u32, core_arity);
+
     quote! {
         impl #impl_generics tidepool_bridge::sealed::FromCoreSealed for #name #ty_generics #where_clause {}
 
@@ -321,11 +358,7 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
                 match value {
                     tidepool_eval::Value::Con(id, fields) => {
-                        let con_id = table.get_by_name_arity(#core_name, #core_arity_u32)
-                            .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
-                                name: #core_name.to_string(),
-                                arity: #core_arity,
-                            })?;
+                        let con_id = #lookup;
                         if *id != con_id {
                             return Err(tidepool_bridge::BridgeError::UnknownDataCon(*id));
                         }
@@ -362,6 +395,7 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
 pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
     let name = &info.name;
     let core_name = &info.core_name;
+    let core_module = info.core_module.as_ref();
     let trait_path: syn::Path = parse_quote!(tidepool_bridge::ToCore);
     let mut generics = info.generics.clone();
 
@@ -414,17 +448,15 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
         quote! { #name { #(#destructure_fields),* } }
     };
 
+    let lookup = emit_datacon_lookup(core_module, core_name, core_arity_u32, core_arity);
+
     quote! {
         impl #impl_generics tidepool_bridge::sealed::ToCoreSealed for #name #ty_generics #where_clause {}
 
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
                 let #destructure = self;
-                let id = table.get_by_name_arity(#core_name, #core_arity_u32)
-                    .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
-                        name: #core_name.to_string(),
-                        arity: #core_arity,
-                    })?;
+                let id = #lookup;
                 Ok(tidepool_eval::Value::Con(id, vec![#(#field_to_values),*]))
             }
         }

--- a/tidepool-bridge-derive/src/codegen.rs
+++ b/tidepool-bridge-derive/src/codegen.rs
@@ -6,30 +6,28 @@ use syn::{parse_quote, Type};
 
 fn collect_type_params(ty: &Type, params: &HashSet<syn::Ident>, used: &mut HashSet<syn::Ident>) {
     match ty {
-        Type::Path(tp) => {
-            if tp.qself.is_none() {
-                // If it's PhantomData<T>, we DON'T consider T "used" for the purpose
-                // of adding FromCore/ToCore bounds, because our PhantomData impl
-                // doesn't require T to be FromCore/ToCore.
-                if tp
-                    .path
-                    .segments
-                    .last()
-                    .is_some_and(|s| s.ident == "PhantomData")
-                {
-                    return;
+        Type::Path(tp) if tp.qself.is_none() => {
+            // If it's PhantomData<T>, we DON'T consider T "used" for the purpose
+            // of adding FromCore/ToCore bounds, because our PhantomData impl
+            // doesn't require T to be FromCore/ToCore.
+            if tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|s| s.ident == "PhantomData")
+            {
+                return;
+            }
+            if let Some(ident) = tp.path.get_ident() {
+                if params.contains(ident) {
+                    used.insert(ident.clone());
                 }
-                if let Some(ident) = tp.path.get_ident() {
-                    if params.contains(ident) {
-                        used.insert(ident.clone());
-                    }
-                }
-                for segment in &tp.path.segments {
-                    if let syn::PathArguments::AngleBracketed(ab) = &segment.arguments {
-                        for arg in &ab.args {
-                            if let syn::GenericArgument::Type(inner_ty) = arg {
-                                collect_type_params(inner_ty, params, used);
-                            }
+            }
+            for segment in &tp.path.segments {
+                if let syn::PathArguments::AngleBracketed(ab) = &segment.arguments {
+                    for arg in &ab.args {
+                        if let syn::GenericArgument::Type(inner_ty) = arg {
+                            collect_type_params(inner_ty, params, used);
                         }
                     }
                 }
@@ -45,6 +43,24 @@ fn collect_type_params(ty: &Type, params: &HashSet<syn::Ident>, used: &mut HashS
         }
         _ => {}
     }
+}
+
+/// A field is a phantom (`std::marker::PhantomData<_>`) if its outermost path
+/// segment is `PhantomData`. Such fields have no Core representation and are
+/// skipped when computing a variant/struct's Core arity and when encoding or
+/// decoding fields — analogous to how they are skipped for trait-bound
+/// inference in `collect_type_params`.
+fn is_phantom_data(ty: &Type) -> bool {
+    if let Type::Path(tp) = ty {
+        if tp.qself.is_none() {
+            return tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|s| s.ident == "PhantomData");
+        }
+    }
+    false
 }
 
 fn add_trait_bounds(
@@ -84,29 +100,51 @@ pub fn generate_from_core(info: &EnumInfo) -> TokenStream {
     for variant in &info.variants {
         let rust_name = &variant.rust_name;
         let core_name = &variant.core_name;
-        let arity = variant.fields.len();
+        let rust_arity = variant.fields.len();
 
-        let field_conversions = (0..arity).map(|i| {
-            let ty = &variant.fields[i];
-            quote! {
-                <#ty as tidepool_bridge::FromCore>::from_value(&fields[#i], table)?
+        // Core arity excludes PhantomData fields — they have no Core
+        // representation and must not consume slots in the encoded Con.
+        let core_arity: usize = variant
+            .fields
+            .iter()
+            .filter(|ty| !is_phantom_data(ty))
+            .count();
+        let core_arity_u32 = core_arity as u32;
+
+        // Build per-Rust-field construction expressions. PhantomData fields
+        // get a default `PhantomData` literal; other fields pull from the next
+        // Core field slot.
+        let mut core_ix: usize = 0;
+        let mut field_exprs: Vec<TokenStream> = Vec::with_capacity(rust_arity);
+        for ty in &variant.fields {
+            if is_phantom_data(ty) {
+                field_exprs.push(quote! { <#ty as core::default::Default>::default() });
+            } else {
+                let i = core_ix;
+                core_ix += 1;
+                field_exprs.push(quote! {
+                    <#ty as tidepool_bridge::FromCore>::from_value(&fields[#i], table)?
+                });
             }
-        });
+        }
 
-        let construction = if arity == 0 {
+        let construction = if rust_arity == 0 {
             quote! { #name::#rust_name }
         } else {
-            quote! { #name::#rust_name(#(#field_conversions),*) }
+            quote! { #name::#rust_name(#(#field_exprs),*) }
         };
 
         match_arms.push(quote! {
-            let variant_id = table.get_by_name(#core_name)
-                .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConName(#core_name.to_string()))?;
+            let variant_id = table.get_by_name_arity(#core_name, #core_arity_u32)
+                .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
+                    name: #core_name.to_string(),
+                    arity: #core_arity,
+                })?;
             if *id == variant_id {
-                if fields.len() != #arity {
+                if fields.len() != #core_arity {
                     return Err(tidepool_bridge::BridgeError::ArityMismatch {
                         con: *id,
-                        expected: #arity,
+                        expected: #core_arity,
                         got: fields.len(),
                     });
                 }
@@ -164,23 +202,54 @@ pub fn generate_to_core(info: &EnumInfo) -> TokenStream {
     for variant in &info.variants {
         let rust_name = &variant.rust_name;
         let core_name = &variant.core_name;
-        let arity = variant.fields.len();
+        let rust_arity = variant.fields.len();
 
-        let field_names: Vec<_> = (0..arity).map(|i| quote::format_ident!("f{}", i)).collect();
-        let pattern = if arity == 0 {
+        let core_arity: usize = variant
+            .fields
+            .iter()
+            .filter(|ty| !is_phantom_data(ty))
+            .count();
+        let core_arity_u32 = core_arity as u32;
+
+        // Bind ALL rust fields (so the pattern compiles) but we underscore
+        // phantom fields since they aren't encoded.
+        let field_bindings: Vec<_> = variant
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| {
+                let base = quote::format_ident!("f{}", i);
+                if is_phantom_data(ty) {
+                    // Bind to _<name> so the pattern is still irrefutable but unused.
+                    let under = quote::format_ident!("_f{}", i);
+                    (under, true)
+                } else {
+                    (base, false)
+                }
+            })
+            .collect();
+
+        let pattern_idents = field_bindings.iter().map(|(ident, _)| ident);
+        let pattern = if rust_arity == 0 {
             quote! { #name::#rust_name }
         } else {
-            quote! { #name::#rust_name(#(#field_names),*) }
+            quote! { #name::#rust_name(#(#pattern_idents),*) }
         };
 
-        let field_to_values = field_names.iter().map(|f| {
-            quote! { tidepool_bridge::ToCore::to_value(#f, table)? }
-        });
+        let field_to_values = field_bindings
+            .iter()
+            .filter(|(_, is_phantom)| !is_phantom)
+            .map(|(ident, _)| {
+                quote! { tidepool_bridge::ToCore::to_value(#ident, table)? }
+            });
 
         match_arms.push(quote! {
             #pattern => {
-                let id = table.get_by_name(#core_name)
-                    .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConName(#core_name.to_string()))?;
+                let id = table.get_by_name_arity(#core_name, #core_arity_u32)
+                    .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
+                        name: #core_name.to_string(),
+                        arity: #core_arity,
+                    })?;
                 Ok(tidepool_eval::Value::Con(id, vec![#(#field_to_values),*]))
             }
         });
@@ -212,15 +281,29 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
     );
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let arity = info.fields.len();
 
+    let core_arity: usize = info
+        .fields
+        .iter()
+        .filter(|(_, ty)| !is_phantom_data(ty))
+        .count();
+    let core_arity_u32 = core_arity as u32;
+
+    let mut core_ix: usize = 0;
     let field_constructions: Vec<_> = info
         .fields
         .iter()
-        .enumerate()
-        .map(|(i, (field_name, field_ty))| {
-            quote! {
-                #field_name: <#field_ty as tidepool_bridge::FromCore>::from_value(&fields[#i], table)?
+        .map(|(field_name, field_ty)| {
+            if is_phantom_data(field_ty) {
+                quote! {
+                    #field_name: <#field_ty as core::default::Default>::default()
+                }
+            } else {
+                let i = core_ix;
+                core_ix += 1;
+                quote! {
+                    #field_name: <#field_ty as tidepool_bridge::FromCore>::from_value(&fields[#i], table)?
+                }
             }
         })
         .collect();
@@ -238,15 +321,18 @@ pub fn generate_struct_from_core(info: &StructInfo) -> TokenStream {
             fn from_value(value: &tidepool_eval::Value, table: &tidepool_repr::DataConTable) -> Result<Self, tidepool_bridge::BridgeError> {
                 match value {
                     tidepool_eval::Value::Con(id, fields) => {
-                        let con_id = table.get_by_name(#core_name)
-                            .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConName(#core_name.to_string()))?;
+                        let con_id = table.get_by_name_arity(#core_name, #core_arity_u32)
+                            .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
+                                name: #core_name.to_string(),
+                                arity: #core_arity,
+                            })?;
                         if *id != con_id {
                             return Err(tidepool_bridge::BridgeError::UnknownDataCon(*id));
                         }
-                        if fields.len() != #arity {
+                        if fields.len() != #core_arity {
                             return Err(tidepool_bridge::BridgeError::ArityMismatch {
                                 con: *id,
-                                expected: #arity,
+                                expected: #core_arity,
                                 got: fields.len(),
                             });
                         }
@@ -287,10 +373,37 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let field_names: Vec<_> = info.fields.iter().map(|(name, _)| name).collect();
-    let field_to_values: Vec<_> = field_names
+    let core_arity: usize = info
+        .fields
         .iter()
-        .map(|f| {
+        .filter(|(_, ty)| !is_phantom_data(ty))
+        .count();
+    let core_arity_u32 = core_arity as u32;
+
+    // Bind ALL fields in the destructure pattern; phantom fields get `_` prefix
+    // to silence unused warnings (the pattern must still cover them).
+    let field_bindings: Vec<_> = info
+        .fields
+        .iter()
+        .map(|(field_name, ty)| {
+            let is_phantom = is_phantom_data(ty);
+            (field_name.clone(), ty.clone(), is_phantom)
+        })
+        .collect();
+
+    let destructure_fields = field_bindings.iter().map(|(name, _, is_phantom)| {
+        if *is_phantom {
+            // `name: _` in a field pattern binds nothing.
+            quote! { #name: _ }
+        } else {
+            quote! { #name }
+        }
+    });
+
+    let field_to_values: Vec<_> = field_bindings
+        .iter()
+        .filter(|(_, _, is_phantom)| !is_phantom)
+        .map(|(f, _, _)| {
             quote! { tidepool_bridge::ToCore::to_value(#f, table)? }
         })
         .collect();
@@ -298,7 +411,7 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
     let destructure = if info.fields.is_empty() {
         quote! { #name }
     } else {
-        quote! { #name { #(#field_names),* } }
+        quote! { #name { #(#destructure_fields),* } }
     };
 
     quote! {
@@ -307,8 +420,11 @@ pub fn generate_struct_to_core(info: &StructInfo) -> TokenStream {
         impl #impl_generics tidepool_bridge::ToCore for #name #ty_generics #where_clause {
             fn to_value(&self, table: &tidepool_repr::DataConTable) -> Result<tidepool_eval::Value, tidepool_bridge::BridgeError> {
                 let #destructure = self;
-                let id = table.get_by_name(#core_name)
-                    .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConName(#core_name.to_string()))?;
+                let id = table.get_by_name_arity(#core_name, #core_arity_u32)
+                    .ok_or_else(|| tidepool_bridge::BridgeError::UnknownDataConNameArity {
+                        name: #core_name.to_string(),
+                        arity: #core_arity,
+                    })?;
                 Ok(tidepool_eval::Value::Con(id, vec![#(#field_to_values),*]))
             }
         }

--- a/tidepool-bridge-derive/src/parse.rs
+++ b/tidepool-bridge-derive/src/parse.rs
@@ -9,6 +9,10 @@ pub struct EnumInfo {
 pub struct VariantInfo {
     pub rust_name: Ident,
     pub core_name: String,
+    /// Optional source-module path (e.g. `"Pattern.Memory"`). When present,
+    /// derive-generated lookups call `get_by_qualified_name("<module>.<core_name>")`
+    /// to disambiguate constructors that share name and arity across modules.
+    pub core_module: Option<String>,
     pub fields: Vec<Type>,
 }
 
@@ -16,6 +20,8 @@ pub struct StructInfo {
     pub name: Ident,
     pub generics: Generics,
     pub core_name: String,
+    /// See [`VariantInfo::core_module`].
+    pub core_module: Option<String>,
     pub fields: Vec<(Ident, Type)>,
 }
 
@@ -28,7 +34,11 @@ pub fn parse_input(input: &DeriveInput) -> Result<DataInfo, syn::Error> {
     match &input.data {
         Data::Enum(_) => parse_enum(input).map(DataInfo::Enum),
         Data::Struct(s) => {
-            let core_name = get_core_name(&input.attrs)?.unwrap_or_else(|| input.ident.to_string());
+            let CoreAttr {
+                name: core_name,
+                module: core_module,
+            } = parse_core_attr(&input.attrs)?;
+            let core_name = core_name.unwrap_or_else(|| input.ident.to_string());
             let fields = match &s.fields {
                 Fields::Named(f) => f
                     .named
@@ -47,6 +57,7 @@ pub fn parse_input(input: &DeriveInput) -> Result<DataInfo, syn::Error> {
                 name: input.ident.clone(),
                 generics: input.generics.clone(),
                 core_name,
+                core_module,
                 fields,
             }))
         }
@@ -63,7 +74,10 @@ pub fn parse_enum(input: &DeriveInput) -> Result<EnumInfo, syn::Error> {
     let mut variants = Vec::new();
     for variant in &data_enum.variants {
         let rust_name = variant.ident.clone();
-        let core_name = get_core_name(&variant.attrs)?;
+        let CoreAttr {
+            name: core_name,
+            module: core_module,
+        } = parse_core_attr(&variant.attrs)?;
 
         let fields = match &variant.fields {
             Fields::Unnamed(f) => f.unnamed.iter().map(|field| field.ty.clone()).collect(),
@@ -81,6 +95,7 @@ pub fn parse_enum(input: &DeriveInput) -> Result<EnumInfo, syn::Error> {
         variants.push(VariantInfo {
             rust_name,
             core_name: core_name_str,
+            core_module,
             fields,
         });
     }
@@ -92,28 +107,45 @@ pub fn parse_enum(input: &DeriveInput) -> Result<EnumInfo, syn::Error> {
     })
 }
 
-fn get_core_name(attrs: &[Attribute]) -> Result<Option<String>, syn::Error> {
+/// Parsed contents of a single `#[core(...)]` attribute.
+#[derive(Default)]
+pub(crate) struct CoreAttr {
+    /// Explicit `name = "..."` override; defaults to the Rust identifier.
+    pub(crate) name: Option<String>,
+    /// Optional `module = "..."` qualifier. When set, derived lookups use
+    /// `get_by_qualified_name("<module>.<name>")` to pick the correct
+    /// constructor when name+arity collisions exist across source modules.
+    pub(crate) module: Option<String>,
+}
+
+pub(crate) fn parse_core_attr(attrs: &[Attribute]) -> Result<CoreAttr, syn::Error> {
+    let mut out = CoreAttr::default();
     for attr in attrs {
         if attr.path().is_ident("core") {
-            let mut core_name = None;
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("name") {
                     let value = meta.value()?;
                     let lit: Lit = value.parse()?;
                     if let Lit::Str(s) = lit {
-                        core_name = Some(s.value());
+                        out.name = Some(s.value());
                         Ok(())
                     } else {
                         Err(meta.error("expected string literal for 'name'"))
                     }
+                } else if meta.path.is_ident("module") {
+                    let value = meta.value()?;
+                    let lit: Lit = value.parse()?;
+                    if let Lit::Str(s) = lit {
+                        out.module = Some(s.value());
+                        Ok(())
+                    } else {
+                        Err(meta.error("expected string literal for 'module'"))
+                    }
                 } else {
-                    Err(meta.error("unknown core attribute"))
+                    Err(meta.error("unknown core attribute (expected 'name' or 'module')"))
                 }
             })?;
-            if core_name.is_some() {
-                return Ok(core_name);
-            }
         }
     }
-    Ok(None)
+    Ok(out)
 }

--- a/tidepool-bridge-derive/tests/arity_disambiguation.rs
+++ b/tidepool-bridge-derive/tests/arity_disambiguation.rs
@@ -1,0 +1,135 @@
+//! Regression tests for DataCon lookup by (name, arity) in `FromCore`/`ToCore` derives.
+//!
+//! Two GADTs from different Haskell modules can declare same-named constructors
+//! (e.g. `Pattern.Memory.Read` and `Pattern.File.Read`). The derive must
+//! disambiguate by arity so decoding doesn't fail with "Unknown DataCon name".
+
+use tidepool_bridge::{BridgeError, FromCore, ToCore};
+use tidepool_bridge_derive::{FromCore, ToCore};
+use tidepool_eval::Value;
+use tidepool_repr::{DataCon, DataConId, DataConTable};
+use tidepool_testing::gen::datacon_table::standard_datacon_table;
+
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+enum Alpha {
+    #[core(name = "Read")]
+    Read(i64),
+}
+
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+enum Beta {
+    #[core(name = "Read")]
+    Read(i64, u64),
+}
+
+/// Build a DataConTable holding two constructors sharing the unqualified name
+/// "Read" but with different arities — the scenario that was failing. Built
+/// on top of the standard table so primitive boxing constructors (`I#`, `W#`)
+/// are available for field encoding.
+fn ambiguous_table() -> (DataConTable, DataConId, DataConId) {
+    let mut t = standard_datacon_table();
+    let alpha_id = DataConId(100);
+    let beta_id = DataConId(101);
+    t.insert(DataCon {
+        id: alpha_id,
+        name: "Read".into(),
+        tag: 1,
+        rep_arity: 1,
+        field_bangs: vec![],
+        qualified_name: Some("Pattern.Memory.Read".into()),
+    });
+    t.insert(DataCon {
+        id: beta_id,
+        name: "Read".into(),
+        tag: 1,
+        rep_arity: 2,
+        field_bangs: vec![],
+        qualified_name: Some("Pattern.File.Read".into()),
+    });
+    (t, alpha_id, beta_id)
+}
+
+#[test]
+fn alpha_roundtrips_when_beta_shares_name() {
+    let (table, alpha_id, _) = ambiguous_table();
+    let original = Alpha::Read(17);
+
+    let encoded = original
+        .to_value(&table)
+        .expect("Alpha encode must succeed");
+    match &encoded {
+        Value::Con(id, fields) => {
+            assert_eq!(*id, alpha_id, "must encode to the arity-1 Read id");
+            assert_eq!(fields.len(), 1, "Alpha encodes with 1 Core field");
+        }
+        other => panic!("expected Con, got {:?}", other),
+    }
+
+    let decoded = Alpha::from_value(&encoded, &table).expect("Alpha decode must succeed");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn beta_roundtrips_when_alpha_shares_name() {
+    let (table, _, beta_id) = ambiguous_table();
+    let original = Beta::Read(3, 42);
+
+    let encoded = original.to_value(&table).expect("Beta encode must succeed");
+    match &encoded {
+        Value::Con(id, fields) => {
+            assert_eq!(*id, beta_id, "must encode to the arity-2 Read id");
+            assert_eq!(fields.len(), 2, "Beta encodes with 2 Core fields");
+        }
+        other => panic!("expected Con, got {:?}", other),
+    }
+
+    let decoded = Beta::from_value(&encoded, &table).expect("Beta decode must succeed");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn alpha_decode_rejects_beta_shaped_value() {
+    // Negative case: Alpha's decoder fed a Con tagged with the Beta id.
+    // The id lookup resolves to the arity-1 Read; the supplied id is the
+    // arity-2 Read; they differ, so decode must error (not silently succeed).
+    let (table, _alpha_id, beta_id) = ambiguous_table();
+
+    // Build a syntactically shaped Con with 2 dummy fields — Alpha's decoder
+    // should bail at the id check before touching the fields.
+    let dummy = Value::Con(DataConId(0), vec![]);
+    let beta_value = Value::Con(beta_id, vec![dummy.clone(), dummy]);
+
+    let result = Alpha::from_value(&beta_value, &table);
+    match result {
+        Err(BridgeError::UnknownDataCon(id)) => {
+            assert_eq!(id, beta_id, "error should name the Beta id we supplied");
+        }
+        Err(other) => panic!("expected UnknownDataCon, got {:?}", other),
+        Ok(v) => panic!("expected error, got successful decode: {:?}", v),
+    }
+}
+
+#[test]
+fn unknown_name_reports_arity() {
+    // When a constructor name exists but not at the requested arity, we should
+    // get UnknownDataConNameArity identifying the name and the expected arity.
+    let mut t = standard_datacon_table();
+    t.insert(DataCon {
+        id: DataConId(200),
+        name: "Read".into(),
+        tag: 1,
+        rep_arity: 5, // neither Alpha's 1 nor Beta's 2
+        field_bangs: vec![],
+        qualified_name: None,
+    });
+
+    let val = Alpha::Read(1);
+    let err = val.to_value(&t).expect_err("no arity-1 Read present");
+    match err {
+        BridgeError::UnknownDataConNameArity { name, arity } => {
+            assert_eq!(name, "Read");
+            assert_eq!(arity, 1);
+        }
+        other => panic!("expected UnknownDataConNameArity, got {:?}", other),
+    }
+}

--- a/tidepool-bridge-derive/tests/module_qualification.rs
+++ b/tidepool-bridge-derive/tests/module_qualification.rs
@@ -1,0 +1,111 @@
+//! `#[core(module = "...")]` qualified-name disambiguation.
+//!
+//! When two types declare variants that share both unqualified name AND arity
+//! but come from different source modules, the plain name+arity lookup can't
+//! pick between them. Tagging each variant with its source module enables the
+//! derive to emit `DataConTable::get_by_qualified_name("<module>.<name>")`
+//! instead, producing a single unambiguous `DataConId`.
+
+use tidepool_bridge::{BridgeError, FromCore, ToCore};
+use tidepool_bridge_derive::{FromCore, ToCore};
+use tidepool_eval::Value;
+use tidepool_repr::{DataCon, DataConId, DataConTable};
+
+// Nullary variants keep the test focused on DataCon lookup — avoids pulling
+// in `Text` / `C#` / list-constructor table-setup just to carry a payload.
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+enum Alpha {
+    #[core(module = "TestMod.Alpha", name = "Read")]
+    Read,
+}
+
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+enum Beta {
+    #[core(module = "TestMod.Beta", name = "Read")]
+    Read,
+}
+
+/// Build a table containing both `TestMod.Alpha.Read` and
+/// `TestMod.Beta.Read` at distinct `DataConId`s with identical
+/// unqualified names and arities.
+fn build_collision_table() -> (DataConTable, DataConId, DataConId) {
+    let mut table = DataConTable::new();
+    let alpha_id = DataConId(1);
+    let beta_id = DataConId(2);
+
+    table.insert(DataCon {
+        id: alpha_id,
+        name: "Read".to_string(),
+        tag: 1,
+        rep_arity: 0,
+        field_bangs: vec![],
+        qualified_name: Some("TestMod.Alpha.Read".to_string()),
+    });
+    table.insert(DataCon {
+        id: beta_id,
+        name: "Read".to_string(),
+        tag: 1,
+        rep_arity: 0,
+        field_bangs: vec![],
+        qualified_name: Some("TestMod.Beta.Read".to_string()),
+    });
+    (table, alpha_id, beta_id)
+}
+
+#[test]
+fn alpha_roundtrips_when_beta_shares_name() {
+    let (table, _, _) = build_collision_table();
+    let original = Alpha::Read;
+    let value = original.to_value(&table).expect("to_value");
+    match &value {
+        Value::Con(id, _) => assert_eq!(id.0, 1, "alpha encode should use TestMod.Alpha.Read id"),
+        other => panic!("expected Con, got {other:?}"),
+    }
+    let decoded = Alpha::from_value(&value, &table).expect("from_value");
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn beta_roundtrips_when_alpha_shares_name() {
+    let (table, _, _) = build_collision_table();
+    let original = Beta::Read;
+    let value = original.to_value(&table).expect("to_value");
+    match &value {
+        Value::Con(id, _) => assert_eq!(id.0, 2, "beta encode should use TestMod.Beta.Read id"),
+        other => panic!("expected Con, got {other:?}"),
+    }
+    let decoded = Beta::from_value(&value, &table).expect("from_value");
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn alpha_decode_rejects_beta_shaped_value() {
+    // A `Value::Con` carrying Beta's DataConId must NOT decode as Alpha.
+    // With qualified lookup, Alpha's decoder looks up TestMod.Alpha.Read's id
+    // (which is 1), the incoming id is 2 (Beta), so they differ → the
+    // branch short-circuits and the decoder reports UnknownDataCon.
+    let (table, _alpha_id, beta_id) = build_collision_table();
+    let beta_value = Value::Con(beta_id, vec![]);
+    let err = Alpha::from_value(&beta_value, &table).expect_err("alpha should reject beta id");
+    match err {
+        BridgeError::UnknownDataCon(id) => assert_eq!(id, beta_id),
+        other => panic!("expected UnknownDataCon(Beta), got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_qualified_name_reports_qualified_error() {
+    // Build a table that is MISSING both qualified entries. The derive's
+    // lookup must then surface the `UnknownDataConQualified` variant, which
+    // carries the full qualified path for diagnostic clarity.
+    let table = DataConTable::new();
+    let err = Alpha::Read
+        .to_value(&table)
+        .expect_err("encode must fail without qualified entry");
+    match err {
+        BridgeError::UnknownDataConQualified { qualified_name } => {
+            assert_eq!(qualified_name, "TestMod.Alpha.Read");
+        }
+        other => panic!("expected UnknownDataConQualified, got {other:?}"),
+    }
+}

--- a/tidepool-bridge/src/error.rs
+++ b/tidepool-bridge/src/error.rs
@@ -10,6 +10,16 @@ pub enum BridgeError {
     /// The `DataConId` was found, but it has an unexpected name.
     #[error("Unknown DataCon name: {0}")]
     UnknownDataConName(String),
+    /// Lookup by (name, arity) failed — no constructor with this name has the
+    /// expected representation arity. Emitted by derived `FromCore`/`ToCore`
+    /// impls to disambiguate constructors sharing an unqualified name.
+    #[error("Unknown DataCon name: {name} (arity {arity})")]
+    UnknownDataConNameArity {
+        /// The unqualified constructor name.
+        name: String,
+        /// The expected representation arity.
+        arity: usize,
+    },
     /// The number of fields in a constructor does not match the expected arity.
     #[error("Arity mismatch for DataCon {con:?}: expected {expected}, got {got}")]
     ArityMismatch {

--- a/tidepool-bridge/src/error.rs
+++ b/tidepool-bridge/src/error.rs
@@ -20,6 +20,18 @@ pub enum BridgeError {
         /// The expected representation arity.
         arity: usize,
     },
+    /// Lookup by module-qualified name failed. Emitted by derived
+    /// `FromCore`/`ToCore` impls when a variant carries a
+    /// `#[core(module = "...", name = "...")]` attribute and the computed
+    /// `<module>.<name>` is absent from the `DataConTable`. Used to
+    /// disambiguate constructors that share both unqualified name and arity
+    /// across source modules (e.g. `Pattern.Memory.Read` vs
+    /// `Pattern.File.Read`).
+    #[error("Unknown DataCon qualified name: {qualified_name}")]
+    UnknownDataConQualified {
+        /// The fully-qualified constructor name (`Module.Constructor`).
+        qualified_name: String,
+    },
     /// The number of fields in a constructor does not match the expected arity.
     #[error("Arity mismatch for DataCon {con:?}: expected {expected}, got {got}")]
     ArityMismatch {

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -232,10 +232,27 @@ impl CompiledEffectMachine {
             if tag_ptr.is_null() {
                 return Yield::Error(YieldError::NullPointer);
             }
-            // Read the actual tag value from the Lit HeapObject (offset 16 = LIT_VALUE_OFFSET)
+            // Read the actual effect tag value. The Union's first field is the
+            // position index (Word#). After GHC optimization in single-module
+            // compilation, this is an unboxed Lit(Word, N). In cross-module
+            // compilation, the boxing may survive as Con(W#, [Lit(Word, N)]).
+            // Handle both layouts to avoid reading garbage.
             let tag_ptr_tag = unsafe { *tag_ptr };
-            let effect_tag =
-                unsafe { *(tag_ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const u64) };
+            let effect_tag = if tag_ptr_tag == layout::TAG_LIT {
+                // Unboxed: read value directly from Lit.
+                unsafe { *(tag_ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const u64) }
+            } else if tag_ptr_tag == layout::TAG_CON {
+                // Boxed (W# n): peel the box — read field[0] which is the Lit.
+                let inner = unsafe { Self::read_con_field(tag_ptr, 0) };
+                let inner = self.force_ptr(inner);
+                if inner.is_null() {
+                    return Yield::Error(YieldError::NullPointer);
+                }
+                unsafe { *(inner.add(layout::LIT_VALUE_OFFSET as usize) as *const u64) }
+            } else {
+                // Unexpected heap tag for Union position.
+                return Yield::Error(YieldError::UnexpectedTag(tag_ptr_tag));
+            };
             let mut request = unsafe { Self::read_con_field(union_ptr, 1) };
             request = self.force_ptr(request);
 

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -520,6 +520,16 @@ impl CompiledEffectMachine {
         // SAFETY: tail_callee and tail_arg are valid heap pointers set by JIT tail-call
         // sites. Code pointers in closures point to finalized JIT functions.
         while result.is_null() && !self.vmctx.tail_callee.is_null() {
+            // External cancellation safepoint — an infinite tail-recursive
+            // loop must be interruptible. See `host_fns::trampoline_resolve`
+            // for the rationale.
+            if crate::host_fns::check_cancel_and_set_error() {
+                self.vmctx.tail_callee = std::ptr::null_mut();
+                self.vmctx.tail_arg = std::ptr::null_mut();
+                *result = crate::host_fns::error_poison_ptr();
+                return;
+            }
+
             let callee = self.vmctx.tail_callee;
             let arg = self.vmctx.tail_arg;
             self.vmctx.tail_callee = std::ptr::null_mut();

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -3,7 +3,8 @@ use crate::gc::frame_walker;
 use crate::layout;
 use crate::stack_map::StackMapRegistry;
 use std::cell::{Cell, RefCell};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
 use tidepool_heap::layout as heap_layout;
 
 /// Addresses below this are considered invalid (null page guard).
@@ -38,6 +39,10 @@ pub enum RuntimeError {
     BadThunkState(u8),
     #[error("Haskell error: {0}")]
     UserErrorMsg(String),
+    /// External cancellation requested via a `CancelHandle`.
+    /// Observed at the next GC safepoint (heap check).
+    #[error("execution cancelled by external request")]
+    Cancelled,
 }
 
 thread_local! {
@@ -64,6 +69,14 @@ thread_local! {
     /// Heap pointer slots registered by Rust code (e.g., apply_cont_heap's k2_stack)
     /// so GC can update them in-place when objects move during collection.
     static RUST_ROOTS: RefCell<Vec<*mut *mut u8>> = const { RefCell::new(Vec::new()) };
+
+    /// External cancellation flag. When set, the next GC safepoint will abort the
+    /// running program with `RuntimeError::Cancelled`. Cloned from the
+    /// `Arc<AtomicBool>` owned by the `JitEffectMachine` before entering JIT code.
+    ///
+    /// Installed by `set_cancel_flag` (called from `JitEffectMachine::install_registries`)
+    /// and cleared by `clear_cancel_flag` (called from `RegistryGuard::drop`).
+    static CANCEL_FLAG: RefCell<Option<Arc<AtomicBool>>> = const { RefCell::new(None) };
 }
 
 /// Register a Rust stack/heap slot containing a heap pointer as a GC root.
@@ -141,6 +154,57 @@ pub fn clear_gc_state() {
     clear_rust_roots();
 }
 
+/// Install an external cancellation flag for the current thread. The next
+/// GC safepoint (heap check) will observe the flag and abort the program with
+/// `RuntimeError::Cancelled` if it has been set to `true`.
+///
+/// Called from `JitEffectMachine::install_registries` before entering JIT code.
+pub(crate) fn set_cancel_flag(flag: Arc<AtomicBool>) {
+    CANCEL_FLAG.with(|cell| {
+        *cell.borrow_mut() = Some(flag);
+    });
+}
+
+/// Remove the installed cancellation flag for the current thread. Called from
+/// `RegistryGuard::drop` so the Arc is released even on an early error return.
+pub(crate) fn clear_cancel_flag() {
+    CANCEL_FLAG.with(|cell| {
+        cell.borrow_mut().take();
+    });
+}
+
+/// Fast check for an external cancel request. Uses a relaxed load — the cost
+/// of a single extra relaxed atomic load per heap check is negligible, and
+/// cancellation is best-effort (observed at the next safepoint) so stronger
+/// ordering is not required.
+#[inline]
+fn cancel_requested() -> bool {
+    CANCEL_FLAG.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+    })
+}
+
+/// If cancellation has been requested, record `RuntimeError::Cancelled`
+/// (unless another error is already pending) and return `true`. Callers
+/// should then unwind by returning a poison pointer from their loop so the
+/// outer run loop can surface the error.
+#[inline]
+pub(crate) fn check_cancel_and_set_error() -> bool {
+    if cancel_requested() {
+        RUNTIME_ERROR.with(|cell| {
+            let mut slot = cell.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(RuntimeError::Cancelled);
+            }
+        });
+        true
+    } else {
+        false
+    }
+}
+
 /// GC trigger: called by JIT code when alloc_ptr exceeds alloc_limit.
 ///
 /// This function MUST be compiled with frame pointers preserved
@@ -157,6 +221,24 @@ pub extern "C" fn gc_trigger(vmctx: *mut VMContext) {
 
     GC_TRIGGER_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
     GC_TRIGGER_LAST_VMCTX.store(vmctx as usize, Ordering::SeqCst);
+
+    // External cancellation safepoint. We record `RuntimeError::Cancelled`
+    // here but still perform a normal GC so the caller's allocation can
+    // succeed cleanly — routing through `runtime_oom` is unsafe for Con
+    // allocations larger than the 24-byte poison closure, which would be
+    // written past. The cancellation is actually observed at the next
+    // trampoline loop iteration (see `check_cancel_and_set_error` in the
+    // trampolines), which returns the poison pointer in a context where it
+    // will not be written to.
+    if cancel_requested() {
+        RUNTIME_ERROR.with(|cell| {
+            let mut slot = cell.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(RuntimeError::Cancelled);
+            }
+        });
+        // Fall through to `perform_gc` so the allocation succeeds.
+    }
 
     #[cfg(target_arch = "x86_64")]
     {
@@ -368,6 +450,19 @@ pub extern "C" fn trampoline_resolve(vmctx: *mut VMContext) -> *mut u8 {
     // during compilation and point to finalized JIT functions.
     unsafe {
         loop {
+            // External cancellation safepoint. Tail-recursive loops never
+            // return to the top-level JIT call on their own, so we must check
+            // here — otherwise a runaway loop observes the cancel in
+            // `gc_trigger`, receives a poison pointer from `runtime_oom`, and
+            // immediately re-enters the trampoline forever. Returning the
+            // poison here unwinds up to `JitEffectMachine::run_pure`, which
+            // then surfaces `RuntimeError::Cancelled`.
+            if check_cancel_and_set_error() {
+                (*vmctx).tail_callee = std::ptr::null_mut();
+                (*vmctx).tail_arg = std::ptr::null_mut();
+                return error_poison_ptr();
+            }
+
             let callee = (*vmctx).tail_callee;
             let arg = (*vmctx).tail_arg;
 
@@ -523,8 +618,15 @@ pub extern "C" fn runtime_error_with_msg(kind: u64, msg_ptr: *const u8, msg_len:
 }
 
 pub extern "C" fn runtime_oom() -> *mut u8 {
+    // Preserve a pre-existing runtime error if one is already set. The
+    // external-cancellation path (see `gc_trigger`) sets `RuntimeError::Cancelled`
+    // and then forces `runtime_oom` to fire; without this guard, `HeapOverflow`
+    // would overwrite the more specific cancellation cause.
     RUNTIME_ERROR.with(|cell| {
-        *cell.borrow_mut() = Some(RuntimeError::HeapOverflow);
+        let mut slot = cell.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(RuntimeError::HeapOverflow);
+        }
     });
     error_poison_ptr()
 }

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -653,32 +653,63 @@ pub extern "C" fn runtime_bad_thunk_state_trap(_vmctx: *mut VMContext, state: u8
     error_poison_ptr()
 }
 
+/// Size of the poison buffer.
+///
+/// The JIT's `emit_alloc_fast_path` slow-fail edge calls `runtime_oom`, takes
+/// the returned pointer as if it were a freshly-allocated heap object, and
+/// then unconditionally writes the full header + payload into it (tag byte,
+/// size halfword, Con/Closure/Thunk fields, capture slots, …). If the poison
+/// is smaller than the attempted allocation, those post-OOM stores spill past
+/// the poison into adjacent heap — we've observed glibc "corrupted size vs.
+/// prev_size" aborts as a direct consequence.
+///
+/// The JIT never clamps allocation size at emit time. The effective upper
+/// bound is `CON_FIELDS_OFFSET + MAX_FIELDS * 8` (i.e. the largest Con the
+/// read-side `heap_bridge` is willing to decode; see `MAX_FIELDS = 1024`
+/// there). Closures and thunks are bounded by the same field/capture count
+/// in practice. We size the poison to comfortably absorb that worst case so
+/// any OOM path can complete its field writes harmlessly.
+///
+/// 16 KiB: `24 + 8 * 1024 = 8216` bytes for a max-arity Con, doubled for
+/// headroom. Stays well under the `u16` header `size` encoding limit.
+pub(crate) const POISON_BUF_SIZE: usize = 16 * 1024;
+
 /// Return a pointer to a pre-allocated "poison" Closure heap object.
 /// When JIT code tries to call this as a function, it returns itself,
 /// preventing cascading crashes. The runtime error flag is already set,
 /// so the effect machine will catch it before the poison reaches user code.
+///
+/// The backing allocation is oversized (`POISON_BUF_SIZE`) so that OOM
+/// paths which treat the poison as freshly-allocated scratch (via
+/// `runtime_oom`) can complete their field writes without corrupting
+/// adjacent heap. See `POISON_BUF_SIZE` for rationale.
 pub fn error_poison_ptr() -> *mut u8 {
     use std::sync::OnceLock;
     // Layout: Closure with code_ptr pointing to `poison_trampoline`,
     // num_captured = 0. When called, returns the poison closure itself.
     static POISON: OnceLock<usize> = OnceLock::new();
     let addr = *POISON.get_or_init(|| {
-        // Closure size: header(8) + code_ptr(8) + num_captured(8) = 24
-        let size = 24usize;
-        let layout =
-            std::alloc::Layout::from_size_align(size, 8).unwrap_or_else(|_| std::process::abort());
+        // Backing buffer is oversized to absorb post-OOM scratch writes
+        // from the JIT (see POISON_BUF_SIZE docs). The Closure header
+        // describes only the logical 24-byte Closure layout — the tail
+        // bytes are zero-initialized padding that the JIT may clobber
+        // after a `runtime_oom` return.
+        let logical_size = 24u16;
+        let layout = std::alloc::Layout::from_size_align(POISON_BUF_SIZE, 8)
+            .unwrap_or_else(|_| std::process::abort());
         // SAFETY: alloc_zeroed returns a valid, zeroed allocation of the requested size.
         let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
         if ptr.is_null() {
             std::alloc::handle_alloc_error(layout);
         }
-        // SAFETY: ptr is a fresh allocation of 24 bytes. Writing the closure header,
-        // code pointer, and capture count at known offsets within that allocation.
+        // SAFETY: ptr is a fresh allocation of POISON_BUF_SIZE bytes
+        // (>= 24). Writing the closure header, code pointer, and capture
+        // count at known offsets within the first 24 bytes.
         unsafe {
             tidepool_heap::layout::write_header(
                 ptr,
                 tidepool_heap::layout::TAG_CLOSURE,
-                size as u16,
+                logical_size,
             );
             // code_ptr = poison_trampoline
             *(ptr.add(tidepool_heap::layout::CLOSURE_CODE_PTR_OFFSET) as *mut usize) =
@@ -2427,5 +2458,72 @@ mod tests {
             let err = take_runtime_error().expect("Should have flagged error");
             assert!(matches!(err, RuntimeError::BadThunkState(255)));
         }
+    }
+
+    /// Regression test for the poison-buffer undersize bug.
+    ///
+    /// Prior to the fix, `runtime_oom` returned a 24-byte poison buffer that
+    /// the JIT's slow-fail alloc path then treated as freshly-allocated
+    /// scratch. For any Con with `>= 1` field (size `>= 32`) the post-OOM
+    /// field write spilled past the 24-byte allocation into adjacent heap,
+    /// manifesting as glibc "corrupted size vs. prev_size" aborts.
+    ///
+    /// The fix enlarges the poison buffer to absorb the maximum Con/Closure
+    /// footprint the JIT can emit. This test simulates the JIT's write
+    /// sequence directly: allocate a worst-case Con (24 + 1024*8 = 8216
+    /// bytes) into the poison and verify no OOB writes occur.
+    ///
+    /// Under Miri / ASan this would fail before the fix; under glibc the
+    /// corruption is non-deterministic, but the write itself is unsound
+    /// and the buffer-size assertion below guards against regression.
+    #[test]
+    fn poison_buf_absorbs_max_con_write() {
+        // Mirror of the read-side guard in heap_bridge.rs. If that constant
+        // grows, POISON_BUF_SIZE must grow to match.
+        const MAX_FIELDS: usize = 1024;
+        let worst_case_con = layout::CON_FIELDS_OFFSET as usize + MAX_FIELDS * 8;
+        assert!(
+            POISON_BUF_SIZE >= worst_case_con,
+            "poison buffer ({} B) must cover worst-case Con footprint ({} B)",
+            POISON_BUF_SIZE,
+            worst_case_con,
+        );
+
+        // Simulate the JIT's post-OOM write sequence exactly as
+        // `emit_alloc_fast_path` + the Con emitter do: tag at 0, size
+        // halfword at 1, CON_TAG at 8, num_fields at 16, fields from 24.
+        let ptr = runtime_oom();
+        assert!(!ptr.is_null());
+
+        // SAFETY: `ptr` is the poison buffer (POISON_BUF_SIZE >= worst_case_con).
+        // Writing a TAG_CON header and MAX_FIELDS u64 field slots into it
+        // stays entirely within the allocation after the fix.
+        // JIT stores use `MemFlags::trusted()` which permits unaligned
+        // access; mirror that with `write_unaligned` so the test also works
+        // on targets where a naked deref would trap on misalignment (the
+        // size halfword lands at offset 1).
+        unsafe {
+            ptr.write(layout::TAG_CON);
+            (ptr.add(1) as *mut u16).write_unaligned(worst_case_con as u16);
+            (ptr.add(layout::CON_TAG_OFFSET as usize) as *mut u64).write_unaligned(7);
+            (ptr.add(layout::CON_NUM_FIELDS_OFFSET as usize) as *mut u16)
+                .write_unaligned(MAX_FIELDS as u16);
+            for i in 0..MAX_FIELDS {
+                let off = layout::CON_FIELDS_OFFSET as usize + 8 * i;
+                (ptr.add(off) as *mut u64).write_unaligned(0xDEAD_BEEF_0000_0000 | (i as u64));
+            }
+            // Read back a sentinel to ensure the writes landed (and weren't
+            // silently dropped) — also defeats the optimizer.
+            let last_off = layout::CON_FIELDS_OFFSET as usize + 8 * (MAX_FIELDS - 1);
+            assert_eq!(
+                (ptr.add(last_off) as *const u64).read_unaligned(),
+                0xDEAD_BEEF_0000_0000 | (MAX_FIELDS as u64 - 1),
+            );
+        }
+
+        // `runtime_oom` sets `RuntimeError::HeapOverflow` — clear it so
+        // we don't leak state to other tests sharing this thread.
+        let err = take_runtime_error().expect("runtime_oom must flag an error");
+        assert!(matches!(err, RuntimeError::HeapOverflow));
     }
 }

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use cranelift_module::FuncId;
 use tidepool_effect::{DispatchEffect, EffectContext, EffectError};
 use tidepool_eval::value::Value;
@@ -56,6 +59,48 @@ pub struct JitEffectMachine {
     nursery: Nursery,
     tags: Result<ConTags, &'static str>,
     func_id: FuncId,
+    /// External cancellation flag. The JIT installs a thread-local clone of this
+    /// `Arc` via `set_cancel_flag` before entering compiled code; the next
+    /// GC safepoint observes the flag and aborts execution with
+    /// `YieldError::Cancelled` if it has been set. See [`Self::cancel_handle`].
+    cancel_flag: Arc<AtomicBool>,
+}
+
+/// External handle for cancelling a running `JitEffectMachine`.
+///
+/// `CancelHandle` is `Send + Sync + Clone`, so callers can hand clones to
+/// watchdog threads. Cancellation is observed at the next GC safepoint
+/// (heap check), which fires on essentially every non-trivial allocation in
+/// Haskell code. The running program unwinds via the normal error path with
+/// `JitError::Yield(YieldError::Cancelled)`.
+///
+/// The flag is per-`JitEffectMachine`, not per-run: call [`Self::reset`]
+/// between runs if you intend to reuse the machine after a cancellation.
+#[derive(Clone, Debug)]
+pub struct CancelHandle(Arc<AtomicBool>);
+
+impl CancelHandle {
+    /// Request cancellation of the associated `JitEffectMachine`. The running
+    /// program (if any) will abort at its next GC safepoint with
+    /// `YieldError::Cancelled`.
+    pub fn cancel(&self) {
+        // SeqCst is overkill for correctness here (the JIT thread's relaxed
+        // load will observe the store eventually), but this is not a hot path
+        // — it is called once from a watchdog — so we prefer the stronger
+        // ordering for debuggability.
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    /// Returns `true` if cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    /// Clear a previous cancellation request. Call this between runs if the
+    /// same `JitEffectMachine` is reused after a cancelled run.
+    pub fn reset(&self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
 }
 
 /// Ensures thread-local JIT registries are cleaned up even on early error return.
@@ -65,6 +110,7 @@ impl Drop for RegistryGuard {
     fn drop(&mut self) {
         crate::host_fns::clear_gc_state();
         crate::host_fns::clear_stack_map_registry();
+        crate::host_fns::clear_cancel_flag();
         crate::debug::clear_lambda_registry();
         // Clean up remaining thread-local state for same-thread reuse
         let _ = crate::host_fns::take_runtime_error();
@@ -95,13 +141,22 @@ impl JitEffectMachine {
             nursery,
             tags,
             func_id,
+            cancel_flag: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    /// Obtain a clone-able, thread-safe handle for requesting cancellation of
+    /// this machine's next (or in-flight) run. The handle remains valid for
+    /// the lifetime of the machine; multiple handles may be held concurrently.
+    pub fn cancel_handle(&self) -> CancelHandle {
+        CancelHandle(self.cancel_flag.clone())
     }
 
     fn install_registries(&mut self) -> RegistryGuard {
         crate::debug::set_lambda_registry(self.pipeline.build_lambda_registry());
         crate::host_fns::set_stack_map_registry(&self.pipeline.stack_maps);
         crate::host_fns::set_gc_state(self.nursery.start() as *mut u8, self.nursery.size());
+        crate::host_fns::set_cancel_flag(self.cancel_flag.clone());
         RegistryGuard
     }
 
@@ -267,6 +322,17 @@ unsafe fn resolve_tail_calls_protected(
 ) -> Result<*mut u8, JitError> {
     let mut ptr = result;
     while ptr.is_null() && !vmctx.tail_callee.is_null() {
+        // External cancellation safepoint — see the rationale in
+        // `host_fns::trampoline_resolve`. Without this check, an infinite
+        // tail-recursive loop never yields control back to the caller even
+        // when cancellation has been requested.
+        if crate::host_fns::check_cancel_and_set_error() {
+            vmctx.tail_callee = std::ptr::null_mut();
+            vmctx.tail_arg = std::ptr::null_mut();
+            ptr = crate::host_fns::error_poison_ptr();
+            break;
+        }
+
         let callee = vmctx.tail_callee;
         let arg = vmctx.tail_arg;
         vmctx.tail_callee = std::ptr::null_mut();

--- a/tidepool-codegen/src/yield_type.rs
+++ b/tidepool-codegen/src/yield_type.rs
@@ -96,6 +96,10 @@ pub enum YieldError {
     /// Thunk encountered with an invalid evaluation state.
     #[error("thunk has invalid evaluation state: {0}")]
     BadThunkState(u8),
+    /// External cancellation observed at a GC safepoint. Raised when a holder
+    /// of `CancelHandle` flips the flag while the JIT is executing.
+    #[error("execution cancelled by external request")]
+    Cancelled,
 }
 
 fn format_yield_signal(sig: i32) -> String {
@@ -147,6 +151,7 @@ impl From<crate::host_fns::RuntimeError> for YieldError {
             RuntimeError::StackOverflow => YieldError::StackOverflow,
             RuntimeError::BlackHole => YieldError::BlackHole,
             RuntimeError::BadThunkState(state) => YieldError::BadThunkState(state),
+            RuntimeError::Cancelled => YieldError::Cancelled,
         }
     }
 }

--- a/tidepool-codegen/tests/external_cancellation.rs
+++ b/tidepool-codegen/tests/external_cancellation.rs
@@ -1,0 +1,277 @@
+//! External cancellation of running JIT programs.
+//!
+//! `JitEffectMachine::cancel_handle` hands out a `CancelHandle` that external
+//! code (e.g. a watchdog thread) can flip. The next GC safepoint observes the
+//! flag and aborts with `YieldError::Cancelled`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use tidepool_codegen::jit_machine::{CancelHandle, JitEffectMachine, JitError};
+use tidepool_codegen::yield_type::YieldError;
+use tidepool_repr::datacon_table::DataConTable;
+use tidepool_repr::frame::CoreFrame;
+use tidepool_repr::types::*;
+use tidepool_repr::{CoreExpr, Literal, TreeBuilder};
+
+fn test_table() -> DataConTable {
+    let mut table = DataConTable::new();
+    // A 1-arity `Wrap` constructor used by the allocating-loop fixture.
+    table.insert(tidepool_repr::datacon::DataCon {
+        id: DataConId(1),
+        name: "Wrap".to_string(),
+        tag: 1,
+        rep_arity: 1,
+        field_bangs: vec![],
+        qualified_name: None,
+    });
+    // Freer-simple tags required by `JitEffectMachine::compile`.
+    use tidepool_codegen::effect_machine::EffContKind;
+    for (i, kind) in EffContKind::ALL.iter().enumerate() {
+        table.insert(tidepool_repr::datacon::DataCon {
+            id: DataConId(1000 + i as u64),
+            name: kind.name().to_string(),
+            tag: (1000 + i) as u32,
+            rep_arity: if matches!(kind, EffContKind::Node | EffContKind::Union) {
+                2
+            } else {
+                1
+            },
+            field_bangs: vec![],
+            qualified_name: None,
+        });
+    }
+    table
+}
+
+/// `letrec go = \n -> case n ==# 0# of { 1# -> Lit 42; _ -> go (n -# 1#) } in go N`
+/// — a long-running tail-recursive countdown. With a sufficiently large `n`,
+/// this takes far longer than any reasonable test timeout, giving the cancel
+/// flag a chance to be observed at the tail-call trampoline safepoint.
+/// Uses only unboxed Int# arithmetic so the hot path does not allocate —
+/// this exercises the *trampoline* cancel check independently of `gc_trigger`.
+fn build_long_running_countdown(n: i64) -> CoreExpr {
+    build_terminating_countdown(n, 42)
+}
+
+/// `letrec go = \n -> case n ==# 0# of { 1# -> Lit 7; _ -> go (n -# 1#) } in go 100`
+/// A terminating tail-recursive countdown that never sees the cancel flag.
+fn build_terminating_countdown(n: i64, result: i64) -> CoreExpr {
+    let go = VarId(1);
+    let param_n = VarId(2);
+    let case_binder = VarId(3);
+
+    let mut bld = TreeBuilder::new();
+
+    let var_n = bld.push(CoreFrame::Var(param_n));
+    let lit_0 = bld.push(CoreFrame::Lit(Literal::LitInt(0)));
+    let cmp = bld.push(CoreFrame::PrimOp {
+        op: PrimOpKind::IntEq,
+        args: vec![var_n, lit_0],
+    });
+
+    let lit_result = bld.push(CoreFrame::Lit(Literal::LitInt(result)));
+
+    let var_n2 = bld.push(CoreFrame::Var(param_n));
+    let lit_1 = bld.push(CoreFrame::Lit(Literal::LitInt(1)));
+    let sub = bld.push(CoreFrame::PrimOp {
+        op: PrimOpKind::IntSub,
+        args: vec![var_n2, lit_1],
+    });
+    let var_go = bld.push(CoreFrame::Var(go));
+    let tail_call = bld.push(CoreFrame::App {
+        fun: var_go,
+        arg: sub,
+    });
+
+    let case_node = bld.push(CoreFrame::Case {
+        scrutinee: cmp,
+        binder: case_binder,
+        alts: vec![
+            Alt {
+                con: AltCon::LitAlt(Literal::LitInt(1)),
+                binders: vec![],
+                body: lit_result,
+            },
+            Alt {
+                con: AltCon::Default,
+                binders: vec![],
+                body: tail_call,
+            },
+        ],
+    });
+
+    let lam = bld.push(CoreFrame::Lam {
+        binder: param_n,
+        body: case_node,
+    });
+
+    let lit_n = bld.push(CoreFrame::Lit(Literal::LitInt(n)));
+    let var_go_call = bld.push(CoreFrame::Var(go));
+    let app = bld.push(CoreFrame::App {
+        fun: var_go_call,
+        arg: lit_n,
+    });
+
+    bld.push(CoreFrame::LetRec {
+        bindings: vec![(go, lam)],
+        body: app,
+    });
+
+    bld.build()
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Unit coverage for `CancelHandle`'s atomic semantics.
+// ──────────────────────────────────────────────────────────────────────
+
+/// A `CancelHandle` is obtainable from a compiled machine, and distinct clones
+/// share state — cancellation on one is visible on another.
+#[test]
+fn cancel_handle_clones_share_state() {
+    let expr = build_terminating_countdown(1, 42);
+    let table = test_table();
+    let machine = JitEffectMachine::compile(&expr, &table, 1 << 16).unwrap();
+
+    let h1 = machine.cancel_handle();
+    let h2 = h1.clone();
+    let h3 = machine.cancel_handle();
+
+    assert!(!h1.is_cancelled());
+    assert!(!h2.is_cancelled());
+    assert!(!h3.is_cancelled());
+
+    h2.cancel();
+
+    assert!(h1.is_cancelled());
+    assert!(h2.is_cancelled());
+    assert!(h3.is_cancelled(), "fresh handles also see the flag");
+
+    h1.reset();
+    assert!(!h1.is_cancelled());
+    assert!(!h2.is_cancelled());
+    assert!(!h3.is_cancelled());
+}
+
+/// `CancelHandle` is `Send + Sync`, required so callers can hand clones to
+/// watchdog threads. This is a compile-time assertion.
+#[test]
+fn cancel_handle_is_send_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<CancelHandle>();
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Integration: cancellation observed at a GC safepoint.
+// ──────────────────────────────────────────────────────────────────────
+
+/// A runaway tail-recursive loop is aborted by an external
+/// `cancel()` call within a bounded time budget. The program must surface
+/// `YieldError::Cancelled` via the normal error path. The fixture uses a
+/// non-allocating countdown so the cancel-observation site exercised here
+/// is the tail-call trampoline (see `host_fns::trampoline_resolve`) rather
+/// than `gc_trigger`.
+#[test]
+fn cancel_runaway_tail_recursive_loop() {
+    // Use a small nursery so GC fires often and cancellation is observed quickly.
+    // Extremely large bound — at ~1e8 per second this runs for ~10s, well
+    // beyond the 100ms warmup + 2s cancel deadline.
+    let expr = build_long_running_countdown(1_000_000_000);
+    let table = test_table();
+    let mut machine = JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+    let handle = machine.cancel_handle();
+
+    // Run in a separate thread so we can flip the flag from here.
+    let done = std::sync::Arc::new(AtomicBool::new(false));
+    let done_thread = done.clone();
+    let jit_thread = std::thread::spawn(move || {
+        let result = machine.run_pure();
+        done_thread.store(true, Ordering::SeqCst);
+        result
+    });
+
+    // Let it warm up and start spinning.
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(
+        !done.load(Ordering::SeqCst),
+        "fixture program was not actually infinite — it returned before cancel"
+    );
+
+    handle.cancel();
+
+    // The JIT should observe the cancel at its next heap check (which happens
+    // many times per millisecond in this fixture). 2s is a very generous bound.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !done.load(Ordering::SeqCst) {
+        if Instant::now() > deadline {
+            panic!("JIT did not observe cancellation within 2s");
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    let err = jit_thread.join().unwrap().unwrap_err();
+    match err {
+        JitError::Yield(YieldError::Cancelled) => {}
+        other => panic!("expected YieldError::Cancelled, got {:?}", other),
+    }
+}
+
+/// When the cancel flag is not set, a terminating program runs to completion
+/// with its normal result — cancellation is strictly opt-in.
+#[test]
+fn no_cancel_means_normal_completion() {
+    let expr = build_terminating_countdown(1000, 99);
+    let table = test_table();
+    let mut machine = JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+    let handle = machine.cancel_handle();
+    assert!(!handle.is_cancelled());
+
+    let result = machine
+        .run_pure()
+        .expect("terminating program must succeed");
+    match result {
+        tidepool_eval::value::Value::Lit(Literal::LitInt(n)) => assert_eq!(n, 99),
+        other => panic!("expected Lit(Int(99)), got {:?}", other),
+    }
+
+    // Flag was never touched and the machine stays uncancelled afterwards.
+    assert!(!handle.is_cancelled());
+}
+
+/// The cancel flag is per-machine (not per-run). After cancellation unwinds,
+/// `reset()` lets the same machine be reused for a fresh run.
+#[test]
+fn reset_enables_reuse_after_cancellation() {
+    let expr = build_long_running_countdown(1_000_000_000);
+    let table = test_table();
+    let mut machine = JitEffectMachine::compile(&expr, &table, 1 << 20).unwrap();
+    let handle = machine.cancel_handle();
+
+    // Pre-set cancel, then run: should abort almost immediately.
+    handle.cancel();
+    let err = machine.run_pure().unwrap_err();
+    assert!(
+        matches!(err, JitError::Yield(YieldError::Cancelled)),
+        "first run must surface Cancelled, got {:?}",
+        err
+    );
+    assert!(handle.is_cancelled());
+
+    // Reset and run a different (terminating) program on a fresh machine —
+    // confirms `reset()` clears the flag, which would also unblock reuse of
+    // *this* machine if the compiled program supported multiple invocations.
+    handle.reset();
+    assert!(!handle.is_cancelled());
+
+    let expr2 = build_terminating_countdown(500, 7);
+    let mut machine2 = JitEffectMachine::compile(&expr2, &table, 1 << 20).unwrap();
+    let handle2 = machine2.cancel_handle();
+    // Explicitly reset (even though a fresh machine starts clean) to exercise
+    // the path.
+    handle2.reset();
+    let result = machine2.run_pure().expect("second run must succeed");
+    match result {
+        tidepool_eval::value::Value::Lit(Literal::LitInt(n)) => assert_eq!(n, 7),
+        other => panic!("expected Lit(Int(7)), got {:?}", other),
+    }
+}

--- a/tidepool-runtime/tests/multi_module_datacon.rs
+++ b/tidepool-runtime/tests/multi_module_datacon.rs
@@ -62,7 +62,7 @@ fn test_cross_module_inspect_tags() {
     let pp = prelude_path();
     let include: Vec<&Path> = vec![pp.as_path(), effect_dir.path()];
 
-    let (expr, table, _warnings) =
+    let (expr, _table, _warnings) =
         compile_haskell(&main_src, "agent", &include).expect("compilation failed");
 
     // Pretty print the expression tree
@@ -87,15 +87,11 @@ fn test_cross_module_inspect_tags() {
                     }
                 }
             }
-            CoreFrame::Con { tag, .. } => {
-                if tag.0 == target_tag {
-                    eprintln!("  FOUND at node {} as Con", i);
-                }
+            CoreFrame::Con { tag, .. } if tag.0 == target_tag => {
+                eprintln!("  FOUND at node {} as Con", i);
             }
-            CoreFrame::Var(vid) => {
-                if vid.0 == target_tag {
-                    eprintln!("  FOUND at node {} as Var", i);
-                }
+            CoreFrame::Var(vid) if vid.0 == target_tag => {
+                eprintln!("  FOUND at node {} as Var", i);
             }
             _ => {}
         }

--- a/tidepool-runtime/tests/multi_module_datacon.rs
+++ b/tidepool-runtime/tests/multi_module_datacon.rs
@@ -1,0 +1,128 @@
+//! Regression test for multi-module DataCon tag inconsistency.
+
+mod common;
+
+use tidepool_bridge_derive::FromCore;
+use tidepool_effect::{EffectContext, EffectError, EffectHandler};
+use tidepool_eval::value::Value;
+use tidepool_runtime::{compile_and_run, compile_haskell};
+
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn prelude_path() -> std::path::PathBuf {
+    common::prelude_path()
+}
+
+#[derive(FromCore)]
+enum FooReq {
+    #[core(name = "Ping")]
+    Ping,
+}
+
+struct FooHandler;
+
+impl EffectHandler for FooHandler {
+    type Request = FooReq;
+    fn handle(&mut self, req: FooReq, cx: &EffectContext) -> Result<Value, EffectError> {
+        match req {
+            FooReq::Ping => cx.respond(()),
+        }
+    }
+}
+
+fn setup_multi_module_test() -> (TempDir, String) {
+    let effect_dir = TempDir::new().expect("failed to create temp dir");
+
+    let effect_src = r#"{-# LANGUAGE GADTs, DataKinds, TypeOperators, FlexibleContexts #-}
+module RemoteEffect where
+import Control.Monad.Freer (Eff, Member, send)
+data Foo a where Ping :: Foo ()
+sendFoo :: Member Foo effs => Eff effs ()
+sendFoo = send Ping
+"#;
+    std::fs::write(effect_dir.path().join("RemoteEffect.hs"), effect_src)
+        .expect("failed to write RemoteEffect.hs");
+
+    let main_src = r#"{-# LANGUAGE DataKinds, TypeOperators, FlexibleContexts #-}
+module MinRepro where
+import Control.Monad.Freer (Eff)
+import qualified RemoteEffect as R
+agent :: Eff '[R.Foo] ()
+agent = R.sendFoo
+"#;
+
+    (effect_dir, main_src.to_string())
+}
+
+/// Inspect the expression tree for tag mismatches.
+#[test]
+fn test_cross_module_inspect_tags() {
+    let (effect_dir, main_src) = setup_multi_module_test();
+    let pp = prelude_path();
+    let include: Vec<&Path> = vec![pp.as_path(), effect_dir.path()];
+
+    let (expr, table, _warnings) =
+        compile_haskell(&main_src, "agent", &include).expect("compilation failed");
+
+    // Pretty print the expression tree
+    eprintln!("Expression tree ({} nodes):", expr.nodes.len());
+    let pp_expr = tidepool_repr::pretty::pretty_print(&expr);
+    eprintln!("{}", pp_expr);
+
+    // Check for the mystery tag
+    let target_tag = 0xfe39c1e45ffaa2ad_u64;
+    eprintln!("\nSearching for mystery tag {:#018x}:", target_tag);
+
+    use tidepool_repr::frame::CoreFrame;
+    use tidepool_repr::types::AltCon;
+    for (i, node) in expr.nodes.iter().enumerate() {
+        match node {
+            CoreFrame::Case { alts, .. } => {
+                for alt in alts {
+                    if let AltCon::DataAlt(id) = alt.con {
+                        if id.0 == target_tag {
+                            eprintln!("  FOUND at node {} in case alt", i);
+                        }
+                    }
+                }
+            }
+            CoreFrame::Con { tag, .. } => {
+                if tag.0 == target_tag {
+                    eprintln!("  FOUND at node {} as Con", i);
+                }
+            }
+            CoreFrame::Var(vid) => {
+                if vid.0 == target_tag {
+                    eprintln!("  FOUND at node {} as Var", i);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Test that cross-module effect actually runs without CASE TRAP.
+#[test]
+fn test_cross_module_effect_runs() {
+    let (effect_dir, main_src) = setup_multi_module_test();
+    let pp = prelude_path();
+    let effect_path: PathBuf = effect_dir.path().to_owned();
+    let pp_clone = pp.clone();
+
+    let result = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            let _keep = effect_dir;
+            let include: Vec<&Path> = vec![pp_clone.as_path(), effect_path.as_path()];
+            let mut handlers = frunk::hlist![FooHandler];
+            compile_and_run(&main_src, "agent", &include, &mut handlers, &())
+                .expect("compile_and_run should succeed for cross-module effect")
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+
+    let json = result.to_json();
+    assert_eq!(json, serde_json::json!(null));
+}


### PR DESCRIPTION
If you want me to split these up better I can, but the fixes are all kinda linked.

Thing I ran into was multi-module via --include (etc.) basically didn't work and you had to inline everything. which is ~fine, but not ideal as I wanted to keep the SDK modular rather than concatenating everything into a single program conditionally in Rust the way the tidepool MCP does it. The series of fixes were mostly downstream of getting that behaving and avoiding spurious namespace collisions from imports and handlers.

The external cancellation handle is to help with the orphaned thread problem if a program starts misbehaving, basically try and handle things a little more gracefully before that point.