### PR TITLE
feat: encode core-shapes invariants as debug_assert preconditions (with review fixes)

### DIFF
--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -9,6 +9,16 @@ use tidepool_repr::{DataConId, DataConTable, Literal};
 
 /// Check if a DataConId matches a known boxing constructor name (I#, W#, D#, C#).
 fn is_boxing_con(name: &str, id: DataConId, table: &DataConTable) -> bool {
+    #[cfg(debug_assertions)]
+    if matches!(name, "I#" | "W#") {
+        let matches = table.get_all_by_name(name);
+        debug_assert!(
+            matches.len() <= 1,
+            "core-shapes.md §10: ambiguous unqualified DataCon name '{}' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+            name,
+            matches
+        );
+    }
     table.get_by_name(name) == Some(id)
 }
 
@@ -145,6 +155,15 @@ impl FromCore for i64 {
 
 impl ToCore for i64 {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("I#");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name 'I#' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let id = table
             .get_by_name("I#")
             .ok_or_else(|| BridgeError::UnknownDataConName("I#".into()))?;
@@ -175,6 +194,15 @@ impl FromCore for u64 {
 
 impl ToCore for u64 {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("W#");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name 'W#' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let id = table
             .get_by_name("W#")
             .ok_or_else(|| BridgeError::UnknownDataConName("W#".into()))?;
@@ -327,6 +355,16 @@ impl ToCoreSealed for String {}
 
 impl FromCore for String {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
+        #[cfg(debug_assertions)]
+        for name in ["Text", "ByteArray", "[]"] {
+            let matches = table.get_all_by_name(name);
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '{}' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                name,
+                matches
+            );
+        }
         match value {
             // Text constructor: Text ByteArray# off len
             Value::Con(id, fields)
@@ -417,6 +455,15 @@ impl FromCore for String {
 
 impl ToCore for String {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("Text");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name 'Text' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let text_id = table
             .get_by_name("Text")
             .ok_or_else(|| BridgeError::UnknownDataConName("Text".into()))?;
@@ -508,6 +555,15 @@ impl<T> ToCoreSealed for Vec<T> {}
 
 impl<T: FromCore> FromCore for Vec<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("[]");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '[]' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let nil_id = table
             .get_by_name("[]")
             .ok_or(BridgeError::UnknownDataConName("[]".into()))?;
@@ -556,6 +612,15 @@ impl<T: FromCore> FromCore for Vec<T> {
 
 impl<T: ToCore> ToCore for Vec<T> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("[]");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '[]' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let nil_id = table
             .get_by_name("[]")
             .ok_or_else(|| BridgeError::UnknownDataConName("[]".into()))?;
@@ -576,6 +641,16 @@ impl<T, E> ToCoreSealed for Result<T, E> {}
 
 impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
+        #[cfg(debug_assertions)]
+        for name in ["Right", "Ok"] {
+            let matches = table.get_all_by_name(name);
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '{}' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                name,
+                matches
+            );
+        }
         match value {
             Value::Con(id, fields) => {
                 let right_id = table
@@ -618,6 +693,16 @@ impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
 
 impl<T: ToCore, E: ToCore> ToCore for Result<T, E> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        for name in ["Right", "Ok"] {
+            let matches = table.get_all_by_name(name);
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '{}' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                name,
+                matches
+            );
+        }
         match self {
             Ok(x) => {
                 let id = table

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -10,7 +10,7 @@ use tidepool_repr::{DataConId, DataConTable, Literal};
 /// Check if a DataConId matches a known boxing constructor name (I#, W#, D#, C#).
 fn is_boxing_con(name: &str, id: DataConId, table: &DataConTable) -> bool {
     #[cfg(debug_assertions)]
-    if matches!(name, "I#" | "W#") {
+    if matches!(name, "I#" | "W#" | "D#" | "C#") {
         let matches = table.get_all_by_name(name);
         debug_assert!(
             matches.len() <= 1,
@@ -642,7 +642,7 @@ impl<T, E> ToCoreSealed for Result<T, E> {}
 impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
         #[cfg(debug_assertions)]
-        for name in ["Right", "Ok"] {
+        for name in ["Right", "Ok", "Left", "Err"] {
             let matches = table.get_all_by_name(name);
             debug_assert!(
                 matches.len() <= 1,
@@ -694,7 +694,7 @@ impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
 impl<T: ToCore, E: ToCore> ToCore for Result<T, E> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
         #[cfg(debug_assertions)]
-        for name in ["Right", "Ok"] {
+        for name in ["Right", "Ok", "Left", "Err"] {
             let matches = table.get_all_by_name(name);
             debug_assert!(
                 matches.len() <= 1,

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -290,6 +290,15 @@ impl CompiledEffectMachine {
             }
             // SAFETY: current is non-null (checked above) and points to a valid heap object.
             let tag = unsafe { *current };
+            // core-shapes.md §9: pointer must have a valid heap tag before forcing or returning
+            debug_assert!(
+                matches!(
+                    tag,
+                    layout::TAG_THUNK | layout::TAG_CON | layout::TAG_LIT | layout::TAG_CLOSURE
+                ),
+                "core-shapes.md §9: unexpected heap tag {} in force_ptr",
+                tag
+            );
             if tag == layout::TAG_THUNK {
                 let vmctx = &mut self.vmctx as *mut VMContext;
                 current = crate::host_fns::heap_force(vmctx, current);
@@ -360,6 +369,12 @@ impl CompiledEffectMachine {
                         k = k1;
                         continue;
                     } else {
+                        // core-shapes.md §7: continuation must be Leaf or Node
+                        debug_assert!(
+                            false,
+                            "core-shapes.md §7: apply_cont_heap unexpected continuation con_tag {}",
+                            con_tag
+                        );
                         crate::host_fns::push_diagnostic(format!(
                             "apply_cont_heap: unexpected continuation con_tag {} (expected Leaf or Node)",
                             con_tag
@@ -387,15 +402,31 @@ impl CompiledEffectMachine {
 
             // We have a result from call_closure. Compose with pending k2s.
             if result.is_null() {
+                // core-shapes.md §7: closure application must return a valid result
+                debug_assert!(
+                    false,
+                    "core-shapes.md §7: apply_cont_heap closure returned null"
+                );
                 return std::ptr::null_mut();
             }
             let result = self.force_ptr(result);
             if result.is_null() {
+                // core-shapes.md §7: forced result must be non-null
+                debug_assert!(
+                    false,
+                    "core-shapes.md §7: apply_cont_heap forced result is null"
+                );
                 return std::ptr::null_mut();
             }
 
             let result_tag = *result;
             if result_tag != layout::TAG_CON {
+                // core-shapes.md §7: Eff result must be TAG_CON
+                debug_assert!(
+                    result_tag == layout::TAG_CON,
+                    "core-shapes.md §7: apply_cont_heap result has unexpected tag {}",
+                    result_tag
+                );
                 crate::host_fns::push_diagnostic(format!(
                     "apply_cont_heap: result has unexpected tag {} (expected TAG_CON)",
                     result_tag
@@ -428,6 +459,12 @@ impl CompiledEffectMachine {
                 }
                 return self.alloc_con(self.tags.e, &[union_val, k_prime]);
             } else {
+                // core-shapes.md §7: Eff result must be Val or E
+                debug_assert!(
+                    result_con_tag == self.tags.val || result_con_tag == self.tags.e,
+                    "core-shapes.md §7: apply_cont_heap result con_tag {} is neither Val nor E",
+                    result_con_tag
+                );
                 crate::host_fns::push_diagnostic(format!(
                     "apply_cont_heap: result con_tag {} is neither Val nor E",
                     result_con_tag

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -89,9 +89,16 @@ unsafe fn heap_to_value_inner(
             match lit_tag {
                 x if x == LIT_TAG_INT => Ok(Value::Lit(Literal::LitInt(raw_value))),
                 x if x == LIT_TAG_WORD => Ok(Value::Lit(Literal::LitWord(raw_value as u64))),
-                x if x == LIT_TAG_CHAR => Ok(Value::Lit(Literal::LitChar(
-                    char::from_u32(raw_value as u32).unwrap_or('\0'),
-                ))),
+                x if x == LIT_TAG_CHAR => {
+                    // core-shapes.md §1: Char lit must hold valid Unicode codepoint
+                    debug_assert!(
+                        char::from_u32(raw_value as u32).is_some(),
+                        "core-shapes.md §1: Char lit must hold valid Unicode codepoint"
+                    );
+                    Ok(Value::Lit(Literal::LitChar(
+                        char::from_u32(raw_value as u32).unwrap_or('\0'),
+                    )))
+                }
                 x if x == LIT_TAG_FLOAT => Ok(Value::Lit(Literal::LitFloat(raw_value as u64))),
                 x if x == LIT_TAG_DOUBLE => Ok(Value::Lit(Literal::LitDouble(raw_value as u64))),
                 x if x == LIT_TAG_STRING => {
@@ -110,6 +117,11 @@ unsafe fn heap_to_value_inner(
                     Ok(Value::Lit(Literal::LitString(bytes)))
                 }
                 x if x == LIT_TAG_ADDR => {
+                    // core-shapes.md §1: LIT_TAG_ADDR should not survive translation
+                    debug_assert!(
+                        false,
+                        "core-shapes.md §1: LIT_TAG_ADDR should not survive translation; got at heap_bridge.rs"
+                    );
                     // Addr# — intermediate value, shouldn't normally be a final result.
                     // Wrap as empty LitString as graceful fallback.
                     Ok(Value::Lit(Literal::LitString(vec![])))


### PR DESCRIPTION
This PR encodes foundational invariants from `docs/core-shapes.md` as `debug_assert!` preconditions and `#[cfg(debug_assertions)]` sanity checks at hot-path read sites.

### Encoded Invariants (by section)

- **§1: Literals**: Added Unicode validity checks for `Char` literals and explicit traps for `LIT_TAG_ADDR` surfacing at the bridge.
- **§7: Effects**: Hardened `apply_cont_heap` with assertions for expected continuation tags (`TAG_CON`/`TAG_CLOSURE`), `Eff` result tags (`Val`/`E`), and non-null result pointers.
- **§8: Bridge**: Integrated boxing constructor lookup validation into `is_boxing_con` (including `I#`, `W#`, `D#`, and `C#`).
- **§9: Heap-layout**: Added heap tag validation in `force_ptr` to catch corrupted or unexpected object types before forcing.
- **§10: Cross-module compilation**: Added ambiguity detection for unqualified `DataCon` lookups at sites flagged as high-risk for module collisions (`Text`, `ByteArray`, `[]`, `I#`, `W#`, `Right`, `Ok`, `Left`, `Err`).

### Fixes from Copilot Review

- Expanded `is_boxing_con` ambiguity checks to cover `D#` and `C#`.
- Expanded `Result` ambiguity checks to cover `Left` and `Err` branches in both `FromCore` and `ToCore` implementations.

### Coverage Gaps Remaining

- **`audit-bridge § Text`**: Migration to `get_by_name_arity` is deferred; currently flagged by ambiguity assertion.
- **Haskell-side**: Encoding in `Translate.hs` is deferred.
- **`TAG_CLOSURE` in bridge**: The assertion was narrowed/removed for `heap_bridge.rs` as closures are intentionally permitted as opaque values in some traversals (e.g., `Array#` inspection).

### Verification Results

- `nix develop --command cargo test --workspace`: **PASS**.
- `nix develop --command cargo build --release --workspace`: **PASS**.
- `nix develop --command cargo clippy --workspace -- -D warnings`: **PASS**.

Total assertions added: 28.
