### PR TITLE
feat(codegen): hook normalize() into JIT compile pipeline

### DIFF
--- a/tidepool-codegen/src/datacon_env.rs
+++ b/tidepool-codegen/src/datacon_env.rs
@@ -10,14 +10,12 @@ use tidepool_repr::{CoreExpr, CoreFrame, DataConTable, TreeBuilder, VarId};
 ///
 /// The binding VarId matches `VarId(dc.id.0)`, which is what the GHC Core translator
 /// uses to reference data constructors as function values.
-pub fn wrap_with_datacon_env(expr: &CoreExpr, table: &DataConTable) -> CoreExpr {
+pub fn wrap_with_datacon_env(mut expr: CoreExpr, table: &DataConTable) -> CoreExpr {
     let mut b = TreeBuilder::new();
 
-    // First, push all nodes from the original expression
-    let mut src = TreeBuilder::new();
-    src.extend(expr.nodes.iter().cloned());
-    let base = b.push_tree(src);
-    let root = base + expr.nodes.len() - 1;
+    // First, push all nodes from the original expression.
+    // Since b is empty, we can move the nodes directly without index offsetting.
+    let root = b.extend(expr.nodes.drain(..));
 
     // Collect datacons sorted by id for deterministic output
     let mut datacons: Vec<_> = table.iter().collect();

--- a/tidepool-codegen/src/host_fns.rs
+++ b/tidepool-codegen/src/host_fns.rs
@@ -693,8 +693,7 @@ pub(crate) const POISON_BUF_SIZE: usize = 16 * 1024;
 /// regression test lives in the module's `tests` block under
 /// `poison_buf_absorbs_max_con_write`.
 const _: () = {
-    let worst_case_con =
-        layout::CON_FIELDS_OFFSET as usize + crate::heap_bridge::MAX_FIELDS * 8;
+    let worst_case_con = layout::CON_FIELDS_OFFSET as usize + crate::heap_bridge::MAX_FIELDS * 8;
     assert!(
         POISON_BUF_SIZE >= worst_case_con,
         "POISON_BUF_SIZE must absorb worst-case Con write \

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -128,7 +128,7 @@ impl JitEffectMachine {
         nursery_size: usize,
     ) -> Result<Self, JitError> {
         let expr = tidepool_repr::normalize(expr, table);
-        let expr = crate::datacon_env::wrap_with_datacon_env(&expr, table);
+        let expr = crate::datacon_env::wrap_with_datacon_env(expr, table);
         let mut pipeline = CodegenPipeline::new(&crate::host_fns::host_fn_symbols())?;
         let func_id = crate::emit::expr::compile_expr(&mut pipeline, &expr, "main")
             .map_err(JitError::Compilation)?;

--- a/tidepool-codegen/src/jit_machine.rs
+++ b/tidepool-codegen/src/jit_machine.rs
@@ -127,7 +127,8 @@ impl JitEffectMachine {
         table: &DataConTable,
         nursery_size: usize,
     ) -> Result<Self, JitError> {
-        let expr = crate::datacon_env::wrap_with_datacon_env(expr, table);
+        let expr = tidepool_repr::normalize(expr, table);
+        let expr = crate::datacon_env::wrap_with_datacon_env(&expr, table);
         let mut pipeline = CodegenPipeline::new(&crate::host_fns::host_fn_symbols())?;
         let func_id = crate::emit::expr::compile_expr(&mut pipeline, &expr, "main")
             .map_err(JitError::Compilation)?;
@@ -236,9 +237,7 @@ impl JitEffectMachine {
                     // handler-driven scenario without depending on the
                     // shape of the compiled program.
                     if self.cancel_flag.load(std::sync::atomic::Ordering::Relaxed) {
-                        break Err(JitError::Yield(
-                            crate::yield_type::YieldError::Cancelled,
-                        ));
+                        break Err(JitError::Yield(crate::yield_type::YieldError::Cancelled));
                     }
 
                     const MAX_EFFECT_RESPONSE_NODES: usize = 10_000;

--- a/tidepool-codegen/tests/effect_machine.rs
+++ b/tidepool-codegen/tests/effect_machine.rs
@@ -370,7 +370,10 @@ fn test_yield_request_e_boxed_tag() {
         continuation,
     } = result
     else {
-        panic!("Expected Yield::Request from boxed-tag Union, got {:?}", result);
+        panic!(
+            "Expected Yield::Request from boxed-tag Union, got {:?}",
+            result
+        );
     };
 
     assert_eq!(

--- a/tidepool-codegen/tests/emit_letrec_con.rs
+++ b/tidepool-codegen/tests/emit_letrec_con.rs
@@ -453,7 +453,7 @@ fn compile_repl_cbor_inner() {
     let meta_data = std::fs::read(meta_path).unwrap();
     let (table, _) = tidepool_repr::serial::read::read_metadata(&meta_data).unwrap();
 
-    let expr = tidepool_codegen::datacon_env::wrap_with_datacon_env(&expr, &table);
+    let expr = tidepool_codegen::datacon_env::wrap_with_datacon_env(expr, &table);
 
     let mut pipeline = CodegenPipeline::new(&host_fns::host_fn_symbols()).unwrap();
     let result = compile_expr(&mut pipeline, &expr, "repl");


### PR DESCRIPTION
Hooks `tidepool_repr::normalize` into `JitEffectMachine::compile`. This ensures every CoreExpr compiled via the high-level JIT interface is canonicalized before being wrapped with the datacon environment and passed to the codegen layer.

### Changes
- Call `tidepool_repr::normalize` in `JitEffectMachine::compile` before wrapping the expression with the datacon environment.
- **Optimization:** Modified `wrap_with_datacon_env` to take `CoreExpr` by value and move its nodes into the `TreeBuilder`. This ensures that even though `normalize` currently returns a clone (as it is the identity pass), the overall compilation pipeline preserves the previous performance characteristics by avoiding a second clone inside the wrapper.
- Preserved the existing compile pipeline and effect-machine behavior while routing all high-level JIT callers through normalization.
- Applied formatting cleanup to `host_fns.rs` and `effect_machine.rs` to satisfy workspace `cargo fmt` checks.

Entry points covered:
- `JitEffectMachine::compile` (and all its callers in `tidepool-runtime`, examples, and tests)

Bypassing entry points:
- Internal codegen tests in `tidepool-codegen/tests/` call `compile_expr` directly to verify specific lower-level behavior. These bypass normalization by design as they often test unoptimized or ad-hoc tree shapes.

Verified:
- `cargo check --workspace`
- `cargo test --workspace` (all tests pass with normalize=identity)
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`