### PR TITLE
followup(#272): tests, prompt cancel safepoint, doc clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,27 @@ match vm.run_pure() {
 }
 ```
 
-Cancellation is observed at the next GC safepoint (heap check) or tail-call
-trampoline iteration, whichever comes first. Both fire frequently enough
-that latency is essentially negligible — typically sub-millisecond.
+Cancellation is observed at three safepoints, in priority order:
+
+1. **Tail-call trampoline iteration** — every iteration of a `letrec`-style
+   tail loop. Fires constantly in tail-recursive Haskell. Promptly unwinds
+   with `YieldError::Cancelled`.
+2. **Effect-dispatch boundary** — checked in `JitEffectMachine::run` after
+   each handler invocation, before resuming the JIT. Promptly unwinds for
+   freer-simple effect loops, including handler-driven cancellation
+   (a watchdog handler that flips its own machine's `CancelHandle`).
+3. **GC heap-check safepoint** — fires on every non-trivial allocation.
+   Best-effort: it records the cancellation but does not unwind, so the
+   actual surface latency depends on the program reaching one of the
+   prompt safepoints above.
+
+The pathological case is a non-tail-call, non-effectful loop that allocates
+without bound — for example, `length [1..]` style programs. Such loops
+observe the cancel at the heap check but have no prompt safepoint to
+unwind through, so cancellation may surface only as an eventual
+heap-overflow error rather than `Cancelled`. This is tracked as a
+follow-up; in practice the handler-driven and tail-recursive shapes
+cover the realistic uses.
 
 The flag is per-machine, not per-run. Call `handle.reset()` between runs if
 you intend to reuse the same `JitEffectMachine` after a cancellation.

--- a/README.md
+++ b/README.md
@@ -219,9 +219,10 @@ The pathological case is a non-tail-call, non-effectful loop that allocates
 without bound — for example, `length [1..]` style programs. Such loops
 observe the cancel at the heap check but have no prompt safepoint to
 unwind through, so cancellation may surface only as an eventual
-heap-overflow error rather than `Cancelled`. This is tracked as a
-follow-up; in practice the handler-driven and tail-recursive shapes
-cover the realistic uses.
+heap-overflow error rather than `Cancelled`. Tracked in
+[#273](https://github.com/tidepool-heavy-industries/tidepool/issues/273);
+in practice the handler-driven and tail-recursive shapes cover the
+realistic uses.
 
 The flag is per-machine, not per-run. Call `handle.reset()` between runs if
 you intend to reuse the same `JitEffectMachine` after a cancellation.

--- a/haskell/src/Tidepool/Translate.hs
+++ b/haskell/src/Tidepool/Translate.hs
@@ -1043,9 +1043,8 @@ translateHead = \case
   -- emit the body directly. Without this, the translator emits Con_unit for
   -- unsafeEqualityProof but the case alt expects Con_UnsafeRefl, causing a
   -- tag mismatch (CASE TRAP) at runtime.
-  Case scrut _b _alts_ty [Alt (DataAlt _dc) binders body]
-    | isUnsafeEqualityCase scrut -> do
-        let _typeEvidence = filter isTyVar binders
+  Case scrut _b _alts_ty [Alt (DataAlt _dc) _binders body]
+    | isUnsafeEqualityCase scrut ->
         translate body
   Case scrut b _alts_ty alts -> do
     scrutIdx <- translate scrut

--- a/tidepool-bridge-derive/tests/phantom_data.rs
+++ b/tidepool-bridge-derive/tests/phantom_data.rs
@@ -1,0 +1,212 @@
+//! `PhantomData<T>` fields are excluded from the Core representation by the
+//! `FromCore`/`ToCore` derives.
+//!
+//! Two properties to guard:
+//!
+//! 1. **Arity**: a Rust struct/variant with `N` total fields and `K` phantom
+//!    fields encodes to a Core `Con` with arity `N - K`. The derived decoder
+//!    must look up the constructor at the *Core* arity, not the Rust arity.
+//! 2. **No bound leak**: `T` in `PhantomData<T>` must not require `FromCore`
+//!    / `ToCore`. The phantom-only struct below uses a `T` that intentionally
+//!    has no bridge impls; this file failing to compile would prove the bound
+//!    leaked.
+
+use std::marker::PhantomData;
+
+use tidepool_bridge::{FromCore, ToCore};
+use tidepool_bridge_derive::{FromCore, ToCore};
+use tidepool_eval::Value;
+use tidepool_repr::{DataCon, DataConId, DataConTable};
+use tidepool_testing::gen::datacon_table::standard_datacon_table;
+
+/// A type with no `FromCore`/`ToCore` impls. Using it inside `PhantomData<_>`
+/// proves the derive does not require bridge bounds on phantom type params.
+#[derive(Debug, PartialEq, Eq)]
+struct NoBridgeImpl;
+
+// ──────────────────────────────────────────────────────────────────────
+// Enum coverage
+// ──────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+enum WithPhantom {
+    /// Phantom-only variant: 1 Rust field, 0 Core fields.
+    #[core(name = "Tagged")]
+    Tagged(PhantomData<NoBridgeImpl>),
+
+    /// Mixed: 1 Rust phantom + 1 Rust real = 1 Core field.
+    #[core(name = "Mixed")]
+    Mixed(PhantomData<NoBridgeImpl>, i64),
+
+    /// Real-only: 1 Rust real = 1 Core field. Sanity check that the
+    /// non-phantom path is unaffected.
+    #[core(name = "Plain")]
+    Plain(i64),
+}
+
+fn build_enum_table() -> DataConTable {
+    let mut t = standard_datacon_table();
+    t.insert(DataCon {
+        id: DataConId(1000),
+        name: "Tagged".into(),
+        tag: 1,
+        rep_arity: 0,
+        field_bangs: vec![],
+        qualified_name: None,
+    });
+    t.insert(DataCon {
+        id: DataConId(1001),
+        name: "Mixed".into(),
+        tag: 2,
+        rep_arity: 1,
+        field_bangs: vec![],
+        qualified_name: None,
+    });
+    t.insert(DataCon {
+        id: DataConId(1002),
+        name: "Plain".into(),
+        tag: 3,
+        rep_arity: 1,
+        field_bangs: vec![],
+        qualified_name: None,
+    });
+    t
+}
+
+#[test]
+fn phantom_only_variant_encodes_zero_core_fields() {
+    let table = build_enum_table();
+    let v = WithPhantom::Tagged(PhantomData);
+    let encoded = v.to_value(&table).expect("Tagged encode");
+    match encoded {
+        Value::Con(id, ref fields) => {
+            assert_eq!(id, DataConId(1000));
+            assert!(
+                fields.is_empty(),
+                "phantom-only variant must encode to a 0-field Con, got {} fields",
+                fields.len()
+            );
+        }
+        _ => panic!("expected Con, got {:?}", encoded),
+    }
+    let decoded = WithPhantom::from_value(&encoded, &table).expect("Tagged decode");
+    assert_eq!(decoded, v);
+}
+
+#[test]
+fn mixed_variant_encodes_only_real_fields() {
+    let table = build_enum_table();
+    let v = WithPhantom::Mixed(PhantomData, 42);
+    let encoded = v.to_value(&table).expect("Mixed encode");
+    match &encoded {
+        Value::Con(id, fields) => {
+            assert_eq!(*id, DataConId(1001));
+            assert_eq!(
+                fields.len(),
+                1,
+                "mixed variant must encode 1 Core field (the Int), not 2",
+            );
+        }
+        _ => panic!("expected Con, got {:?}", encoded),
+    }
+    let decoded = WithPhantom::from_value(&encoded, &table).expect("Mixed decode");
+    assert_eq!(decoded, v);
+}
+
+#[test]
+fn real_only_variant_unaffected_by_phantom_path() {
+    let table = build_enum_table();
+    let v = WithPhantom::Plain(7);
+    let encoded = v.to_value(&table).expect("Plain encode");
+    match &encoded {
+        Value::Con(id, fields) => {
+            assert_eq!(*id, DataConId(1002));
+            assert_eq!(fields.len(), 1);
+        }
+        _ => panic!("expected Con, got {:?}", encoded),
+    }
+    let decoded = WithPhantom::from_value(&encoded, &table).expect("Plain decode");
+    assert_eq!(decoded, v);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Struct coverage
+// ──────────────────────────────────────────────────────────────────────
+
+/// Mixed struct: phantom field interleaved with a real field. Tests that the
+/// derived destructure pattern (`name: _` for phantom slots) and the encoded
+/// field order both stay correct.
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+#[core(name = "MixStruct")]
+struct MixStruct {
+    payload: i64,
+    _marker: PhantomData<NoBridgeImpl>,
+}
+
+#[derive(Debug, PartialEq, Eq, FromCore, ToCore)]
+#[core(name = "PhantomStruct")]
+struct PhantomStruct {
+    _marker: PhantomData<NoBridgeImpl>,
+}
+
+fn build_struct_table() -> DataConTable {
+    let mut t = standard_datacon_table();
+    t.insert(DataCon {
+        id: DataConId(2000),
+        name: "MixStruct".into(),
+        tag: 1,
+        rep_arity: 1,
+        field_bangs: vec![],
+        qualified_name: None,
+    });
+    t.insert(DataCon {
+        id: DataConId(2001),
+        name: "PhantomStruct".into(),
+        tag: 1,
+        rep_arity: 0,
+        field_bangs: vec![],
+        qualified_name: None,
+    });
+    t
+}
+
+#[test]
+fn struct_with_mixed_fields_round_trips() {
+    let table = build_struct_table();
+    let v = MixStruct {
+        payload: 99,
+        _marker: PhantomData,
+    };
+    let encoded = v.to_value(&table).expect("MixStruct encode");
+    match &encoded {
+        Value::Con(id, fields) => {
+            assert_eq!(*id, DataConId(2000));
+            assert_eq!(
+                fields.len(),
+                1,
+                "MixStruct has 1 real + 1 phantom field; Core encoding must be arity 1",
+            );
+        }
+        _ => panic!("expected Con, got {:?}", encoded),
+    }
+    let decoded = MixStruct::from_value(&encoded, &table).expect("MixStruct decode");
+    assert_eq!(decoded, v);
+}
+
+#[test]
+fn phantom_only_struct_encodes_zero_fields() {
+    let table = build_struct_table();
+    let v = PhantomStruct {
+        _marker: PhantomData,
+    };
+    let encoded = v.to_value(&table).expect("PhantomStruct encode");
+    match &encoded {
+        Value::Con(id, fields) => {
+            assert_eq!(*id, DataConId(2001));
+            assert!(fields.is_empty(), "phantom-only struct encodes 0 fields");
+        }
+        _ => panic!("expected Con, got {:?}", encoded),
+    }
+    let decoded = PhantomStruct::from_value(&encoded, &table).expect("PhantomStruct decode");
+    assert_eq!(decoded, v);
+}

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -59,7 +59,11 @@ pub unsafe fn heap_to_value_forcing(
 }
 
 const MAX_DEPTH: usize = 10_000;
-const MAX_FIELDS: usize = 1024;
+/// Maximum number of fields the read-side decoder will accept on a single
+/// `Con` heap object. The poison buffer in `host_fns` must be large enough
+/// to absorb a worst-case Con write at this arity (see
+/// `host_fns::POISON_BUF_SIZE` and the compile-time assertion there).
+pub(crate) const MAX_FIELDS: usize = 1024;
 const MAX_DATA_SIZE: usize = 64 * 1024 * 1024; // 64MB
 
 unsafe fn heap_to_value_inner(

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -222,14 +222,22 @@ pub extern "C" fn gc_trigger(vmctx: *mut VMContext) {
     GC_TRIGGER_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
     GC_TRIGGER_LAST_VMCTX.store(vmctx as usize, Ordering::SeqCst);
 
-    // External cancellation safepoint. We record `RuntimeError::Cancelled`
-    // here but still perform a normal GC so the caller's allocation can
-    // succeed cleanly — routing through `runtime_oom` is unsafe for Con
-    // allocations larger than the 24-byte poison closure, which would be
-    // written past. The cancellation is actually observed at the next
-    // trampoline loop iteration (see `check_cancel_and_set_error` in the
-    // trampolines), which returns the poison pointer in a context where it
-    // will not be written to.
+    // External cancellation safepoint (best-effort). We record
+    // `RuntimeError::Cancelled` here but do NOT unwind: the GC must still
+    // run so the caller's allocation succeeds. Routing through
+    // `runtime_oom` here would hand back the poison pointer to a JIT site
+    // that's about to write a full Con/Closure header into it, which the
+    // emitter assumes is fresh nursery space; the now-larger
+    // `POISON_BUF_SIZE` makes that survivable but it would still bypass
+    // the prompt-cancel paths above (which give better error semantics).
+    //
+    // Prompt unwind happens at the trampoline loop
+    // (`check_cancel_and_set_error` in trampoline_resolve) and at the
+    // effect-dispatch boundary in `JitEffectMachine::run`. A pure
+    // non-tail-call loop that only allocates would observe the cancel
+    // here but never reach those safepoints — it surfaces eventually
+    // as some other error (typically `HeapOverflow`). Tracked as a
+    // follow-up; pure-allocator-only programs are not the realistic case.
     if cancel_requested() {
         RUNTIME_ERROR.with(|cell| {
             let mut slot = cell.borrow_mut();

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -236,8 +236,9 @@ pub extern "C" fn gc_trigger(vmctx: *mut VMContext) {
     // effect-dispatch boundary in `JitEffectMachine::run`. A pure
     // non-tail-call loop that only allocates would observe the cancel
     // here but never reach those safepoints — it surfaces eventually
-    // as some other error (typically `HeapOverflow`). Tracked as a
-    // follow-up; pure-allocator-only programs are not the realistic case.
+    // as some other error (typically `HeapOverflow`). Tracked in
+    // <https://github.com/tidepool-heavy-industries/tidepool/issues/273>;
+    // pure-allocator-only programs are not the realistic case.
     if cancel_requested() {
         RUNTIME_ERROR.with(|cell| {
             let mut slot = cell.borrow_mut();

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -674,6 +674,26 @@ pub extern "C" fn runtime_bad_thunk_state_trap(_vmctx: *mut VMContext, state: u8
 /// headroom. Stays well under the `u16` header `size` encoding limit.
 pub(crate) const POISON_BUF_SIZE: usize = 16 * 1024;
 
+/// Compile-time guard: the poison buffer must be large enough to absorb a
+/// post-OOM write of a worst-case Con at the read-side decoder's
+/// `MAX_FIELDS` ceiling. If `MAX_FIELDS` is bumped without updating
+/// `POISON_BUF_SIZE`, this assertion fails to compile rather than
+/// regressing into the runtime heap-corruption symptom that PR #272
+/// originally diagnosed (glibc "corrupted size vs. prev_size" aborts on
+/// OOM paths writing past the old 24-byte poison). The matching runtime
+/// regression test lives in the module's `tests` block under
+/// `poison_buf_absorbs_max_con_write`.
+const _: () = {
+    let worst_case_con =
+        layout::CON_FIELDS_OFFSET as usize + crate::heap_bridge::MAX_FIELDS * 8;
+    assert!(
+        POISON_BUF_SIZE >= worst_case_con,
+        "POISON_BUF_SIZE must absorb worst-case Con write \
+         (CON_FIELDS_OFFSET + MAX_FIELDS * 8); bump POISON_BUF_SIZE \
+         when MAX_FIELDS grows",
+    );
+};
+
 /// Return a pointer to a pre-allocated "poison" Closure heap object.
 /// When JIT code tries to call this as a function, it returns itself,
 /// preventing cascading crashes. The runtime error flag is already set,
@@ -2478,9 +2498,11 @@ mod tests {
     /// and the buffer-size assertion below guards against regression.
     #[test]
     fn poison_buf_absorbs_max_con_write() {
-        // Mirror of the read-side guard in heap_bridge.rs. If that constant
-        // grows, POISON_BUF_SIZE must grow to match.
-        const MAX_FIELDS: usize = 1024;
+        // The read-side decoder cap; the compile-time assertion above
+        // guarantees POISON_BUF_SIZE absorbs this. The runtime check here
+        // additionally exercises the full write sequence to surface any
+        // overflow under Miri / ASan, not just the size relationship.
+        use crate::heap_bridge::MAX_FIELDS;
         let worst_case_con = layout::CON_FIELDS_OFFSET as usize + MAX_FIELDS * 8;
         assert!(
             POISON_BUF_SIZE >= worst_case_con,

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -223,6 +223,24 @@ impl JitEffectMachine {
                     }
                     let cx = EffectContext::with_user(table, user);
                     let resp_val = handlers.dispatch(tag, &req_val, &cx)?;
+
+                    // External cancellation safepoint at the effect-dispatch
+                    // boundary. The handler we just called may itself have
+                    // flipped the cancel flag (a watchdog handler is the
+                    // canonical case); the JIT-internal safepoints
+                    // (gc_trigger, trampoline_resolve) only fire on
+                    // tail-recursive or heavy-allocating Haskell, so
+                    // freer-simple effect loops would otherwise observe
+                    // the cancel only as an eventual unrelated error.
+                    // Checking here gives prompt unwind for the realistic
+                    // handler-driven scenario without depending on the
+                    // shape of the compiled program.
+                    if self.cancel_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                        break Err(JitError::Yield(
+                            crate::yield_type::YieldError::Cancelled,
+                        ));
+                    }
+
                     const MAX_EFFECT_RESPONSE_NODES: usize = 10_000;
                     let nodes = resp_val.node_count();
                     if nodes > MAX_EFFECT_RESPONSE_NODES {

--- a/tidepool-codegen/tests/effect_machine.rs
+++ b/tidepool-codegen/tests/effect_machine.rs
@@ -306,6 +306,83 @@ fn test_yield_request_e() {
     assert!(!continuation.is_null());
 }
 
+/// Yield::Request when the Union's position field is a *boxed* `W# n`
+/// (`Con(W#, [Lit(Word, n)])`) rather than the unboxed `Lit(Word, n)`.
+///
+/// Single-module compilation lets GHC eliminate the box via case-of-known-
+/// constructor, but cross-module compilation can leave it intact. The
+/// effect_machine must therefore peel the box transparently. Without that
+/// branch, `*tag_ptr.add(LIT_VALUE_OFFSET)` reads the Con's `num_fields`
+/// halfword as a u64, returning garbage for the effect tag.
+///
+/// Constructing both shapes side-by-side here pins the contract independent
+/// of GHC's optimizer.
+#[test]
+fn test_yield_request_e_boxed_tag() {
+    let (_pipeline, func) = build_test_fn("test_e_boxed", |builder, vmctx, gc_sig, oom_func| {
+        let request_lit = emit_alloc_lit_int(builder, vmctx, gc_sig, oom_func, 99);
+
+        // Boxed Word: Con(W#_tag, [Lit(Word, 7)]). The W# Con tag id is
+        // arbitrary from the effect_machine's perspective — it only checks
+        // that the position field has TAG_CON, then reads field[0].
+        let inner_word = emit_alloc_lit_word(builder, vmctx, gc_sig, oom_func, 7);
+        const W_HASH_CON_TAG: u64 = 42; // arbitrary, not val/e/union/leaf/node
+        let boxed_tag =
+            emit_alloc_con1(builder, vmctx, gc_sig, oom_func, W_HASH_CON_TAG, inner_word);
+
+        let union_ptr = emit_alloc_con2(
+            builder,
+            vmctx,
+            gc_sig,
+            oom_func,
+            UNION_CON_TAG,
+            boxed_tag,
+            request_lit,
+        );
+        let cont_ptr = emit_alloc_lit_int(builder, vmctx, gc_sig, oom_func, 0);
+        let e_ptr = emit_alloc_con2(
+            builder, vmctx, gc_sig, oom_func, E_CON_TAG, union_ptr, cont_ptr,
+        );
+        builder.ins().return_(&[e_ptr]);
+    });
+
+    let mut nursery = vec![0u8; 4096];
+    let start = nursery.as_mut_ptr();
+    let end = unsafe { start.add(4096) };
+    let vmctx = VMContext::new(start, end, host_fns::gc_trigger);
+
+    let mut machine = CompiledEffectMachine::new(
+        func,
+        vmctx,
+        tidepool_codegen::effect_machine::ConTags {
+            val: VAL_CON_TAG,
+            e: E_CON_TAG,
+            union: UNION_CON_TAG,
+            leaf: LEAF_CON_TAG,
+            node: NODE_CON_TAG,
+        },
+    );
+    let result = machine.step();
+
+    let Yield::Request {
+        tag,
+        request,
+        continuation,
+    } = result
+    else {
+        panic!("Expected Yield::Request from boxed-tag Union, got {:?}", result);
+    };
+
+    assert_eq!(
+        tag, 7,
+        "boxed Union tag must be peeled and read as the inner Word value, \
+         not the Con's num_fields halfword"
+    );
+    assert_eq!(unsafe { *request }, TAG_LIT);
+    assert_eq!(unsafe { *(request.add(16) as *const i64) }, 99);
+    assert!(!continuation.is_null());
+}
+
 /// Test 3: CompiledEffectMachine is Send.
 #[test]
 fn test_machine_is_send() {

--- a/tidepool-runtime/tests/multi_module_datacon.rs
+++ b/tidepool-runtime/tests/multi_module_datacon.rs
@@ -55,47 +55,57 @@ agent = R.sendFoo
     (effect_dir, main_src.to_string())
 }
 
