### PR TITLE
feat(runtime): add cross-mode test harness

### DIFF
--- a/tidepool-runtime/tests/cross_mode_harness/mod.rs
+++ b/tidepool-runtime/tests/cross_mode_harness/mod.rs
@@ -40,15 +40,9 @@ pub fn prelude_path() -> PathBuf {
     manifest.parent().unwrap().join("haskell").join("lib")
 }
 
-/// Compiles the fixture in both single and split modes.
-pub fn compile_cross_mode(fixture: &CrossModeFixture) -> CrossModeArtifacts {
-    let pp = prelude_path();
-
-    // 1. Compile single mode
-    let (single_expr, single_table, _) = compile_haskell(&fixture.single, fixture.target, &[&pp])
-        .expect("failed to compile single-mode fixture");
-
-    // 2. Compile split mode
+/// Stages the split fixture into a temporary directory.
+/// Returns the main module source and the TempDir.
+fn stage_split_fixture(fixture: &CrossModeFixture) -> (String, TempDir) {
     let temp_dir = TempDir::new().expect("failed to create temp dir for split-mode");
     let mut split_entries = fixture.split.iter().peekable();
     let mut last_source = String::new();
@@ -59,7 +53,11 @@ pub fn compile_cross_mode(fixture: &CrossModeFixture) -> CrossModeArtifacts {
             last_source = source.clone();
         } else {
             // Other entries are dependencies to be written to the temp dir
-            std::fs::write(temp_dir.path().join(filename), source)
+            let path = temp_dir.path().join(filename);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("failed to create parent directories for dependency");
+            }
+            std::fs::write(path, source)
                 .expect("failed to write dependency file to temp dir");
         }
     }
@@ -68,6 +66,19 @@ pub fn compile_cross_mode(fixture: &CrossModeFixture) -> CrossModeArtifacts {
         panic!("fixture.split must contain at least one entry (the main module)");
     }
 
+    (last_source, temp_dir)
+}
+
+/// Compiles the fixture in both single and split modes.
+pub fn compile_cross_mode(fixture: &CrossModeFixture) -> CrossModeArtifacts {
+    let pp = prelude_path();
+
+    // 1. Compile single mode
+    let (single_expr, single_table, _) = compile_haskell(&fixture.single, fixture.target, &[&pp])
+        .expect("failed to compile single-mode fixture");
+
+    // 2. Compile split mode
+    let (last_source, temp_dir) = stage_split_fixture(fixture);
     let include = [pp.as_path(), temp_dir.path()];
     let (split_expr, split_table, _) = compile_haskell(&last_source, fixture.target, &include)
         .expect("failed to compile split-mode fixture");
@@ -87,7 +98,7 @@ pub fn compile_cross_mode(fixture: &CrossModeFixture) -> CrossModeArtifacts {
 /// - Same tree shape (lockstep iteration over CoreFrames).
 /// - Literals match exactly.
 /// - DataConIds match by name + rep_arity lookup in their respective tables.
-/// - VarIds are tolerated to differ (they are variants of hashed names).
+/// - VarIds and JoinIds match modulo alpha-renaming.
 pub fn assert_cross_mode_structurally_equivalent(fixture: &CrossModeFixture) {
     let artifacts = compile_cross_mode(fixture);
     structural_eq::assert_equivalent(&artifacts);
@@ -102,19 +113,7 @@ pub fn assert_cross_mode_pure_equivalent(fixture: &CrossModeFixture) {
         .expect("failed to run single-mode fixture");
 
     // Run split
-    let temp_dir = TempDir::new().expect("failed to create temp dir for split-mode");
-    let mut split_entries = fixture.split.iter().peekable();
-    let mut last_source = String::new();
-
-    while let Some((filename, source)) = split_entries.next() {
-        if split_entries.peek().is_none() {
-            last_source = source.clone();
-        } else {
-            std::fs::write(temp_dir.path().join(filename), source)
-                .expect("failed to write dependency file to temp dir");
-        }
-    }
-
+    let (last_source, temp_dir) = stage_split_fixture(fixture);
     let include = [pp.as_path(), temp_dir.path()];
     let res_split = tidepool_runtime::compile_and_run_pure(&last_source, fixture.target, &include)
         .expect("failed to run split-mode fixture");
@@ -126,13 +125,12 @@ pub fn assert_cross_mode_pure_equivalent(fixture: &CrossModeFixture) {
         res_split.table(),
     );
 }
-
 /// Asserts that the fixture's single and split modes produce equivalent runtime values.
 ///
 /// Runs both modes through the JIT and compares the resulting `Value`s recursively.
 /// Constructor values are compared by name+arity.
-#[allow(dead_code)]
 pub fn assert_cross_mode_runtime_equivalent<U, H1, H2>(
+
     fixture: &CrossModeFixture,
     mk_single_handlers: impl FnOnce() -> H1,
     mk_split_handlers: impl FnOnce() -> H2,
@@ -149,19 +147,7 @@ pub fn assert_cross_mode_runtime_equivalent<U, H1, H2>(
         .expect("failed to run single-mode fixture");
 
     // Run split
-    let temp_dir = TempDir::new().expect("failed to create temp dir for split-mode");
-    let mut split_entries = fixture.split.iter().peekable();
-    let mut last_source = String::new();
-
-    while let Some((filename, source)) = split_entries.next() {
-        if split_entries.peek().is_none() {
-            last_source = source.clone();
-        } else {
-            std::fs::write(temp_dir.path().join(filename), source)
-                .expect("failed to write dependency file to temp dir");
-        }
-    }
-
+    let (last_source, temp_dir) = stage_split_fixture(fixture);
     let include = [pp.as_path(), temp_dir.path()];
     let mut h2 = mk_split_handlers();
     let res_split = tidepool_runtime::compile_and_run(&last_source, fixture.target, &include, &mut h2, user)

--- a/tidepool-runtime/tests/cross_mode_harness/mod.rs
+++ b/tidepool-runtime/tests/cross_mode_harness/mod.rs
@@ -1,0 +1,176 @@
+//! Harness for asserting equivalence between single-module and multi-module Haskell compilation.
+//!
+//! This catches bugs where GHC's post-optimizer Core shape diverges when bindings are
+//! split across module boundaries (e.g. PR #272). Downstream tests use this to ensure
+//! that any regression in cross-module translation is caught structurally.
+
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use tidepool_runtime::{compile_haskell, DispatchEffect};
+use tidepool_repr::{CoreExpr, DataConTable};
+
+pub mod structural_eq;
+
+/// A Haskell program expressed in two equivalent ways.
+pub struct CrossModeFixture {
+    /// Inlined source where all logic lives in one module.
+    pub single: String,
+    /// Split source where logic is divided across files.
+    /// The `Vec` contains `(filename, source)` pairs.
+    /// The LAST entry is the main module to be compiled.
+    pub split: Vec<(String, String)>,
+    /// The binder name to compile (e.g. "agent").
+    pub target: &'static str,
+}
+
+/// Artifacts from both compilation modes.
+pub struct CrossModeArtifacts {
+    pub single_expr: CoreExpr,
+    pub single_table: DataConTable,
+    pub split_expr: CoreExpr,
+    pub split_table: DataConTable,
+    /// Keep the temp directory alive so include paths remain valid if needed
+    /// (though CoreExpr/DataConTable are owned and don't need it).
+    pub _temp_dir: Option<TempDir>,
+}
+
+/// Helper to get the path to the Haskell prelude library.
+pub fn prelude_path() -> PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().unwrap().join("haskell").join("lib")
+}
+
+/// Compiles the fixture in both single and split modes.
+pub fn compile_cross_mode(fixture: &CrossModeFixture) -> CrossModeArtifacts {
+    let pp = prelude_path();
+
+    // 1. Compile single mode
+    let (single_expr, single_table, _) = compile_haskell(&fixture.single, fixture.target, &[&pp])
+        .expect("failed to compile single-mode fixture");
+
+    // 2. Compile split mode
+    let temp_dir = TempDir::new().expect("failed to create temp dir for split-mode");
+    let mut split_entries = fixture.split.iter().peekable();
+    let mut last_source = String::new();
+
+    while let Some((filename, source)) = split_entries.next() {
+        if split_entries.peek().is_none() {
+            // Last entry is the main module source
+            last_source = source.clone();
+        } else {
+            // Other entries are dependencies to be written to the temp dir
+            std::fs::write(temp_dir.path().join(filename), source)
+                .expect("failed to write dependency file to temp dir");
+        }
+    }
+
+    if last_source.is_empty() {
+        panic!("fixture.split must contain at least one entry (the main module)");
+    }
+
+    let include = [pp.as_path(), temp_dir.path()];
+    let (split_expr, split_table, _) = compile_haskell(&last_source, fixture.target, &include)
+        .expect("failed to compile split-mode fixture");
+
+    CrossModeArtifacts {
+        single_expr,
+        single_table,
+        split_expr,
+        split_table,
+        _temp_dir: Some(temp_dir),
+    }
+}
+
+/// Asserts that the fixture's single and split modes produce structurally equivalent Core trees.
+///
+/// 'Structural equivalence' means:
+/// - Same tree shape (lockstep iteration over CoreFrames).
+/// - Literals match exactly.
+/// - DataConIds match by name + rep_arity lookup in their respective tables.
+/// - VarIds are tolerated to differ (they are variants of hashed names).
+pub fn assert_cross_mode_structurally_equivalent(fixture: &CrossModeFixture) {
+    let artifacts = compile_cross_mode(fixture);
+    structural_eq::assert_equivalent(&artifacts);
+}
+
+/// Asserts that the fixture's single and split modes produce equivalent runtime values for pure programs.
+pub fn assert_cross_mode_pure_equivalent(fixture: &CrossModeFixture) {
+    let pp = prelude_path();
+
+    // Run single
+    let res_single = tidepool_runtime::compile_and_run_pure(&fixture.single, fixture.target, &[&pp])
+        .expect("failed to run single-mode fixture");
+
+    // Run split
+    let temp_dir = TempDir::new().expect("failed to create temp dir for split-mode");
+    let mut split_entries = fixture.split.iter().peekable();
+    let mut last_source = String::new();
+
+    while let Some((filename, source)) = split_entries.next() {
+        if split_entries.peek().is_none() {
+            last_source = source.clone();
+        } else {
+            std::fs::write(temp_dir.path().join(filename), source)
+                .expect("failed to write dependency file to temp dir");
+        }
+    }
+
+    let include = [pp.as_path(), temp_dir.path()];
+    let res_split = tidepool_runtime::compile_and_run_pure(&last_source, fixture.target, &include)
+        .expect("failed to run split-mode fixture");
+
+    structural_eq::assert_value_equivalent(
+        res_single.value(),
+        res_single.table(),
+        res_split.value(),
+        res_split.table(),
+    );
+}
+
+/// Asserts that the fixture's single and split modes produce equivalent runtime values.
+///
+/// Runs both modes through the JIT and compares the resulting `Value`s recursively.
+/// Constructor values are compared by name+arity.
+#[allow(dead_code)]
+pub fn assert_cross_mode_runtime_equivalent<U, H1, H2>(
+    fixture: &CrossModeFixture,
+    mk_single_handlers: impl FnOnce() -> H1,
+    mk_split_handlers: impl FnOnce() -> H2,
+    user: &U,
+) where
+    H1: DispatchEffect<U>,
+    H2: DispatchEffect<U>,
+{
+    let pp = prelude_path();
+
+    // Run single
+    let mut h1 = mk_single_handlers();
+    let res_single = tidepool_runtime::compile_and_run(&fixture.single, fixture.target, &[&pp], &mut h1, user)
+        .expect("failed to run single-mode fixture");
+
+    // Run split
+    let temp_dir = TempDir::new().expect("failed to create temp dir for split-mode");
+    let mut split_entries = fixture.split.iter().peekable();
+    let mut last_source = String::new();
+
+    while let Some((filename, source)) = split_entries.next() {
+        if split_entries.peek().is_none() {
+            last_source = source.clone();
+        } else {
+            std::fs::write(temp_dir.path().join(filename), source)
+                .expect("failed to write dependency file to temp dir");
+        }
+    }
+
+    let include = [pp.as_path(), temp_dir.path()];
+    let mut h2 = mk_split_handlers();
+    let res_split = tidepool_runtime::compile_and_run(&last_source, fixture.target, &include, &mut h2, user)
+        .expect("failed to run split-mode fixture");
+
+    structural_eq::assert_value_equivalent(
+        res_single.value(),
+        res_single.table(),
+        res_split.value(),
+        res_split.table(),
+    );
+}

--- a/tidepool-runtime/tests/cross_mode_harness/structural_eq.rs
+++ b/tidepool-runtime/tests/cross_mode_harness/structural_eq.rs
@@ -1,0 +1,271 @@
+use tidepool_repr::frame::CoreFrame;
+use tidepool_repr::types::{AltCon, DataConId};
+use tidepool_repr::DataConTable;
+use tidepool_eval::value::Value;
+use super::CrossModeArtifacts;
+
+/// Asserts that two Core expression trees are structurally equivalent.
+pub fn assert_equivalent(art: &CrossModeArtifacts) {
+    let single = &art.single_expr.nodes;
+    let split = &art.split_expr.nodes;
+
+    if single.len() != split.len() {
+        panic!(
+            "cross-mode divergence: tree size mismatch (single={}, split={})",
+            single.len(),
+            split.len()
+        );
+    }
+
+    assert_table_compatible(&art.single_table, &art.split_table);
+
+    for (i, (s_node, p_node)) in single.iter().zip(split.iter()).enumerate() {
+        match (s_node, p_node) {
+            (CoreFrame::Var(_), CoreFrame::Var(_)) => {} // Tolerate any VarId
+            (CoreFrame::Lit(s_lit), CoreFrame::Lit(p_lit)) => {
+                if s_lit != p_lit {
+                    panic!("cross-mode divergence at node {}: literals differ (single={:?}, split={:?})", i, s_lit, p_lit);
+                }
+            }
+            (CoreFrame::App { fun: sf, arg: sa }, CoreFrame::App { fun: pf, arg: pa }) => {
+                if sf != pf || sa != pa {
+                    panic!("cross-mode divergence at node {}: App indices differ", i);
+                }
+            }
+            (CoreFrame::Lam { binder: _, body: sb }, CoreFrame::Lam { binder: _, body: pb }) => {
+                if sb != pb {
+                    panic!("cross-mode divergence at node {}: Lam body indices differ", i);
+                }
+            }
+            (CoreFrame::LetNonRec { binder: _, rhs: sr, body: sb }, CoreFrame::LetNonRec { binder: _, rhs: pr, body: pb }) => {
+                if sr != pr || sb != pb {
+                    panic!("cross-mode divergence at node {}: LetNonRec indices differ", i);
+                }
+            }
+            (CoreFrame::LetRec { bindings: sb, body: s_body }, CoreFrame::LetRec { bindings: pb, body: p_body }) => {
+                if sb.len() != pb.len() {
+                    panic!("cross-mode divergence at node {}: LetRec binding count mismatch", i);
+                }
+                for (j, ((_, sr), (_, pr))) in sb.iter().zip(pb.iter()).enumerate() {
+                    if sr != pr {
+                        panic!("cross-mode divergence at node {}: LetRec binding {} rhs index mismatch", i, j);
+                    }
+                }
+                if s_body != p_body {
+                    panic!("cross-mode divergence at node {}: LetRec body index mismatch", i);
+                }
+            }
+            (CoreFrame::Case { scrutinee: ss, binder: _, alts: sa }, CoreFrame::Case { scrutinee: ps, binder: _, alts: pa }) => {
+                if ss != ps {
+                    panic!("cross-mode divergence at node {}: Case scrutinee index mismatch", i);
+                }
+                if sa.len() != pa.len() {
+                    panic!("cross-mode divergence at node {}: Case alt count mismatch", i);
+                }
+                for (j, (s_alt, p_alt)) in sa.iter().zip(pa.iter()).enumerate() {
+                    compare_alt_con(i, j, &s_alt.con, &art.single_table, &p_alt.con, &art.split_table);
+                    if s_alt.binders.len() != p_alt.binders.len() {
+                        panic!("cross-mode divergence at node {} alt {}: binder count mismatch", i, j);
+                    }
+                    if s_alt.body != p_alt.body {
+                        panic!("cross-mode divergence at node {} alt {}: body index mismatch", i, j);
+                    }
+                }
+            }
+            (CoreFrame::Con { tag: st, fields: sf }, CoreFrame::Con { tag: pt, fields: pf }) => {
+                compare_datacon_ids(i, *st, &art.single_table, *pt, &art.split_table);
+                if sf.len() != pf.len() {
+                    panic!("cross-mode divergence at node {}: Con field count mismatch", i);
+                }
+                if sf != pf {
+                    panic!("cross-mode divergence at node {}: Con field indices differ", i);
+                }
+            }
+            (CoreFrame::Join { label: _, params: sp, rhs: sr, body: sb }, CoreFrame::Join { label: _, params: pp, rhs: pr, body: pb }) => {
+                if sp.len() != pp.len() {
+                    panic!("cross-mode divergence at node {}: Join param count mismatch", i);
+                }
+                if sr != pr || sb != pb {
+                    panic!("cross-mode divergence at node {}: Join indices differ", i);
+                }
+            }
+            (CoreFrame::Jump { label: _, args: sa }, CoreFrame::Jump { label: _, args: pa }) => {
+                if sa.len() != pa.len() {
+                    panic!("cross-mode divergence at node {}: Jump arg count mismatch", i);
+                }
+                if sa != pa {
+                    panic!("cross-mode divergence at node {}: Jump arg indices differ", i);
+                }
+            }
+            (CoreFrame::PrimOp { op: so, args: sa }, CoreFrame::PrimOp { op: po, args: pa }) => {
+                if so != po {
+                    panic!("cross-mode divergence at node {}: PrimOp kind mismatch (single={:?}, split={:?})", i, so, po);
+                }
+                if sa.len() != pa.len() {
+                    panic!("cross-mode divergence at node {}: PrimOp arg count mismatch", i);
+                }
+                if sa != pa {
+                    panic!("cross-mode divergence at node {}: PrimOp arg indices differ", i);
+                }
+            }
+            (s, p) => {
+                panic!(
+                    "cross-mode divergence at node {}: variant mismatch (single={:?}, split={:?})",
+                    i, core_kind(s), core_kind(p)
+                );
+            }
+        }
+    }
+}
+
+fn core_kind<A>(frame: &CoreFrame<A>) -> &'static str {
+    match frame {
+        CoreFrame::Var(_) => "Var",
+        CoreFrame::Lit(_) => "Lit",
+        CoreFrame::App { .. } => "App",
+        CoreFrame::Lam { .. } => "Lam",
+        CoreFrame::LetNonRec { .. } => "LetNonRec",
+        CoreFrame::LetRec { .. } => "LetRec",
+        CoreFrame::Case { .. } => "Case",
+        CoreFrame::Con { .. } => "Con",
+        CoreFrame::Join { .. } => "Join",
+        CoreFrame::Jump { .. } => "Jump",
+        CoreFrame::PrimOp { .. } => "PrimOp",
+    }
+}
+
+fn compare_alt_con(node_idx: usize, alt_idx: usize, s_con: &AltCon, s_table: &DataConTable, p_con: &AltCon, p_table: &DataConTable) {
+    match (s_con, p_con) {
+        (AltCon::Default, AltCon::Default) => {}
+        (AltCon::LitAlt(sl), AltCon::LitAlt(pl)) => {
+            if sl != pl {
+                panic!("cross-mode divergence at node {} alt {}: literals differ ({:?} vs {:?})", node_idx, alt_idx, sl, pl);
+            }
+        }
+        (AltCon::DataAlt(si), AltCon::DataAlt(pi)) => {
+            compare_datacon_ids_detailed(format!("node {} alt {}", node_idx, alt_idx), *si, s_table, *pi, p_table);
+        }
+        (s, p) => {
+            panic!("cross-mode divergence at node {} alt {}: AltCon variant mismatch (single={:?}, split={:?})", node_idx, alt_idx, s, p);
+        }
+    }
+}
+
+fn compare_datacon_ids(node_idx: usize, s_id: DataConId, s_table: &DataConTable, p_id: DataConId, p_table: &DataConTable) {
+    compare_datacon_ids_detailed(format!("node {}", node_idx), s_id, s_table, p_id, p_table);
+}
+
+fn compare_datacon_ids_detailed(loc: String, s_id: DataConId, s_table: &DataConTable, p_id: DataConId, p_table: &DataConTable) {
+    let s_info = s_table.get(s_id).map(|dc| (dc.name.as_str(), dc.rep_arity));
+    let p_info = p_table.get(p_id).map(|dc| (dc.name.as_str(), dc.rep_arity));
+
+    if s_info != p_info {
+        panic!(
+            "cross-mode divergence at {}: DataCon mismatch. \
+             single={:?} (id={:?}), split={:?} (id={:?})",
+            loc, s_info, s_id, p_info, p_id
+        );
+    }
+}
+
+/// Asserts that all constructors in the single-mode table are present and compatible in the split-mode table.
+pub fn assert_table_compatible(single_table: &DataConTable, split_table: &DataConTable) {
+    for s_dc in single_table.iter() {
+        let p_dc_id = split_table.get_by_name_arity(&s_dc.name, s_dc.rep_arity)
+            .unwrap_or_else(|| panic!("split table missing DataCon '{}' with arity {}", s_dc.name, s_dc.rep_arity));
+        let p_dc = split_table.get(p_dc_id).unwrap();
+        if s_dc.field_bangs != p_dc.field_bangs {
+            panic!("DataCon '{}' has different field_bangs (single={:?}, split={:?})", s_dc.name, s_dc.field_bangs, p_dc.field_bangs);
+        }
+    }
+    // And vice versa
+    for p_dc in split_table.iter() {
+        if single_table.get_by_name_arity(&p_dc.name, p_dc.rep_arity).is_none() {
+             // It's technically okay if split has MORE datacons (e.g. from extra modules), 
+             // as long as the ones used in the expression tree match.
+        }
+    }
+}
+
+/// Asserts that two runtime values are equivalent.
+pub fn assert_value_equivalent(s_val: &Value, s_table: &DataConTable, p_val: &Value, p_table: &DataConTable) {
+    compare_values(Vec::new(), s_val, s_table, p_val, p_table);
+}
+
+fn compare_values(path: Vec<String>, s_val: &Value, s_table: &DataConTable, p_val: &Value, p_table: &DataConTable) {
+    match (s_val, p_val) {
+        (Value::Lit(sl), Value::Lit(pl)) => {
+            if sl != pl {
+                panic!("value divergence at {}: literals differ ({:?} vs {:?})", format_path(&path), sl, pl);
+            }
+        }
+        (Value::Con(si, sf), Value::Con(pi, pf)) => {
+            let s_dc = s_table.get(*si).expect("single_table missing Con ID");
+            let p_dc = p_table.get(*pi).expect("split_table missing Con ID");
+            if s_dc.name != p_dc.name || s_dc.rep_arity != p_dc.rep_arity {
+                panic!("value divergence at {}: constructor mismatch (single={} arity {}, split={} arity {})",
+                    format_path(&path), s_dc.name, s_dc.rep_arity, p_dc.name, p_dc.rep_arity);
+            }
+            if sf.len() != pf.len() {
+                panic!("value divergence at {}: field count mismatch (single={}, split={})",
+                    format_path(&path), sf.len(), pf.len());
+            }
+            for (i, (sv, pv)) in sf.iter().zip(pf.iter()).enumerate() {
+                let mut new_path = path.clone();
+                new_path.push(format!("{}.fields[{}]", s_dc.name, i));
+                compare_values(new_path, sv, s_table, pv, p_table);
+            }
+        }
+        (Value::Closure(..), Value::Closure(..)) => {} // Closures are opaque
+        (Value::ThunkRef(_), Value::ThunkRef(_)) => {} // Thunks are opaque
+        (Value::JoinCont(..), Value::JoinCont(..)) => {} // Join points are opaque
+        (Value::ConFun(si, sa, sf), Value::ConFun(pi, pa, pf)) => {
+            let s_dc = s_table.get(*si).expect("single_table missing ConFun ID");
+            let p_dc = p_table.get(*pi).expect("split_table missing ConFun ID");
+            if s_dc.name != p_dc.name || *sa != *pa {
+                panic!("value divergence at {}: ConFun mismatch (single={} arity {}, split={} arity {})",
+                    format_path(&path), s_dc.name, sa, p_dc.name, pa);
+            }
+            if sf.len() != pf.len() {
+                panic!("value divergence at {}: ConFun arg count mismatch (single={}, split={})",
+                    format_path(&path), sf.len(), pf.len());
+            }
+            for (i, (sv, pv)) in sf.iter().zip(pf.iter()).enumerate() {
+                let mut new_path = path.clone();
+                new_path.push(format!("{}.partial_args[{}]", s_dc.name, i));
+                compare_values(new_path, sv, s_table, pv, p_table);
+            }
+        }
+        (Value::ByteArray(sb), Value::ByteArray(pb)) => {
+            let s_bytes = sb.lock().expect("single ByteArray poisoned");
+            let p_bytes = pb.lock().expect("split ByteArray poisoned");
+            if *s_bytes != *p_bytes {
+                panic!("value divergence at {}: ByteArray contents differ", format_path(&path));
+            }
+        }
+        (s, p) => {
+            panic!("value divergence at {}: variant mismatch (single={}, split={})",
+                format_path(&path), val_kind(s), val_kind(p));
+        }
+    }
+}
+
+fn format_path(path: &[String]) -> String {
+    if path.is_empty() {
+        "root".to_string()
+    } else {
+        path.join(".")
+    }
+}
+
+fn val_kind(v: &Value) -> &'static str {
+    match v {
+        Value::Lit(_) => "Lit",
+        Value::Con(..) => "Con",
+        Value::Closure(..) => "Closure",
+        Value::ThunkRef(_) => "ThunkRef",
+        Value::JoinCont(..) => "JoinCont",
+        Value::ConFun(..) => "ConFun",
+        Value::ByteArray(_) => "ByteArray",
+    }
+}

--- a/tidepool-runtime/tests/cross_mode_harness/structural_eq.rs
+++ b/tidepool-runtime/tests/cross_mode_harness/structural_eq.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use tidepool_repr::frame::CoreFrame;
-use tidepool_repr::types::{AltCon, DataConId};
+use tidepool_repr::types::{AltCon, DataConId, JoinId, VarId};
 use tidepool_repr::DataConTable;
 use tidepool_eval::value::Value;
 use super::CrossModeArtifacts;
@@ -19,101 +20,205 @@ pub fn assert_equivalent(art: &CrossModeArtifacts) {
 
     assert_table_compatible(&art.single_table, &art.split_table);
 
-    for (i, (s_node, p_node)) in single.iter().zip(split.iter()).enumerate() {
-        match (s_node, p_node) {
-            (CoreFrame::Var(_), CoreFrame::Var(_)) => {} // Tolerate any VarId
-            (CoreFrame::Lit(s_lit), CoreFrame::Lit(p_lit)) => {
-                if s_lit != p_lit {
-                    panic!("cross-mode divergence at node {}: literals differ (single={:?}, split={:?})", i, s_lit, p_lit);
+    // Alpha-equivalence tracking
+    let mut var_map: HashMap<VarId, VarId> = HashMap::new();
+    let mut join_map: HashMap<JoinId, JoinId> = HashMap::new();
+
+    // Start walk from the root (last node)
+    if !single.is_empty() {
+        check_node(
+            single.len() - 1,
+            single,
+            &art.single_table,
+            split,
+            &art.split_table,
+            &mut var_map,
+            &mut join_map,
+        );
+    }
+}
+
+fn check_node(
+    idx: usize,
+    single: &[CoreFrame<usize>],
+    s_table: &DataConTable,
+    split: &[CoreFrame<usize>],
+    p_table: &DataConTable,
+    var_map: &mut HashMap<VarId, VarId>,
+    join_map: &mut HashMap<JoinId, JoinId>,
+) {
+    let s_node = &single[idx];
+    let p_node = &split[idx];
+
+    match (s_node, p_node) {
+        (CoreFrame::Var(s_v), CoreFrame::Var(p_v)) => {
+            if let Some(&expected_p) = var_map.get(s_v) {
+                if expected_p != *p_v {
+                    panic!("node {}: Var mismatch (alpha-equivalence). Expected {:?}, got {:?}", idx, expected_p, p_v);
                 }
             }
-            (CoreFrame::App { fun: sf, arg: sa }, CoreFrame::App { fun: pf, arg: pa }) => {
-                if sf != pf || sa != pa {
-                    panic!("cross-mode divergence at node {}: App indices differ", i);
+        }
+        (CoreFrame::Lit(sl), CoreFrame::Lit(pl)) => {
+            if sl != pl {
+                panic!("node {}: literals differ ({:?} vs {:?})", idx, sl, pl);
+            }
+        }
+        (CoreFrame::App { fun: sf, arg: sa }, CoreFrame::App { fun: pf, arg: pa }) => {
+            if sf != pf { panic!("node {}: App fun index mismatch ({} vs {})", idx, sf, pf); }
+            if sa != pa { panic!("node {}: App arg index mismatch ({} vs {})", idx, sa, pa); }
+            check_node(*sf, single, s_table, split, p_table, var_map, join_map);
+            check_node(*sa, single, s_table, split, p_table, var_map, join_map);
+        }
+        (CoreFrame::Lam { binder: s_v, body: s_b }, CoreFrame::Lam { binder: p_v, body: p_b }) => {
+            if s_b != p_b { panic!("node {}: Lam body index mismatch ({} vs {})", idx, s_b, p_b); }
+            let old = var_map.insert(*s_v, *p_v);
+            check_node(*s_b, single, s_table, split, p_table, var_map, join_map);
+            if let Some(o) = old {
+                var_map.insert(*s_v, o);
+            } else {
+                var_map.remove(s_v);
+            }
+        }
+        (CoreFrame::LetNonRec { binder: s_v, rhs: s_r, body: s_b }, CoreFrame::LetNonRec { binder: p_v, rhs: p_r, body: p_b }) => {
+            if s_r != p_r { panic!("node {}: LetNonRec rhs index mismatch ({} vs {})", idx, s_r, p_r); }
+            if s_b != p_b { panic!("node {}: LetNonRec body index mismatch ({} vs {})", idx, s_b, p_b); }
+            check_node(*s_r, single, s_table, split, p_table, var_map, join_map);
+            let old = var_map.insert(*s_v, *p_v);
+            check_node(*s_b, single, s_table, split, p_table, var_map, join_map);
+            if let Some(o) = old {
+                var_map.insert(*s_v, o);
+            } else {
+                var_map.remove(s_v);
+            }
+        }
+        (CoreFrame::LetRec { bindings: s_binds, body: s_body }, CoreFrame::LetRec { bindings: p_binds, body: p_body }) => {
+            if s_binds.len() != p_binds.len() {
+                panic!("node {}: LetRec binding count mismatch", idx);
+            }
+            if s_body != p_body {
+                panic!("node {}: LetRec body index mismatch ({} vs {})", idx, s_body, p_body);
+            }
+            let mut olds = Vec::new();
+            for ((s_v, s_r), (p_v, p_r)) in s_binds.iter().zip(p_binds.iter()) {
+                if s_r != p_r { panic!("node {}: LetRec binding index mismatch ({} vs {})", idx, s_r, p_r); }
+                olds.push((*s_v, var_map.insert(*s_v, *p_v)));
+            }
+            for (_, s_r) in s_binds.iter() {
+                check_node(*s_r, single, s_table, split, p_table, var_map, join_map);
+            }
+            check_node(*s_body, single, s_table, split, p_table, var_map, join_map);
+            for (s_v, old) in olds {
+                if let Some(o) = old {
+                    var_map.insert(s_v, o);
+                } else {
+                    var_map.remove(&s_v);
                 }
             }
-            (CoreFrame::Lam { binder: _, body: sb }, CoreFrame::Lam { binder: _, body: pb }) => {
-                if sb != pb {
-                    panic!("cross-mode divergence at node {}: Lam body indices differ", i);
-                }
+        }
+        (CoreFrame::Case { scrutinee: ss, binder: s_v, alts: s_alts }, CoreFrame::Case { scrutinee: ps, binder: p_v, alts: p_alts }) => {
+            if ss != ps { panic!("node {}: Case scrutinee index mismatch ({} vs {})", idx, ss, ps); }
+            check_node(*ss, single, s_table, split, p_table, var_map, join_map);
+            if s_alts.len() != p_alts.len() {
+                panic!("node {}: Case alt count mismatch", idx);
             }
-            (CoreFrame::LetNonRec { binder: _, rhs: sr, body: sb }, CoreFrame::LetNonRec { binder: _, rhs: pr, body: pb }) => {
-                if sr != pr || sb != pb {
-                    panic!("cross-mode divergence at node {}: LetNonRec indices differ", i);
+            let old = var_map.insert(*s_v, *p_v);
+            for (j, (s_alt, p_alt)) in s_alts.iter().zip(p_alts.iter()).enumerate() {
+                if s_alt.body != p_alt.body { panic!("node {} alt {}: body index mismatch ({} vs {})", idx, j, s_alt.body, p_alt.body); }
+                compare_alt_con(idx, j, &s_alt.con, s_table, &p_alt.con, p_table);
+                if s_alt.binders.len() != p_alt.binders.len() {
+                    panic!("node {} alt {}: binder count mismatch", idx, j);
                 }
-            }
-            (CoreFrame::LetRec { bindings: sb, body: s_body }, CoreFrame::LetRec { bindings: pb, body: p_body }) => {
-                if sb.len() != pb.len() {
-                    panic!("cross-mode divergence at node {}: LetRec binding count mismatch", i);
+                let mut alt_olds = Vec::new();
+                for (&sv, &pv) in s_alt.binders.iter().zip(p_alt.binders.iter()) {
+                    alt_olds.push((sv, var_map.insert(sv, pv)));
                 }
-                for (j, ((_, sr), (_, pr))) in sb.iter().zip(pb.iter()).enumerate() {
-                    if sr != pr {
-                        panic!("cross-mode divergence at node {}: LetRec binding {} rhs index mismatch", i, j);
+                check_node(s_alt.body, single, s_table, split, p_table, var_map, join_map);
+                for (sv, a_old) in alt_olds {
+                    if let Some(o) = a_old {
+                        var_map.insert(sv, o);
+                    } else {
+                        var_map.remove(&sv);
                     }
                 }
-                if s_body != p_body {
-                    panic!("cross-mode divergence at node {}: LetRec body index mismatch", i);
+            }
+            if let Some(o) = old {
+                var_map.insert(*s_v, o);
+            } else {
+                var_map.remove(s_v);
+            }
+        }
+        (CoreFrame::Con { tag: st, fields: sf }, CoreFrame::Con { tag: pt, fields: pf }) => {
+            compare_datacon_ids(idx, *st, s_table, *pt, p_table);
+            if sf.len() != pf.len() {
+                panic!("node {}: Con field count mismatch", idx);
+            }
+            for (&si, &pi) in sf.iter().zip(pf.iter()) {
+                if si != pi { panic!("node {}: Con field index mismatch ({} vs {})", idx, si, pi); }
+                check_node(si, single, s_table, split, p_table, var_map, join_map);
+            }
+        }
+        (CoreFrame::Join { label: s_l, params: s_params, rhs: s_r, body: s_b }, CoreFrame::Join { label: p_l, params: p_params, rhs: p_r, body: p_b }) => {
+            if s_r != p_r { panic!("node {}: Join rhs index mismatch ({} vs {})", idx, s_r, p_r); }
+            if s_b != p_b { panic!("node {}: Join body index mismatch ({} vs {})", idx, s_b, p_b); }
+            if s_params.len() != p_params.len() {
+                panic!("node {}: Join param count mismatch", idx);
+            }
+            let l_old = join_map.insert(*s_l, *p_l);
+            
+            // Join RHS scope
+            let mut p_olds = Vec::new();
+            for (&sv, &pv) in s_params.iter().zip(p_params.iter()) {
+                p_olds.push((sv, var_map.insert(sv, pv)));
+            }
+            check_node(*s_r, single, s_table, split, p_table, var_map, join_map);
+            for (sv, p_old) in p_olds {
+                if let Some(o) = p_old {
+                    var_map.insert(sv, o);
+                } else {
+                    var_map.remove(&sv);
                 }
             }
-            (CoreFrame::Case { scrutinee: ss, binder: _, alts: sa }, CoreFrame::Case { scrutinee: ps, binder: _, alts: pa }) => {
-                if ss != ps {
-                    panic!("cross-mode divergence at node {}: Case scrutinee index mismatch", i);
-                }
-                if sa.len() != pa.len() {
-                    panic!("cross-mode divergence at node {}: Case alt count mismatch", i);
-                }
-                for (j, (s_alt, p_alt)) in sa.iter().zip(pa.iter()).enumerate() {
-                    compare_alt_con(i, j, &s_alt.con, &art.single_table, &p_alt.con, &art.split_table);
-                    if s_alt.binders.len() != p_alt.binders.len() {
-                        panic!("cross-mode divergence at node {} alt {}: binder count mismatch", i, j);
-                    }
-                    if s_alt.body != p_alt.body {
-                        panic!("cross-mode divergence at node {} alt {}: body index mismatch", i, j);
-                    }
+
+            // Join body scope
+            check_node(*s_b, single, s_table, split, p_table, var_map, join_map);
+
+            if let Some(o) = l_old {
+                join_map.insert(*s_l, o);
+            } else {
+                join_map.remove(s_l);
+            }
+        }
+        (CoreFrame::Jump { label: s_l, args: s_args }, CoreFrame::Jump { label: p_l, args: p_args }) => {
+            if let Some(&expected_p) = join_map.get(s_l) {
+                if expected_p != *p_l {
+                    panic!("node {}: Jump label mismatch. Expected {:?}, got {:?}", idx, expected_p, p_l);
                 }
             }
-            (CoreFrame::Con { tag: st, fields: sf }, CoreFrame::Con { tag: pt, fields: pf }) => {
-                compare_datacon_ids(i, *st, &art.single_table, *pt, &art.split_table);
-                if sf.len() != pf.len() {
-                    panic!("cross-mode divergence at node {}: Con field count mismatch", i);
-                }
-                if sf != pf {
-                    panic!("cross-mode divergence at node {}: Con field indices differ", i);
-                }
+            if s_args.len() != p_args.len() {
+                panic!("node {}: Jump arg count mismatch", idx);
             }
-            (CoreFrame::Join { label: _, params: sp, rhs: sr, body: sb }, CoreFrame::Join { label: _, params: pp, rhs: pr, body: pb }) => {
-                if sp.len() != pp.len() {
-                    panic!("cross-mode divergence at node {}: Join param count mismatch", i);
-                }
-                if sr != pr || sb != pb {
-                    panic!("cross-mode divergence at node {}: Join indices differ", i);
-                }
+            for (&sa, &pa) in s_args.iter().zip(p_args.iter()) {
+                if sa != pa { panic!("node {}: Jump arg index mismatch ({} vs {})", idx, sa, pa); }
+                check_node(sa, single, s_table, split, p_table, var_map, join_map);
             }
-            (CoreFrame::Jump { label: _, args: sa }, CoreFrame::Jump { label: _, args: pa }) => {
-                if sa.len() != pa.len() {
-                    panic!("cross-mode divergence at node {}: Jump arg count mismatch", i);
-                }
-                if sa != pa {
-                    panic!("cross-mode divergence at node {}: Jump arg indices differ", i);
-                }
+        }
+        (CoreFrame::PrimOp { op: so, args: sa }, CoreFrame::PrimOp { op: po, args: pa }) => {
+            if so != po {
+                panic!("node {}: PrimOp kind mismatch ({:?} vs {:?})", idx, so, po);
             }
-            (CoreFrame::PrimOp { op: so, args: sa }, CoreFrame::PrimOp { op: po, args: pa }) => {
-                if so != po {
-                    panic!("cross-mode divergence at node {}: PrimOp kind mismatch (single={:?}, split={:?})", i, so, po);
-                }
-                if sa.len() != pa.len() {
-                    panic!("cross-mode divergence at node {}: PrimOp arg count mismatch", i);
-                }
-                if sa != pa {
-                    panic!("cross-mode divergence at node {}: PrimOp arg indices differ", i);
-                }
+            if sa.len() != pa.len() {
+                panic!("node {}: PrimOp arg count mismatch", idx);
             }
-            (s, p) => {
-                panic!(
-                    "cross-mode divergence at node {}: variant mismatch (single={:?}, split={:?})",
-                    i, core_kind(s), core_kind(p)
-                );
+            for (&sai, &pai) in sa.iter().zip(pa.iter()) {
+                if sai != pai { panic!("node {}: PrimOp arg index mismatch ({} vs {})", idx, sai, pai); }
+                check_node(sai, single, s_table, split, p_table, var_map, join_map);
             }
+        }
+        (s, p) => {
+            panic!(
+                "node {}: variant mismatch (single={:?}, split={:?})",
+                idx, core_kind(s), core_kind(p)
+            );
         }
     }
 }
@@ -139,14 +244,14 @@ fn compare_alt_con(node_idx: usize, alt_idx: usize, s_con: &AltCon, s_table: &Da
         (AltCon::Default, AltCon::Default) => {}
         (AltCon::LitAlt(sl), AltCon::LitAlt(pl)) => {
             if sl != pl {
-                panic!("cross-mode divergence at node {} alt {}: literals differ ({:?} vs {:?})", node_idx, alt_idx, sl, pl);
+                panic!("node {} alt {}: literals differ ({:?} vs {:?})", node_idx, alt_idx, sl, pl);
             }
         }
         (AltCon::DataAlt(si), AltCon::DataAlt(pi)) => {
             compare_datacon_ids_detailed(format!("node {} alt {}", node_idx, alt_idx), *si, s_table, *pi, p_table);
         }
         (s, p) => {
-            panic!("cross-mode divergence at node {} alt {}: AltCon variant mismatch (single={:?}, split={:?})", node_idx, alt_idx, s, p);
+            panic!("node {} alt {}: AltCon variant mismatch (single={:?}, split={:?})", node_idx, alt_idx, s, p);
         }
     }
 }
@@ -176,13 +281,6 @@ pub fn assert_table_compatible(single_table: &DataConTable, split_table: &DataCo
         let p_dc = split_table.get(p_dc_id).unwrap();
         if s_dc.field_bangs != p_dc.field_bangs {
             panic!("DataCon '{}' has different field_bangs (single={:?}, split={:?})", s_dc.name, s_dc.field_bangs, p_dc.field_bangs);
-        }
-    }
-    // And vice versa
-    for p_dc in split_table.iter() {
-        if single_table.get_by_name_arity(&p_dc.name, p_dc.rep_arity).is_none() {
-             // It's technically okay if split has MORE datacons (e.g. from extra modules), 
-             // as long as the ones used in the expression tree match.
         }
     }
 }

--- a/tidepool-runtime/tests/cross_mode_tests.rs
+++ b/tidepool-runtime/tests/cross_mode_tests.rs
@@ -1,0 +1,54 @@
+//! Sanity tests for the cross-mode test harness.
+
+mod cross_mode_harness;
+
+use cross_mode_harness::{CrossModeFixture, assert_cross_mode_structurally_equivalent, assert_cross_mode_pure_equivalent};
+
+#[test]
+fn harness_pure_value_roundtrips() {
+    let fixture = CrossModeFixture {
+        single: r#"
+module Test where
+fortyTwo :: Int
+fortyTwo = 42
+"#.to_string(),
+        split: vec![
+            ("Helper.hs".to_string(), r#"
+module Helper where
+fortyTwo :: Int
+fortyTwo = 42
+"#.to_string()),
+        ],
+        target: "fortyTwo",
+    };
+
+    // Assert structural equivalence (Core trees modulo IDs)
+    assert_cross_mode_structurally_equivalent(&fixture);
+
+    // Assert runtime equivalence
+    assert_cross_mode_pure_equivalent(&fixture);
+}
+
+#[test]
+fn harness_detects_obvious_divergence() {
+    let fixture = CrossModeFixture {
+        single: r#"
+module M where
+x = 1 :: Int
+"#.to_string(),
+        split: vec![
+            ("Main.hs".to_string(), r#"
+module Test where
+x = 2 :: Int
+"#.to_string()),
+        ],
+        target: "x",
+    };
+
+    // Runtime equivalence should fail because 1 != 2
+    let result = std::panic::catch_unwind(|| {
+        assert_cross_mode_pure_equivalent(&fixture);
+    });
+
+    assert!(result.is_err(), "harness should have detected value divergence");
+}

--- a/tidepool-runtime/tests/cross_mode_tests.rs
+++ b/tidepool-runtime/tests/cross_mode_tests.rs
@@ -2,24 +2,31 @@
 
 mod cross_mode_harness;
 
-use cross_mode_harness::{CrossModeFixture, assert_cross_mode_structurally_equivalent, assert_cross_mode_pure_equivalent};
+use cross_mode_harness::{CrossModeFixture, assert_cross_mode_structurally_equivalent, assert_cross_mode_pure_equivalent, assert_cross_mode_runtime_equivalent};
+use tidepool_bridge_derive::FromCore;
+use tidepool_effect::{EffectContext, EffectError, EffectHandler};
+use tidepool_eval::value::Value;
 
 #[test]
 fn harness_pure_value_roundtrips() {
     let fixture = CrossModeFixture {
         single: r#"
 module Test where
-fortyTwo :: Int
-fortyTwo = 42
+y = 42 :: Int
+x = y
 "#.to_string(),
         split: vec![
             ("Helper.hs".to_string(), r#"
 module Helper where
-fortyTwo :: Int
-fortyTwo = 42
+y = 42 :: Int
+"#.to_string()),
+            ("Main.hs".to_string(), r#"
+module Test where
+import qualified Helper
+x = Helper.y
 "#.to_string()),
         ],
-        target: "fortyTwo",
+        target: "x",
     };
 
     // Assert structural equivalence (Core trees modulo IDs)
@@ -29,17 +36,80 @@ fortyTwo = 42
     assert_cross_mode_pure_equivalent(&fixture);
 }
 
+#[derive(FromCore)]
+enum EchoReq {
+    #[core(name = "Echo")]
+    Echo(i64),
+}
+
+struct EchoHandler;
+
+impl EffectHandler for EchoHandler {
+    type Request = EchoReq;
+    fn handle(&mut self, req: EchoReq, cx: &EffectContext) -> Result<Value, EffectError> {
+        match req {
+            EchoReq::Echo(n) => cx.respond(n),
+        }
+    }
+}
+
+#[test]
+fn harness_effect_roundtrips() {
+    let fixture = CrossModeFixture {
+        single: r#"
+{-# LANGUAGE GADTs, DataKinds, TypeOperators, FlexibleContexts #-}
+module Test where
+import Control.Monad.Freer (Eff, Member, send)
+data Echo a where Echo :: Int -> Echo Int
+main :: Eff '[Echo] Int
+main = send (Echo 42)
+"#.to_string(),
+        split: vec![
+            ("Def.hs".to_string(), r#"
+{-# LANGUAGE GADTs, DataKinds, TypeOperators, FlexibleContexts #-}
+module Def where
+import Control.Monad.Freer (Eff, Member, send)
+data Echo a where Echo :: Int -> Echo Int
+echo :: Member Echo effs => Int -> Eff effs Int
+echo n = send (Echo n)
+"#.to_string()),
+            ("Main.hs".to_string(), r#"
+{-# LANGUAGE DataKinds, TypeOperators, FlexibleContexts #-}
+module Test where
+import qualified Def
+import Control.Monad.Freer (Eff)
+main :: Eff '[Def.Echo] Int
+main = Def.echo 42
+"#.to_string()),
+        ],
+        target: "main",
+    };
+
+    // For effects, we assert runtime equivalence. 
+    assert_cross_mode_runtime_equivalent(
+        &fixture,
+        || frunk::hlist![EchoHandler],
+        || frunk::hlist![EchoHandler],
+        &(),
+    );
+}
+
 #[test]
 fn harness_detects_obvious_divergence() {
     let fixture = CrossModeFixture {
         single: r#"
-module M where
+module Test where
 x = 1 :: Int
 "#.to_string(),
         split: vec![
+            ("Helper.hs".to_string(), r#"
+module Helper where
+y = 2 :: Int
+"#.to_string()),
             ("Main.hs".to_string(), r#"
 module Test where
-x = 2 :: Int
+import qualified Helper
+x = Helper.y
 "#.to_string()),
         ],
         target: "x",


### PR DESCRIPTION
This PR adds a cross-mode test harness to `tidepool-runtime`.

### Motivation
The harness catches bugs where GHC's post-optimizer Core shape diverges between single-module compilation and cross-module compilation (as seen in PR #272). Downstream tests will use this to ensure that any regression in cross-module translation is caught structurally.

### Changes
- Created `tidepool-runtime/tests/cross_mode_harness/mod.rs`: defines the `CrossModeFixture` and assertion APIs.
- Created `tidepool-runtime/tests/cross_mode_harness/structural_eq.rs`: implements the structural comparison of Core expression trees and runtime values.
- Created `tidepool-runtime/tests/cross_mode_tests.rs`: integration tests for the harness itself.

### Verification
- `nix develop --command cargo test -p tidepool-runtime --test cross_mode_tests`
- `nix develop --command cargo clippy -p tidepool-runtime --tests -- -D warnings`

The harness supports both pure programs (via `assert_cross_mode_pure_equivalent`) and effectful ones (via `assert_cross_mode_runtime_equivalent`). Structural equivalence is asserted modulo legitimately-varying VarIds and DataConIds (matched by name + arity).