-/// Inspect the expression tree for tag mismatches.
+/// Every `DataAlt` and `Con` referenced by the compiled expression tree must
+/// resolve to an entry in the produced `DataConTable`. The original
+/// multi-module bug manifested as a `Case` alt referencing a `DataConId`
+/// (the "mystery tag" 0xfe39c1e45ffaa2ad) that no `DataCon` row carried —
+/// the runtime then CASE-trapped at the unmatchable id. Verifying table
+/// closure catches that class of regression structurally, without depending
+/// on JIT execution.
 #[test]
-fn test_cross_module_inspect_tags() {
+fn test_cross_module_datacon_table_consistency() {
     let (effect_dir, main_src) = setup_multi_module_test();
     let pp = prelude_path();
     let include: Vec<&Path> = vec![pp.as_path(), effect_dir.path()];
 
-    let (expr, _table, _warnings) =
+    let (expr, table, _warnings) =
         compile_haskell(&main_src, "agent", &include).expect("compilation failed");
-
-    // Pretty print the expression tree
-    eprintln!("Expression tree ({} nodes):", expr.nodes.len());
-    let pp_expr = tidepool_repr::pretty::pretty_print(&expr);
-    eprintln!("{}", pp_expr);
-
-    // Check for the mystery tag
-    let target_tag = 0xfe39c1e45ffaa2ad_u64;
-    eprintln!("\nSearching for mystery tag {:#018x}:", target_tag);
 
     use tidepool_repr::frame::CoreFrame;
     use tidepool_repr::types::AltCon;
+
+    let mut unresolved_alts = Vec::new();
+    let mut unresolved_cons = Vec::new();
     for (i, node) in expr.nodes.iter().enumerate() {
         match node {
             CoreFrame::Case { alts, .. } => {
                 for alt in alts {
                     if let AltCon::DataAlt(id) = alt.con {
-                        if id.0 == target_tag {
-                            eprintln!("  FOUND at node {} in case alt", i);
+                        if table.get(id).is_none() {
+                            unresolved_alts.push((i, id));
                         }
                     }
                 }
             }
-            CoreFrame::Con { tag, .. } if tag.0 == target_tag => {
-                eprintln!("  FOUND at node {} as Con", i);
-            }
-            CoreFrame::Var(vid) if vid.0 == target_tag => {
-                eprintln!("  FOUND at node {} as Var", i);
+            CoreFrame::Con { tag, .. } => {
+                if table.get(*tag).is_none() {
+                    unresolved_cons.push((i, *tag));
+                }
             }
             _ => {}
         }
     }
+
+    assert!(
+        unresolved_alts.is_empty() && unresolved_cons.is_empty(),
+        "cross-module DataCon tag mismatch regression: \
+         unresolved DataAlt ids in Case nodes {:?}; \
+         unresolved Con tags {:?}; \
+         table contains {} entries",
+        unresolved_alts,
+        unresolved_cons,
+        table.len(),
+    );
 }
 
 /// Test that cross-module effect actually runs without CASE TRAP.

--- a/tidepool-runtime/tests/multi_module_datacon.rs
+++ b/tidepool-runtime/tests/multi_module_datacon.rs
@@ -108,6 +108,109 @@ fn test_cross_module_datacon_table_consistency() {
     );
 }
 
+/// Returns true if the table holds a DataCon whose name is exactly
+/// `"UnsafeRefl"` — the constructor pattern that the unsafeEqualityProof
+/// elision (Translate.hs `isUnsafeEqualityCase`) targets.
+fn table_has_unsafe_refl(table: &tidepool_repr::DataConTable) -> bool {
+    table.iter().any(|dc| dc.name == "UnsafeRefl")
+}
+
+/// `case unsafeEqualityProof of UnsafeRefl -> body` must be elided during
+/// translation, regardless of how GHC wraps the scrutinee (bare `Var`, type
+/// applications, or `stripTicksAndCasts`-stripped `Cast`/`Tick`).
+///
+/// We verify this structurally: after translation, **no surviving `Case`
+/// node may have an alt whose `DataAlt` resolves to a `DataCon` named
+/// `"UnsafeRefl"`**. Any such Case means the elision missed the shape GHC
+/// produced and the runtime would CASE-trap on the unmatchable tag.
+///
+/// The fixture exercises layered `Member` constraints across three modules,
+/// which is the GHC pattern most likely to introduce coercion wrappers
+/// around `unsafeEqualityProof` after cross-module inlining.
+#[test]
+fn test_unsafe_refl_case_is_always_elided() {
+    let effect_dir = TempDir::new().expect("failed to create temp dir");
+
+    // Two effects defined in separate modules so cross-module inlining
+    // exercises the Member constraint resolution path that produces
+    // `case unsafeEqualityProof of UnsafeRefl -> ...`.
+    let foo_src = r#"{-# LANGUAGE GADTs, DataKinds, TypeOperators, FlexibleContexts #-}
+module FooEffect where
+import Control.Monad.Freer (Eff, Member, send)
+data Foo a where Ping :: Foo ()
+sendPing :: Member Foo effs => Eff effs ()
+sendPing = send Ping
+"#;
+    let bar_src = r#"{-# LANGUAGE GADTs, DataKinds, TypeOperators, FlexibleContexts #-}
+module BarEffect where
+import Control.Monad.Freer (Eff, Member, send)
+data Bar a where Pong :: Bar ()
+sendPong :: Member Bar effs => Eff effs ()
+sendPong = send Pong
+"#;
+    std::fs::write(effect_dir.path().join("FooEffect.hs"), foo_src)
+        .expect("failed to write FooEffect.hs");
+    std::fs::write(effect_dir.path().join("BarEffect.hs"), bar_src)
+        .expect("failed to write BarEffect.hs");
+
+    // Layered Member constraints + interleaved sends across both effects.
+    let main_src = r#"{-# LANGUAGE DataKinds, TypeOperators, FlexibleContexts #-}
+module Layered where
+import Control.Monad.Freer (Eff)
+import qualified FooEffect as F
+import qualified BarEffect as B
+agent :: Eff '[F.Foo, B.Bar] ()
+agent = do
+  F.sendPing
+  B.sendPong
+  F.sendPing
+"#;
+
+    let pp = prelude_path();
+    let include: Vec<&Path> = vec![pp.as_path(), effect_dir.path()];
+    let (expr, table, _warnings) =
+        compile_haskell(main_src, "agent", &include).expect("compilation failed");
+
+    use tidepool_repr::frame::CoreFrame;
+    use tidepool_repr::types::AltCon;
+
+    // Sanity: the fixture must actually be exercising the path. If GHC
+    // optimized UnsafeRefl out of existence entirely (no DataCon with that
+    // name in the table), the structural test below would trivially pass
+    // and silently lose coverage. Skip cleanly in that case so the test
+    // doesn't pretend to verify what it can't.
+    if !table_has_unsafe_refl(&table) {
+        eprintln!(
+            "fixture did not produce any UnsafeRefl DataCon in the table — \
+             unsafeEqualityProof elision path was not exercised; skipping"
+        );
+        return;
+    }
+
+    let mut surviving = Vec::new();
+    for (i, node) in expr.nodes.iter().enumerate() {
+        if let CoreFrame::Case { alts, .. } = node {
+            for alt in alts {
+                if let AltCon::DataAlt(id) = alt.con {
+                    if let Some(dc) = table.get(id) {
+                        if dc.name == "UnsafeRefl" {
+                            surviving.push((i, id));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        surviving.is_empty(),
+        "Translate.hs failed to elide a `case unsafeEqualityProof of UnsafeRefl -> _` \
+         pattern -- GHC may now wrap the scrutinee in a shape that \
+         isUnsafeEqualityCase doesn't recognize. Surviving Case nodes: {:?}",
+        surviving,
+    );
+}
+
 /// Test that cross-module effect actually runs without CASE TRAP.
 #[test]
 fn test_cross_module_effect_runs() {

--- a/tidepool-runtime/tests/nested_cancellation.rs
+++ b/tidepool-runtime/tests/nested_cancellation.rs
@@ -1,0 +1,133 @@
+//! External cancellation observed *between* effect handler invocations.
+//!
+//! The unit-level external_cancellation suite covers cancelling a top-level
+//! tail-recursive tickLoop with no effects. This test covers the more realistic
+//! shape: a Haskell program that yields effect requests in a tickLoop, with the
+//! cancellation flag flipped from inside an effect handler. The JIT must
+//! observe the flag at the next safepoint after `machine.resume()` returns
+//! from handling the request, surfacing `YieldError::Cancelled` through the
+//! same error path as a top-level cancel.
+
+mod common;
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tidepool_bridge_derive::FromCore;
+use tidepool_codegen::jit_machine::{CancelHandle, JitEffectMachine, JitError};
+use tidepool_codegen::yield_type::YieldError;
+use tidepool_effect::{EffectContext, EffectError, EffectHandler};
+use tidepool_eval::value::Value;
+use tidepool_runtime::compile_haskell;
+
+#[derive(FromCore)]
+enum TickReq {
+    #[core(name = "Tick")]
+    Tick,
+}
+
+/// Counts handler invocations and flips the JIT's cancel flag on the
+/// `cancel_at`'th call. The handler always responds normally with `()` —
+/// cancellation is a side channel observed by the JIT, not a return value.
+/// `count` is an Arc so the test can read the final value after the
+/// handler is moved into the hlist.
+struct CancellingHandler {
+    count: Arc<AtomicUsize>,
+    cancel_at: usize,
+    handle: CancelHandle,
+}
+
+impl EffectHandler for CancellingHandler {
+    type Request = TickReq;
+    fn handle(&mut self, req: TickReq, cx: &EffectContext) -> Result<Value, EffectError> {
+        let n = self.count.fetch_add(1, Ordering::SeqCst) + 1;
+        if n == self.cancel_at {
+            self.handle.cancel();
+        }
+        match req {
+            TickReq::Tick => cx.respond(()),
+        }
+    }
+}
+
+// Concrete effect list (matches the cross-module fixture style) and a
+// recursive loop. The polymorphic `Member TickEff effs => ...` form
+// can fail to JIT-elaborate in this harness; the concrete `'[TickEff]`
+// alias is the working pattern we know.
+const LOOP_SOURCE: &str = r#"{-# LANGUAGE GADTs, DataKinds, TypeOperators, FlexibleContexts #-}
+module TickLoop where
+import Control.Monad.Freer (Eff, send)
+data TickEff a where Tick :: TickEff ()
+tickLoop :: Eff '[TickEff] ()
+tickLoop = do
+  send Tick
+  tickLoop
+"#;
+
+#[test]
+fn cancel_from_inside_effect_handler_unwinds() {
+    let pp = common::prelude_path();
+    let include: Vec<&Path> = vec![pp.as_path()];
+
+    let (expr, mut table, _warnings) =
+        compile_haskell(LOOP_SOURCE, "tickLoop", &include).expect("compile tickLoop fixture");
+    table.populate_siblings_from_expr(&expr);
+
+    let mut machine =
+        JitEffectMachine::compile(&expr, &table, 1 << 20).expect("compile JIT machine");
+    let handle = machine.cancel_handle();
+    assert!(!handle.is_cancelled());
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let handler = CancellingHandler {
+        count: count.clone(),
+        cancel_at: 5,
+        handle: handle.clone(),
+    };
+    let mut handlers = frunk::hlist![handler];
+
+    let result = machine.run(&table, &mut handlers, &());
+    let calls = count.load(Ordering::SeqCst);
+
+    // The handler reached the cancel point...
+    assert!(
+        calls >= 5,
+        "handler must have reached the cancel point; got count={} (result was {:?})",
+        calls,
+        result,
+    );
+
+    // ...and the dispatch loop's cancel safepoint must observe it
+    // *promptly* (next iteration), not after thousands of additional
+    // yields. The exact bound is loose to allow for the cancel firing on
+    // call N where N >= cancel_at; we just guard against the regression
+    // where cancel observation requires JIT-side gc_trigger or trampoline
+    // safepoints (which freer-simple effect loops don't reliably hit).
+    const PROMPT_CANCEL_LIMIT: usize = 50;
+    assert!(
+        calls < PROMPT_CANCEL_LIMIT,
+        "cancel was not observed promptly: handler ran {} times after cancel was set on call 5 \
+         (limit {} additional calls); the dispatch-loop safepoint may have regressed",
+        calls,
+        PROMPT_CANCEL_LIMIT,
+    );
+
+    match result {
+        Err(JitError::Yield(YieldError::Cancelled)) => {}
+        Err(other) => panic!(
+            "expected JitError::Yield(YieldError::Cancelled) after handler-driven cancel, \
+             got {:?} (handler ran {} times)",
+            other, calls
+        ),
+        Ok(v) => panic!(
+            "expected the tickLoop to be cancelled, got Ok({:?}) after {} handler calls",
+            v, calls
+        ),
+    }
+
+    assert!(
+        handle.is_cancelled(),
+        "the shared CancelHandle must still report cancelled after run() returns"
+    );
+}


### PR DESCRIPTION
Stacked follow-up to #272. Each commit is a focused, independently-reviewable change.

## Tests added

1. **Assertify multi-module DataCon test** — the original `test_cross_module_inspect_tags` was an eprintln debug fixture that asserted nothing. Replaced with a structural check that every `DataAlt` id and `Con` tag in the translated tree resolves in the produced `DataConTable`.
2. **PhantomData derive round-trip** — 5 cases (enum + struct, phantom-only + mixed). Phantom fields wrap a `NoBridgeImpl` marker type so the file failing to compile would catch any regression where the trait bounds leak through `PhantomData`.
3. **UnsafeRefl Case elision** — layered-GADT fixture asserting no surviving `Case` node has an alt resolving to a `DataCon` named `"UnsafeRefl"`. Catches regressions where GHC starts wrapping `unsafeEqualityProof` in a coercion shape that `isUnsafeEqualityCase` doesn't recognize.
4. **Boxed Union-tag explicit fixture** — hand-built CoreExpr that produces `Con(W#, [Lit(Word, n)])` for the Union position. Pins the cross-module boxing contract independent of GHC's optimizer.
5. **Nested cancellation** — handler-driven cancel through the new dispatch-loop safepoint (see below).

## Feature

**Cancel safepoint at effect-dispatch boundary.** The existing JIT-internal safepoints (gc_trigger heap check, trampoline_resolve) catch external cancellation only when the running Haskell allocates heavily or makes raw tail calls. Programs structured as freer-simple effect loops (send Eff >> recurse via continuations) hit neither path reliably: a handler-driven cancel could be set on call N and never observed, with the program either running to completion or eventually failing with an unrelated `NullPointer`.

This adds a check at the top of every effect-dispatch loop iteration in `JitEffectMachine::run`: after `handlers.dispatch` returns and before `machine.resume()` re-enters JIT, load the cancel flag and break with `Yield::Cancelled` if set. Cost is one Relaxed atomic load per effect yield (negligible). Strong guarantee for the realistic "watchdog handler flips the flag" scenario.

The new `nested_cancellation` test verifies handler call N=5 leads to prompt unwind within at most 50 additional calls. Without this safepoint the test runs ~10k extra iterations before failing with `NullPointer`.

## Hardening

**`const_assert POISON_BUF_SIZE >= worst-case Con write`.** The poison buffer size was tied to `MAX_FIELDS` only by a runtime test. Promote `MAX_FIELDS` to `pub(crate)` and add a `const _: () = assert!(...)` so a future bump fails to build rather than regressing into the heap-corruption symptom #272's `POISON_BUF_SIZE` enlargement originally fixed.

## Cleanup

- Drop unused `_typeEvidence` binding in the `unsafeEqualityProof` Case branch.

## Docs

- README "Cancelling runaway programs" section now enumerates the three safepoints in priority order (trampoline, effect-dispatch, gc_trigger) and explicitly calls out the pure-allocator-only edge case.
- `gc_trigger` doc-comment clarified: best-effort observation here, prompt unwind elsewhere.
- Both cross-reference #273 (the deferred prompt-cancel issue for pure non-tail-call allocator loops).

## Verification

- `cargo test --workspace` (in `nix develop`) — all green.
- New tests pass; existing tests unchanged.

## Test plan

- [x] `cargo test -p tidepool-runtime --test multi_module_datacon`
- [x] `cargo test -p tidepool-runtime --test nested_cancellation`
- [x] `cargo test -p tidepool-bridge-derive --test phantom_data`
- [x] `cargo test -p tidepool-codegen --test effect_machine`
- [x] `cargo test -p tidepool-codegen --test external_cancellation` (regression check)
- [x] `cargo test --workspace`

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)