### PR TITLE
Shape dossier: catalog Core shape assumptions and encode preconditions

### DIFF
--- a/docs/core-shapes.md
+++ b/docs/core-shapes.md
@@ -1,0 +1,196 @@
+# Core Shapes — Normative Dossier
+
+This dossier provides a consolidated, normative reference for the GHC Core constructs and heap shapes supported by the Tidepool JIT. It synthesizes findings from four parallel audits covering translation, codegen, and runtime bridge layers. This document serves as a technical foundation for addressing "cross-module divergence" patterns where bindings merged across modules break assumptions made during single-module optimization. For historical context, see PR #272 and Issue #273.
+
+## How to read this dossier
+Each section describes a Core construct or shape concern, defining what the JIT must accept and what it produces as a canonical form. Entries cite source audits using cross-links such as [audit-translate § emitRuntimeUnpackCString](core-shapes/audit-translate.md#emitruntimeunpackcstring). The [Coverage Gaps](#coverage-gaps) section at the end provides a prioritized punch list of uncovered branches, silent fallbacks, and cross-module collision risks that require hardening.
+
+## Table of contents
+- [1. Literals (`Lit`)](#1-literals-lit)
+- [2. Constructors (`Con`)](#2-constructors-con)
+- [3. Cases (`Case`) and pattern matching](#3-cases-case-and-pattern-matching)
+- [4. Lambdas, Applications, and Tail Calls](#4-lambdas-applications-and-tail-calls)
+- [5. Let / LetRec](#5-let--letrec)
+- [6. Join points](#6-join-points)
+- [7. Effects (freer-simple Val/E/Union/Leaf/Node)](#7-effects-freer-simple-valeunionleafnode)
+- [8. Bridge: Rust ↔ Core value conversion](#8-bridge-rust--core-value-conversion)
+- [9. Heap-layout invariants](#9-heap-layout-invariants)
+- [10. Cross-module compilation: known divergence points](#10-cross-module-compilation-known-divergence-points)
+- [11. Cancellation safepoints](#11-cancellation-safepoints)
+- [Coverage Gaps](#coverage-gaps)
+- [Cross-references and source audits](#cross-references-and-source-audits)
+
+## 1. Literals (`Lit`)
+
+The JIT must accept literal values arriving as `LEInt`, `LEWord`, `LEChar`, `LEFloat`, `LEDouble`, and `LEString`. During translation, certain GHC-specific literals (like `Addr#` and `RealWorld#`) are erased or canonicalized. Static string literals are desugared from `Addr#` pointers into uniform cons-lists of characters to maintain compatibility with list-processing functions.
+
+Translation produces `NLit` nodes containing the primitive value. The `TAG_LIT` heap layout, including the specific `LitTag` identifying the primitive type, is only materialized during codegen or allocation.
+
+**Special cases**:
+- `unpackCString# "lit"#` desugar — converts static `Addr#` to `(:)` chain. Mode: always-on. [audit-translate § isUnpackCStringVar static desugar](core-shapes/audit-translate.md#isunpackcstringvar-static-desugar).
+- `unpackFoldrCString#` desugar — handles fusion-based string literals. Mode: always-on. [audit-translate § isUnpackFoldrCStringVar static desugar](core-shapes/audit-translate.md#isunpackfoldrcstringvar-static-desugar).
+- `realWorld#` erasure — state tokens are replaced with dummy `LEInt 0`. Mode: always-on. [audit-translate § isRealWorldVar](core-shapes/audit-translate.md#isrealworldvar).
+- `Typeable` metadata erasure — metadata variables are replaced with error nodes. Mode: always-on. [audit-translate § isTypeMetadataVar](core-shapes/audit-translate.md#istypemetadatavar).
+
+**Known fragility**:
+- `Addr#` fallback: raw `Addr#` values reaching the bridge return an empty string rather than risking raw pointer access. [audit-heap-bridge § LitTag::Addr fallback](core-shapes/audit-heap-bridge.md#littagaddr-fallback).
+- Character literals: the bridge performs a silent fallback to `\0` if the heap contains invalid Unicode data. [audit-heap-bridge § LitTag::Char](core-shapes/audit-heap-bridge.md#littagchar).
+
+## 2. Constructors (`Con`)
+
+Constructors are the primary means of heap allocation. The JIT must handle both standard `DataCon` applications and unboxed tuples. Arity must be adjusted for GADTs where equality evidence (`EqSpec`) is present in the Core but erased in the JIT.
+
+Translation produces `NCon` nodes. All constructors are materialized as `TAG_CON` objects on the heap during codegen or dynamic allocation. The runtime heap layout, where `con_tag` (DataConId) and field pointers are stored at fixed offsets, only applies once the constructor has been materialized.
+
+**Special cases**:
+- Unboxed tuples — translated to standard `NCase` dispatch or single-element fallthrough. Mode: always-on. [audit-translate § isUnboxedTupleDataCon (general)](core-shapes/audit-translate.md#isunboxedtupledatacon-general).
+- `unsafeEqualityProof` — represented as a unit constructor `()`. Mode: always-on. [audit-translate § isUnsafeEqualityProofVar desugar](core-shapes/audit-translate.md#isunsafeequalityproofvar-desugar).
+- Arity adjustment — `valueRepArity` corrects for erased `Coercion` arguments. Mode: always-on. [audit-translate § valueRepArity](core-shapes/audit-translate.md#valuereparity).
+- Composed `Node`/`E` — the effect machine dynamically allocates these during continuation composition. Mode: always-on. [audit-effect-machine § alloc_con](core-shapes/audit-effect-machine.md#alloc_con).
+
+**Known fragility**:
+- Raw Con accessors: `read_con_tag` and friends do not perform tag-checks; passing a `TAG_LIT` or `TAG_THUNK` results in UB. [audit-effect-machine § Basic Con Accessors](core-shapes/audit-effect-machine.md#basic-con-accessors).
+- Boxing constructor collisions: the bridge uses unqualified `get_by_name` for boxing types like `I#`, which risks collisions in multi-module builds. [audit-bridge § is_boxing_con helper](core-shapes/audit-bridge.md#is_boxing_con-helper).
+
+## 3. Cases (`Case`) and pattern matching
+
+Case expressions drive control flow and deconstruction. The JIT must accept scrutinees that are evaluated at runtime, as well as complex desugaring for `tagToEnum#` and multi-return primops.
+
+Downstream, `Case` is lowered to Cranelift branch instructions or direct jumps based on the tag of the evaluated scrutinee.
+
+**Special cases**:
+- `tagToEnum#` — desugared into an explicit `Case` on the tag index. Mode: always-on. [audit-translate § tagToEnum# desugar](core-shapes/audit-translate.md#tagtoenum-desugar).
+- `unsafeEqualityProof` elision — cases matching `UnsafeRefl` are elided to prevent tag mismatches with unit-represented evidence. Mode: always-on. [audit-translate § isUnsafeEqualityCase elision](core-shapes/audit-translate.md#isunsafeequalitycase-elision).
+- Multi-return primops — `quotRemInt#` and others are desugared into nested cases of single-return primops. Mode: always-on. [audit-translate § splitMultiReturnPrimOp desugar](core-shapes/audit-translate.md#splitmultireturnprimop-desugar).
+- Stateful primop erasure — `State#` tokens in case results are stripped. Mode: always-on. [audit-translate § Stateful primop state erasure](core-shapes/audit-translate.md#stateful-primop-state-erasure).
+
+**Known fragility**:
+- The `isUnsafeEqualityCase` elision was a critical fix for cross-module divergence where inlined evidence survived the optimizer. [audit-translate § isUnsafeEqualityCase elision](core-shapes/audit-translate.md#isunsafeequalitycase-elision).
+
+## 4. Lambdas, Applications, and Tail Calls
+
+The JIT must handle standard functional applications and eta-reduced variants of intercepted functions. Specialized `Show` instances for `Double` are intercepted to bypass GHC's complex `Integer` pipeline.
+
+After translation, applications become `NApp` or tail-call jumps. Tail calls are resolved iteratively in a loop to avoid stack exhaustion.
+
+**Special cases**:
+- `Show Double` interception — specialized $fShowDouble handlers are replaced with JIT-native implementations. Mode: always-on. [audit-translate § emitShowDoubleSpecBody](core-shapes/audit-translate.md#emitshowdoublespecbody).
+- `runRW#` erasure — state-token applications are simplified to unit applications. Mode: always-on. [audit-translate § isRunRWVar desugar](core-shapes/audit-translate.md#isrunrwvar-desugar).
+- Tail-call resolution — the effect machine resolves `tail_callee` and `tail_arg` in a loop. Mode: always-on. [audit-effect-machine § resolve_tail_calls: Code pointer read](core-shapes/audit-effect-machine.md#resolve_tail_calls-code-pointer-read).
+
+**Known fragility**:
+- Closure code pointers: `call_closure` jumps directly to the pointer read from the heap; a tag mismatch here is fatal. [audit-effect-machine § call_closure: Code pointer read](core-shapes/audit-effect-machine.md#call_closure-code-pointer-read).
+
+## 5. Let / LetRec
+
+The JIT must accept `Let` and `LetRec` bindings, performing reachability analysis to prune unused bindings from large recursive groups. Standard library functions that lack unfoldings (like `(++)` and `take`) are desugared into JIT-native `LetRec` loops.
+
+**Special cases**:
+- `(++)` desugar — provided as a reliable runtime implementation for list concatenation. Mode: always-on. [audit-translate § isAppendVar desugar](core-shapes/audit-translate.md#isappendvar-desugar).
+- `unsafeTake` desugar — implements `take` using unboxed counters and primops. Mode: always-on. [audit-translate § isUnsafeTakeVar desugar](core-shapes/audit-translate.md#isunsafetakevar-desugar).
+- Reachable binds — prunes the transitive closure to keep JIT modules small. Mode: always-on. [audit-translate § reachableBinds](core-shapes/audit-translate.md#reachablebinds).
+
+**Known fragility**:
+- Large `Rec` groups: merging modules can create massive recursive groups that challenge the resolver if reachability analysis fails to fragment them. [audit-translate § reachableBinds](core-shapes/audit-translate.md#reachablebinds).
+
+## 6. Join points
+
+Join points are optimized local jumps. The JIT must promote join points to full closures if they are captured by a lambda, as Cranelift blocks cannot be targeted from separate function scopes.
+
+**Special cases**:
+- `jumpCrossesLam` — detects and promotes invalid join point jumps. Mode: always-on. [audit-translate § jumpCrossesLam (Join Point conversion)](core-shapes/audit-translate.md#jumpcrosseslam-join-point-conversion).
+
+## 7. Effects (freer-simple Val/E/Union/Leaf/Node)
+
+The JIT is specialized for `freer-simple` effect stacks. It must handle the extraction of `Val` and `E` (request) shapes from JIT-compiled results and the composition of continuations in the work-stack.
+
+**Special cases**:
+- Union tag boxing — handles both unboxed `Word#` and boxed `W#` effect tags to support cross-module divergence in the GHC optimizer. Mode: always-on. [audit-effect-machine § parse_result: Union position-tag boxing branch](core-shapes/audit-effect-machine.md#parse_result-union-position-tag-boxing-branch).
+- Continuation tree-walking — iteratively applies `Leaf` and `Node` continuations. Mode: always-on. [audit-effect-machine § apply_cont_heap: Leaf/Node con_tag dispatch](core-shapes/audit-effect-machine.md#apply_cont_heap-leafnode-con_tag-dispatch).
+
+**Known fragility**:
+- `UnexpectedTag` in `parse_result`: if a JIT function returns an unexpected tag for an `Eff` type, the machine yields a hard error. [audit-effect-machine § parse_result: Result tag check](core-shapes/audit-effect-machine.md#parse_result-result-tag-check).
+
+## 8. Bridge: Rust ↔ Core value conversion
+
+The bridge layer converts between raw heap objects and Rust's `Value` enum. It must handle recursion depth limits and null guards. The `ToCore` and `FromCore` traits provide higher-level mapping for standard types like `Result`, `Option`, and `String`.
+
+**Special cases**:
+- Numeric/Char unwrapping — `i64`, `u64`, and `char` impls transparently unwrap `I#`, `W#`, and `C#` boxes. Mode: always-on. [audit-bridge § i64 (Int)](core-shapes/audit-bridge.md#i64-int).
+- `Text` vs `[Char]` — the `String` bridge handles both unboxed `Text` workers and standard character lists. Mode: always-on. [audit-bridge § String (Text)](core-shapes/audit-bridge.md#string-text).
+- JSON mapping — `serde_json::Value` uses `get_by_name_arity` to safely map types without collision. Mode: always-on. [audit-bridge § serde_json::Value](core-shapes/audit-bridge.md#serde_jsonvalue).
+
+**Known fragility**:
+- Unboxing constructors: the bridge relies on standard names like `I#`. If a user module defines a colliding `I#` with different arity, decoding will fail. [audit-bridge § is_boxing_con helper](core-shapes/audit-bridge.md#is_boxing_con-helper).
+
+## 9. Heap-layout invariants
+
+The JIT and runtime share a set of heap layout constants defined in `tidepool-heap`. Every `HeapObject` must begin with a 1-byte tag at offset 0.
+
+**Core Invariants**:
+- `TAG_CON`: `con_tag` at 8, `num_fields` at 16, pointers start at 24.
+- `TAG_LIT`: `lit_tag` at 8, value starts at 16.
+- `TAG_THUNK`: `state` at 8, indirection/code at 16.
+- `TAG_CLOSURE`: code pointer at 8, `num_captured` at 16, fields at 24.
+
+**Special cases**:
+- Thunk indirection — evaluated thunks point to their result via an indirection pointer at offset 16. Mode: always-on. [audit-heap-bridge § TAG_THUNK evaluated (Indirection)](core-shapes/audit-heap-bridge.md#tag_thunk-evaluated-indirection).
+- ByteArrays — data lives outside the GC nursery to prevent use-after-copy bugs. Mode: always-on. [audit-heap-bridge § LitTag::ByteArray](core-shapes/audit-heap-bridge.md#littagbytearray).
+
+## 10. Cross-module compilation: known divergence points
+
+Merging optimized modules into a single JIT module reveals "divergence" where GHC's module-local assumptions break.
+
+**Key strategies**:
+- Hash-based ID disambiguation — `localVarId` hashes `OccName` + `Unique` to prevent shadow-binder collisions across modules. Mode: always-on. [audit-translate § localVarId hash disambiguation](core-shapes/audit-translate.md#localvarid-hash-disambiguation).
+- Stable IDs — `stableVarId` ensures external references have uniform IDs. Mode: always-on. [audit-translate § stableVarId](core-shapes/audit-translate.md#stablevarid).
+- Tag boxing flexibility — codegen accepts both boxed and unboxed effect tags. [audit-effect-machine § parse_result: Union position-tag boxing branch](core-shapes/audit-effect-machine.md#parse_result-union-position-tag-boxing-branch).
+
+**Known fragility**:
+- `String` (Text) bridge: high risk of collision due to multiple unqualified lookups for `Text`, `ByteArray`, and `[]`. [audit-bridge § String (Text)](core-shapes/audit-bridge.md#string-text).
+
+## 11. Cancellation safepoints
+
+The JIT includes safepoints where long-running or infinite computations can be interrupted.
+
+**Special cases**:
+- Tail-call safepoint — the effect machine checks for external cancellation before resolving each tail call. Mode: always-on. [audit-effect-machine § resolve_tail_calls: Cancellation safepoint](core-shapes/audit-effect-machine.md#resolve_tail_calls-cancellation-safepoint).
+
+## Coverage Gaps
+
+### Uncovered branches (no regression test)
+- `audit-translate § emitRuntimeUnpackCString` — fallback for dynamic Addr# strings.
+- `audit-translate § emitRuntimeUnpackAppendCString` — dynamic string concatenation.
+- `audit-translate § isUnpackCStringVar dynamic fallback` — handles non-static `Addr#` variables.
+- `audit-translate § Coercion placeholder` — dummy literal for rare expression-position coercions.
+- `audit-effect-machine § apply_cont_heap: Closure tag check` — raw closures as continuations.
+- `audit-effect-machine § call_closure: Captured fields read` — debug/trace-only field inspection.
+- `audit-heap-bridge § TAG_THUNK evaluated (Indirection)` — decoding already-forced thunks.
+- `audit-heap-bridge § TAG_THUNK forcing` — triggering side-effects during bridge traversal.
+
+### Silent fallbacks (return wrong-but-valid Value on shape mismatch)
+- `audit-effect-machine § force_ptr: Thunk tag check` — returns current pointer if not a thunk, potentially hiding logic errors.
+- `audit-effect-machine § apply_cont_heap` — multiple branches return `null_mut` on mismatch, causing downstream machine failure instead of immediate trap.
+- `audit-heap-bridge § LitTag::Char` — returns `\0` on invalid Unicode data.
+- `audit-heap-bridge § LitTag::Addr fallback` — returns empty `LitString` for raw machine addresses.
+- `audit-heap-bridge § TAG_CLOSURE opaque representation` — produces a dummy opaque `Closure` instead of failing.
+
+### Cross-module collision risk: High
+- `audit-bridge § String (Text)` — uses multiple unqualified `get_by_name` lookups for `Text`, `ByteArray`, and `[]`; highly susceptible to arity or name collisions.
+
+### Cross-module collision risk: Medium
+- `audit-bridge § is_boxing_con` — unqualified lookup for `I#`, `W#`, etc.
+- `audit-bridge § Result<T, E> (Either)` — uses fallback names (Right/Ok) which may collide with user types.
+
+### Defensive code with no observed triggering source
+- `audit-translate § Coercion placeholder` — provides safety if coercions survive inlining into expression position.
+- `audit-translate § isRealWorldVar` — part of the state-token erasure pipeline; rarely appears as a standalone variable.
+
+## Cross-references and source audits
+
+- **[audit-translate.md](core-shapes/audit-translate.md)**: 30 entries covering `Translate.hs` special-case branches and desugaring.
+- **[audit-effect-machine.md](core-shapes/audit-effect-machine.md)**: 19 entries covering `effect_machine.rs` heap interpretation and composition.
+- **[audit-heap-bridge.md](core-shapes/audit-heap-bridge.md)**: 17 entries covering low-level heap-to-value decoding in `heap_bridge.rs`.
+- **[audit-bridge.md](core-shapes/audit-bridge.md)**: 16 entries covering high-level primitive implementations in `tidepool-bridge`.
+
+For more information, see [PR #272](https://github.com/exo-monad/tidepool/pull/272) (cross-module fixes) and [Issue #273](https://github.com/exo-monad/tidepool/issues/273) (deferred hardening).

--- a/docs/core-shapes.md
+++ b/docs/core-shapes.md
@@ -33,7 +33,7 @@ Translation produces `NLit` nodes containing the primitive value. The `TAG_LIT` 
 - `Typeable` metadata erasure — metadata variables are replaced with error nodes. Mode: always-on. [audit-translate § isTypeMetadataVar](core-shapes/audit-translate.md#istypemetadatavar).
 
 **Known fragility**:
-- `Addr#` fallback: raw `Addr#` values reaching the bridge return an empty string rather than risking raw pointer access. [audit-heap-bridge § LitTag::Addr fallback](core-shapes/audit-heap-bridge.md#littagaddr-fallback).
+- `Addr#` fallback: a top-level `Addr#` result (legitimately produced by `PlusAddr` / `ShowDoubleAddr` primops in `emit/primop.rs`) returns an empty `LitString` because the bridge cannot decode a raw pointer back to a typed Haskell value. Intentional behavior, not a translator-bug guard — programs that compose `Addr#` with `unpackCString#` etc. evaluate to a real string before reaching the bridge. [audit-heap-bridge § LitTag::Addr fallback](core-shapes/audit-heap-bridge.md#littagaddr-fallback).
 - Character literals: the bridge performs a silent fallback to `\0` if the heap contains invalid Unicode data. [audit-heap-bridge § LitTag::Char](core-shapes/audit-heap-bridge.md#littagchar).
 
 ## 2. Constructors (`Con`)
@@ -172,8 +172,9 @@ The JIT includes safepoints where long-running or infinite computations can be i
 - `audit-effect-machine § force_ptr: Thunk tag check` — returns current pointer if not a thunk, potentially hiding logic errors.
 - `audit-effect-machine § apply_cont_heap` — multiple branches return `null_mut` on mismatch, causing downstream machine failure instead of immediate trap.
 - `audit-heap-bridge § LitTag::Char` — returns `\0` on invalid Unicode data.
-- `audit-heap-bridge § LitTag::Addr fallback` — returns empty `LitString` for raw machine addresses.
 - `audit-heap-bridge § TAG_CLOSURE opaque representation` — produces a dummy opaque `Closure` instead of failing.
+
+(`audit-heap-bridge § LitTag::Addr fallback` was originally listed here but is intentional behavior, not a silent failure — `Addr#` is a legitimate runtime value produced by primops; see §1 above.)
 
 ### Cross-module collision risk: High
 - `audit-bridge § String (Text)` — uses multiple unqualified `get_by_name` lookups for `Text`, `ByteArray`, and `[]`; highly susceptible to arity or name collisions.

--- a/docs/core-shapes/audit-bridge.md
+++ b/docs/core-shapes/audit-bridge.md
@@ -1,0 +1,193 @@
+# Audit: tidepool-bridge primitive impls
+
+## `is_boxing_con` helper
+
+- **Location:** `tidepool-bridge/src/impls.rs:11` (`fn is_boxing_con`)
+- **Constructor names looked up:** variable `name` (caller passes `"I#"`, `"W#"`, `"D#"`, `"C#"`)
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** N/A (predicate only)
+- **Failure mode on shape mismatch:** Returns `false`.
+- **Cross-module collision risk:** `medium`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Used by numeric and Char `FromCore` impls to unwrap GHC boxing constructors. Diverges from derive by using unqualified `get_by_name`.
+
+## `PhantomData<T>`
+
+- **Location:** `tidepool-bridge/src/impls.rs:38` (`impl FromCore for std::marker::PhantomData<T>`)
+- **Constructor names looked up:** `"()"`
+- **Lookup strategy:** `get_by_name` (ToCore), `iter().find(|dc| dc.rep_arity == 0)` fallback
+- **Assumed arity:** `0`
+- **Failure mode on shape mismatch:** `ArityMismatch`, `TypeMismatch`, `UnknownDataConName`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge-derive/tests/phantom_data.rs`
+- **Notes:** `ToCore` uses `"()"` but falls back to the first arity-0 constructor in the table if missing.
+
+## `()` (Unit)
+
+- **Location:** `tidepool-bridge/src/impls.rs:105` (`impl ToCore for ()` / `impl FromCore for ()`)
+- **Constructor names looked up:** `"()"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `0`
+- **Failure mode on shape mismatch:** `UnknownDataConName`, `TypeMismatch`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/src/impls.rs:tests::test_unit_roundtrip`
+- **Notes:** Candidate for `get_by_name_arity("()", 0)`.
+
+## `i64` (Int)
+
+- **Location:** `tidepool-bridge/src/impls.rs:130` (`impl FromCore for i64` / `impl ToCore for i64`)
+- **Constructor names looked up:** `"I#"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `1`
+- **Failure mode on shape mismatch:** `TypeMismatch`, `UnknownDataConName`
+- **Cross-module collision risk:** `medium`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Transparently unwraps `I#` box or accepts `LitInt`. Related to `i32` and `char` impls.
+
+## `u64` (Word)
+
+- **Location:** `tidepool-bridge/src/impls.rs:160` (`impl FromCore for u64` / `impl ToCore for u64`)
+- **Constructor names looked up:** `"W#"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `1`
+- **Failure mode on shape mismatch:** `TypeMismatch`, `UnknownDataConName`
+- **Cross-module collision risk:** `medium`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Transparently unwraps `W#` box or accepts `LitWord`.
+
+## `f64` (Double)
+
+- **Location:** `tidepool-bridge/src/impls.rs:190` (`impl FromCore for f64` / `impl ToCore for f64`)
+- **Constructor names looked up:** `"D#"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `1`
+- **Failure mode on shape mismatch:** `TypeMismatch`, `UnknownDataConName`
+- **Cross-module collision risk:** `medium`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Transparently unwraps `D#` box or accepts `LitDouble`.
+
+## `bool`
+
+- **Location:** `tidepool-bridge/src/impls.rs:246` (`impl FromCore for bool` / `impl ToCore for bool`)
+- **Constructor names looked up:** `"True"`, `"False"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `0`
+- **Failure mode on shape mismatch:** `UnknownDataConName`, `ArityMismatch`, `UnknownDataCon` (if `DataConId` doesn't match `True` or `False` lookup), `TypeMismatch`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Candidate for `get_by_name_arity`. Collision risk is low as True/False are standard.
+
+## `char`
+
+- **Location:** `tidepool-bridge/src/impls.rs:300` (`impl FromCore for char` / `impl ToCore for char`)
+- **Constructor names looked up:** `"C#"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `1`
+- **Failure mode on shape mismatch:** `TypeMismatch`, `UnknownDataConName`
+- **Cross-module collision risk:** `medium`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Transparently unwraps `C#` box or accepts `LitChar`.
+
+## `String` (Text)
+
+- **Location:** `tidepool-bridge/src/impls.rs:328` (`impl FromCore for String` / `impl ToCore for String`)
+- **Constructor names looked up:** `"Text"`, `"ByteArray"`, `"[]"`, `":"`, `"C#"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `3 for Text`, `1 for ByteArray`, `0 for []`, `2 for :`, `1 for C#`
+- **Failure mode on shape mismatch:** `TypeMismatch`, `UnknownDataConName`, `InternalError` (mutex poisoned)
+- **Cross-module collision risk:** `high`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`, `tidepool-bridge/tests/proptest_text.rs`
+- **Notes:** Complex impl handling both unboxed `Text` worker format and cons-cell `[Char]` list format. Uses multiple `get_by_name` lookups. Should migrate to `get_by_name_arity` for all lookups.
+
+## `Option<T>`
+
+- **Location:** `tidepool-bridge/src/impls.rs:447` (`impl FromCore for Option<T>` / `impl ToCore for Option<T>`)
+- **Constructor names looked up:** `"Nothing"`, `"Just"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `0 for Nothing`, `1 for Just`
+- **Failure mode on shape mismatch:** `UnknownDataConName`, `ArityMismatch`, `UnknownDataCon`, `TypeMismatch`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Candidate for `get_by_name_arity`.
+
+## `Vec<T>` (List)
+
+- **Location:** `tidepool-bridge/src/impls.rs:509` (`impl FromCore for Vec<T>` / `impl ToCore for Vec<T>`)
+- **Constructor names looked up:** `"[]"`, `":"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `0 for []`, `2 for :`
+- **Failure mode on shape mismatch:** `UnknownDataConName`, `ArityMismatch`, `UnknownDataCon`, `TypeMismatch`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Handles standard cons-list. Candidate for `get_by_name_arity`.
+
+## `Result<T, E>` (Either)
+
+- **Location:** `tidepool-bridge/src/impls.rs:577` (`impl FromCore for Result<T, E>` / `impl ToCore for Result<T, E>`)
+- **Constructor names looked up:** `"Right"`, `"Ok"`, `"Left"`, `"Err"`
+- **Lookup strategy:** `get_by_name` (with `or_else` fallback between Haskell/Rust naming)
+- **Assumed arity:** `1`
+- **Failure mode on shape mismatch:** `UnknownDataConName` (Right/Ok or Left/Err), `ArityMismatch`, `UnknownDataCon`, `TypeMismatch`
+- **Cross-module collision risk:** `medium`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Maps both `Either` (Right/Left) and `Result` (Ok/Err) to Rust `Result`. Candidate for `get_by_name_arity`.
+
+## `(A, B)` (Pair)
+
+- **Location:** `tidepool-bridge/src/impls.rs:645` (`impl FromCore for (A, B)` / `impl ToCore for (A, B)`)
+- **Constructor names looked up:** `"(,)"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `2`
+- **Failure mode on shape mismatch:** `UnknownDataConName`, `ArityMismatch`, `UnknownDataCon`, `TypeMismatch`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Candidate for `get_by_name_arity("(,)", 2)`.
+
+## `(A, B, C)` (Triple)
+
+- **Location:** `tidepool-bridge/src/impls.rs:689` (`impl FromCore for (A, B, C)` / `impl ToCore for (A, B, C)`)
+- **Constructor names looked up:** `"(,,)"`
+- **Lookup strategy:** `get_by_name`
+- **Assumed arity:** `3`
+- **Failure mode on shape mismatch:** `UnknownDataConName`, `ArityMismatch`, `UnknownDataCon`, `TypeMismatch`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/tests/roundtrip.rs`
+- **Notes:** Candidate for `get_by_name_arity("(,,)", 3)`.
+
+## `serde_json::Value`
+
+- **Location:** `tidepool-bridge/src/json.rs:22` (`impl ToCore for serde_json::Value`)
+- **Constructor names looked up:** `"Null"`, `"Bool"`, `"Number"`, `"String"`, `"Array"`, `"Object"`
+- **Lookup strategy:** `get_by_name_arity`
+- **Assumed arity:** `0 for Null`, `1 for Bool/Number/String/Array/Object`
+- **Failure mode on shape mismatch:** `UnknownDataConName`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/src/json.rs:tests`
+- **Notes:** Already uses `get_by_name_arity` to avoid collisions with GHC-internal types like `Array`.
+
+## `keymap_to_value` helper
+
+- **Location:** `tidepool-bridge/src/json.rs:93` (`fn keymap_to_value`)
+- **Constructor names looked up:** `"Data.Map.Bin"`, `"Data.Map.Tip"`, `"Bin"`, `"Tip"`, `"I#"`
+- **Lookup strategy:** `get_by_qualified_name` | `get_by_name_arity` | `get_companion`
+- **Assumed arity:** `5 for Bin`, `0 for Tip`, `1 for I#`
+- **Failure mode on shape mismatch:** `UnknownDataConName`
+- **Cross-module collision risk:** `low`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-bridge/src/json.rs:tests`
+- **Notes:** High-quality lookup strategy: tries qualified names first, then falls back to arity-based or companion lookup. Matches `Data.Map.Strict` heap representation.

--- a/docs/core-shapes/audit-effect-machine.md
+++ b/docs/core-shapes/audit-effect-machine.md
@@ -1,0 +1,210 @@
+# Audit: effect_machine.rs
+
+## Basic Con Accessors
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`read_con_tag`, `read_con_num_fields`, `read_con_field`)
+- **Reads:** `u64` at `CON_TAG_OFFSET` (8), `u16` at `CON_NUM_FIELDS_OFFSET` (16), `*mut u8` at `CON_FIELDS_OFFSET + 8*i` (24+)
+- **Expected shape:** `TAG_CON` header at offset 0.
+- **Tag-check coverage:** no — note as a fragility (callers must verify `TAG_CON` before calling these low-level accessors)
+- **Failure mode on shape mismatch:** `UB` (raw pointer reads from arbitrary offsets)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs` (exercised by almost all tests)
+- **Notes:** paired with `alloc_con` and `tidepool_heap::layout::write_header`. Fragility: if passed a `TAG_LIT` or `TAG_THUNK`, it will read internal metadata as pointers/tags.
+
+## parse_result: Result tag check
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`parse_result`)
+- **Reads:** byte at `*result`
+- **Expected shape:** Any valid `HeapObject`.
+- **Tag-check coverage:** yes — verifies `tag == layout::TAG_CON`
+- **Failure mode on shape mismatch:** `YieldError variant returned` (`YieldError::UnexpectedTag`)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_unexpected_tag`
+- **Notes:** Defensive check ensuring the JIT function returned a `Con` as expected for the `Eff` type.
+
+## parse_result: Val shape extraction
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`parse_result` dispatch)
+- **Reads:** `con_tag` (8), `num_fields` (16), `fields[0]` (24)
+- **Expected shape:** `TAG_CON` with `con_tag == self.tags.val` and `num_fields >= 1`.
+- **Tag-check coverage:** yes — `read_con_tag` check follows the `TAG_CON` check.
+- **Failure mode on shape mismatch:** `YieldError variant returned` (`YieldError::BadValFields` if `num_fields < 1`)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_yield_done_val`
+- **Notes:** Writer: `codegen/src/emit/expr.rs` (Con emission). Pair: `tidepool-eval/src/eval.rs` (Value::Done).
+
+## parse_result: E shape extraction
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`parse_result` dispatch)
+- **Reads:** `num_fields` (16), `fields[0]` (24), `fields[1]` (32)
+- **Expected shape:** `TAG_CON` with `con_tag == self.tags.e` and `num_fields == 2`.
+- **Tag-check coverage:** yes — part of the `con_tag` dispatch.
+- **Failure mode on shape mismatch:** `YieldError variant returned` (`YieldError::BadEFields`)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_yield_request_e`
+- **Notes:** Extracts `union_ptr` and `continuation`. Writer: `codegen/src/emit/expr.rs`.
+
+## parse_result: Union object header/field checks
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`parse_result` union extraction)
+- **Reads:** byte at `*union_ptr` (0), `num_fields` (16)
+- **Expected shape:** `TAG_CON` with `num_fields == 2`.
+- **Tag-check coverage:** yes — verifies `union_tag == layout::TAG_CON` and `union_num_fields == 2`.
+- **Failure mode on shape mismatch:** `YieldError variant returned` (`YieldError::UnexpectedTag` or `YieldError::BadUnionFields`)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_yield_request_e`
+- **Notes:** The Union wrapper is produced by `freer-simple`'s `E` constructor.
+
+## parse_result: Union position-tag boxing branch
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`parse_result` union tag read)
+- **Reads:** byte at `*tag_ptr` (0), then either `LIT_VALUE_OFFSET` (16) or `field[0]` (24) of boxed `Con`.
+- **Expected shape:** Either `TAG_LIT` (unboxed `Word#`) or `TAG_CON` (boxed `W# n`).
+- **Tag-check coverage:** yes — branch on `tag_ptr_tag == layout::TAG_LIT` vs `layout::TAG_CON`.
+- **Failure mode on shape mismatch:** `YieldError variant returned` (`YieldError::UnexpectedTag`)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_yield_request_e_boxed_tag`
+- **Notes:** Recent fix in PR #272. Necessary for cross-module compilation where GHC might not unbox the effect tag.
+
+## parse_result: Union request extraction
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`parse_result` union request extraction)
+- **Reads:** `fields[1]` (32) of Union object.
+- **Expected shape:** `TAG_CON` (Union) with at least 2 fields.
+- **Tag-check coverage:** yes — depends on the `union_num_fields == 2` check.
+- **Failure mode on shape mismatch:** `UB` (if `union_num_fields` check were bypassed)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_yield_request_e`
+- **Notes:** Extracts the actual effect request object.
+
+## force_ptr: Thunk tag check
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`force_ptr`)
+- **Reads:** byte at `*current` (0)
+- **Expected shape:** Any valid `HeapObject`.
+- **Tag-check coverage:** yes — verifies `tag == layout::TAG_THUNK`.
+- **Failure mode on shape mismatch:** `silent fallback: returns current`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs` (via lazy fields)
+- **Notes:** Transparently forces thunks. Crucial because `Con` fields in JIT-compiled code are often lazy.
+
+## apply_cont_heap: Continuation tag check
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`apply_cont_heap`)
+- **Reads:** byte at `*k` (0)
+- **Expected shape:** `TAG_CON` (Leaf/Node) or `TAG_CLOSURE`.
+- **Tag-check coverage:** yes — `match tag` covers `TAG_CON` and `TAG_CLOSURE`.
+- **Failure mode on shape mismatch:** `silent fallback: returns null_mut` (logged via `push_diagnostic`)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_resume_leaf_identity`
+- **Notes:** Writer: `tidepool-eval/src/eval.rs` or `alloc_con` in `effect_machine.rs`.
+
+## apply_cont_heap: Leaf/Node con_tag dispatch
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`apply_cont_heap` loop)
+- **Reads:** `con_tag` (8), then `field[0]` (24) for Leaf, or `field[0], field[1]` for Node.
+- **Expected shape:** `TAG_CON` with `con_tag` being `leaf` (arity 1) or `node` (arity 2).
+- **Tag-check coverage:** yes — follows `tag == layout::TAG_CON` check.
+- **Failure mode on shape mismatch:** `silent fallback: returns null_mut` (diagnostic)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_resume_node_identity`
+- **Notes:** Iterative work-stack tree walking. `Leaf` contains a closure; `Node` contains two continuations.
+
+## apply_cont_heap: Closure tag check
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`apply_cont_heap` closure arm)
+- **Reads:** none (already read `tag`)
+- **Expected shape:** `TAG_CLOSURE`.
+- **Tag-check coverage:** yes — part of the `match tag` dispatch.
+- **Failure mode on shape mismatch:** `silent fallback: returns null_mut` (diagnostic)
+- **Mode:** `always-on`
+- **Test coverage:** `uncovered`
+- **Notes:** Degenerate case where a raw closure is used as a continuation.
+
+## apply_cont_heap: Result tag/con_tag check
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`apply_cont_heap` result check)
+- **Reads:** byte at `*result` (0), `con_tag` (8)
+- **Expected shape:** `TAG_CON` with `con_tag == val` or `e`.
+- **Tag-check coverage:** yes — verifies `result_tag == layout::TAG_CON`.
+- **Failure mode on shape mismatch:** `silent fallback: returns null_mut` (diagnostic)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs`
+- **Notes:** Verifies the result of a continuation application is a valid `Eff` value.
+
+## apply_cont_heap: Val(y) composition
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`apply_cont_heap` Val arm)
+- **Reads:** `field[0]` (24) of `Val` result.
+- **Expected shape:** `TAG_CON` with `con_tag == val`.
+- **Tag-check coverage:** yes — dispatch on `result_con_tag == self.tags.val`.
+- **Failure mode on shape mismatch:** `UB` (if dispatch logic were faulty)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_resume_node_identity`
+- **Notes:** Intermediate `Val` results in a `Node` chain trigger the next continuation.
+
+## apply_cont_heap: E(union, k') composition
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`apply_cont_heap` E arm)
+- **Reads:** `field[0]` (24) and `field[1]` (32) of `E` result.
+- **Expected shape:** `TAG_CON` with `con_tag == e`.
+- **Tag-check coverage:** yes — dispatch on `result_con_tag == self.tags.e`.
+- **Failure mode on shape mismatch:** `UB`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_resume_node_with_effect_result`
+- **Notes:** Composition of effectful results. Re-wraps the union and composes the remaining continuation stack.
+
+## call_closure: Code pointer read
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`call_closure`)
+- **Reads:** `usize` at `CLOSURE_CODE_PTR_OFFSET` (8)
+- **Expected shape:** `TAG_CLOSURE` header.
+- **Tag-check coverage:** no — fragility (callers must ensure `closure` is a `TAG_CLOSURE`).
+- **Failure mode on shape mismatch:** `UB` (jumps to arbitrary address read from heap)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs:test_resume_leaf_identity`
+- **Notes:** Critical path. Writer: `codegen/src/emit/expr.rs`. Pair: `heap_bridge.rs`.
+
+## call_closure: Captured fields read
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`call_closure` tracing)
+- **Reads:** `u16` at `CLOSURE_NUM_CAPTURED_OFFSET` (16), `*const u8` at `CLOSURE_CAPTURED_OFFSET + 8*i` (24+)
+- **Expected shape:** `TAG_CLOSURE` with `num_captured` correctly set.
+- **Tag-check coverage:** no — fragility.
+- **Failure mode on shape mismatch:** `UB` (tracing-only, but could crash during debug log)
+- **Mode:** `mode-dependent: debug/trace`
+- **Test coverage:** `uncovered` (requires trace level >= Heap)
+- **Notes:** Only used for tracing/validation in `call_closure`.
+
+## resolve_tail_calls: Cancellation safepoint
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`resolve_tail_calls`)
+- **Reads:** `VMContext.tail_callee` (24), `VMContext.tail_arg` (32)
+- **Expected shape:** Non-null `tail_callee` implies a pending tail call.
+- **Tag-check coverage:** no — fragility (assumes JIT set valid heap pointers).
+- **Failure mode on shape mismatch:** `UB` (eventual crash in `call_closure`)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/external_cancellation.rs`
+- **Notes:** The cancellation check `check_cancel_and_set_error` is a major safepoint.
+
+## resolve_tail_calls: Code pointer read
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`resolve_tail_calls` loop)
+- **Reads:** `usize` at `CLOSURE_CODE_PTR_OFFSET` (8) of `callee`.
+- **Expected shape:** `TAG_CLOSURE` header on `callee`.
+- **Tag-check coverage:** no — fragility.
+- **Failure mode on shape mismatch:** `UB` (jump to garbage)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/external_cancellation.rs`
+- **Notes:** Duplicates `call_closure` logic for the tail-call loop to avoid recursion.
+
+## alloc_con: Heap layout write
+
+- **Location:** `tidepool-codegen/src/effect_machine.rs` (`alloc_con`)
+- **Reads:** none (write site)
+- **Expected shape:** `TAG_CON` header, `con_tag`, `num_fields`, and `fields`.
+- **Tag-check coverage:** n/a (it's the writer)
+- **Failure mode on shape mismatch:** `UB` (if allocation size is miscalculated)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/effect_machine.rs` (via `resume` and `Node` composition)
+- **Notes:** Primary producer of composed `Node` and `E` objects in the machine. Layout must stay in sync with `tidepool-heap`.

--- a/docs/core-shapes/audit-heap-bridge.md
+++ b/docs/core-shapes/audit-heap-bridge.md
@@ -1,0 +1,205 @@
+# Audit: heap_bridge.rs
+
+## Null pointer guard
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:76` (`heap_to_value_inner`)
+- **Reads:** `ptr`
+- **Expected shape:** Non-null pointer to a `HeapObject`
+- **Decoded into:** N/A (guard)
+- **Failure mode on shape mismatch:** `BridgeError::NullPointer`
+- **Bound checks:** `ptr.is_null()`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:556` (`test_null_pointer_error`)
+- **Notes:** Fundamental safety check before any offset-based reads.
+
+## Recursion depth guard
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:79` (`heap_to_value_inner`)
+- **Reads:** `depth` (recursion parameter)
+- **Expected shape:** Object graph depth within safety limits
+- **Decoded into:** N/A (guard)
+- **Failure mode on shape mismatch:** `BridgeError::TooDeep`
+- **Bound checks:** `MAX_DEPTH` (10,000)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/tests/heap_bridge_tests.rs:64` (`test_heap_to_value_deeply_nested_cons`)
+- **Notes:** Prevents stack overflow when decoding circular or extremely deep structures (e.g. large linked lists).
+
+## LitTag dispatch
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:86` (`heap_to_value_inner`)
+- **Reads:** `*ptr.add(layout::LIT_TAG_OFFSET as usize)`
+- **Expected shape:** `TAG_LIT` header, followed by a valid `LitTag` at offset 8
+- **Decoded into:** N/A (dispatch)
+- **Failure mode on shape mismatch:** `BridgeError::UnexpectedLitTag`
+- **Bound checks:** None
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:364` (and many others)
+- **Notes:** Primary entry point for all primitive decoding.
+
+## LitTag::Int
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:90` (`heap_to_value_inner`)
+- **Reads:** `*(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const i64)`
+- **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_INT` (0); 64-bit integer at offset 16
+- **Decoded into:** `Value::Lit(Literal::LitInt(_))`
+- **Failure mode on shape mismatch:** `BridgeError::UnexpectedLitTag` (if tag mismatches)
+- **Bound checks:** None
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:364`, `tidepool-codegen/tests/heap_bridge_tests.rs:10`
+- **Notes:** Assumes bit-representation of Haskell `Int#` matches Rust `i64`.
+
+## LitTag::Word
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:91` (`heap_to_value_inner`)
+- **Reads:** `*(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const i64)`
+- **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_WORD` (1); 64-bit word at offset 16
+- **Decoded into:** `Value::Lit(Literal::LitWord(_))`
+- **Failure mode on shape mismatch:** `BridgeError::UnexpectedLitTag`
+- **Bound checks:** None
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:378`
+- **Notes:** Interprets the `i64` heap value as `u64`.
+
+## LitTag::Char
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:92` (`heap_to_value_inner`)
+- **Reads:** `*(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const i64)`
+- **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_CHAR` (2); 32-bit Unicode scalar zero-extended to 64-bit at offset 16
+- **Decoded into:** `Value::Lit(Literal::LitChar(_))`
+- **Failure mode on shape mismatch:** `silent fallback: char::from_u32(...).unwrap_or('\0')`
+- **Bound checks:** None
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:392`
+- **Notes:** Silent fallback to NUL if the heap contains invalid Unicode data.
+
+## LitTag::Float / LitTag::Double
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:95` (`heap_to_value_inner`)
+- **Reads:** `*(ptr.add(layout::LIT_VALUE_OFFSET as usize) as *const i64)`
+- **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_FLOAT` (3) or `LIT_TAG_DOUBLE` (4); raw bits at offset 16
+- **Decoded into:** `Value::Lit(Literal::LitFloat(_))` | `Value::Lit(Literal::LitDouble(_))`
+- **Failure mode on shape mismatch:** `BridgeError::UnexpectedLitTag`
+- **Bound checks:** None
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:406` (Double), `tidepool-codegen/src/heap_bridge.rs:541` (Float)
+- **Notes:** IEEE 754 bits are passed through as `u64`.
+
+## LitTag::String
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:97` (`heap_to_value_inner`)
+- **Reads:** `raw_value` as `*const u8` pointer; `std::ptr::read_unaligned(data_ptr as *const u64)` for length
+- **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_STRING` (5). Pointer at offset 16 targets a buffer: `[len: u64][bytes...]`
+- **Decoded into:** `Value::Lit(Literal::LitString(_))`
+- **Failure mode on shape mismatch:** `BridgeError::NullPointer` (if data pointer is null) | `BridgeError::DataTooLarge` (if len > 64MB)
+- **Bound checks:** `MAX_DATA_SIZE` (64MB)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:419`
+- **Notes:** Uses `read_unaligned` because string data in JIT data sections may lack 8-byte alignment.
+
+## LitTag::Addr fallback
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:112` (`heap_to_value_inner`)
+- **Reads:** Tag only
+- **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_ADDR` (6)
+- **Decoded into:** `Value::Lit(Literal::LitString(vec![]))`
+- **Failure mode on shape mismatch:** `silent fallback: produces empty LitString`
+- **Bound checks:** None
+- **Mode:** `always-on`
+- **Test coverage:** `uncovered`
+- **Notes:** `Addr#` is a raw machine address. The bridge suppresses it for safety, returning an empty string instead of risking UB from an opaque pointer.
+
+## LitTag::ByteArray
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:117` (`heap_to_value_inner`)
+- **Reads:** `raw_value` as `*const u8` pointer; length from `ba_ptr`
+- **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_BYTEARRAY` (7). Pointer at offset 16 targets a malloc-allocated buffer: `[len: u64][bytes...]`
+- **Decoded into:** `Value::ByteArray(_)` (Arc<Mutex<Vec<u8>>>)
+- **Failure mode on shape mismatch:** `silent fallback: Value::ByteArray(empty)` if pointer is null | `BridgeError::DataTooLarge`
+- **Bound checks:** `MAX_DATA_SIZE` (64MB)
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:502`
+- **Notes:** `ByteArray#` data lives outside the GC nursery to prevent use-after- Cheney-copy bugs.
+
+## LitTag::Array / LitTag::SmallArray
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:135` (`heap_to_value_inner`)
+- **Reads:** `raw_value` as `*const u8` pointer; length from `arr_ptr`; field pointers from `arr_ptr.add(8 + 8*i)`
+- **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_SMALLARRAY` (8) or `LIT_TAG_ARRAY` (9). Pointer targets: `[len: u64][ptr0][ptr1]...`
+- **Decoded into:** `Value::Con(DataConId(0), elems)`
+- **Failure mode on shape mismatch:** `silent fallback: Value::Con(DataConId(0), vec![])` if pointer is null | `BridgeError::DataTooLarge`
+- **Bound checks:** `MAX_DATA_SIZE` (64MB), `MAX_DEPTH` (via recursion)
+- **Mode:** `always-on`
+- **Test coverage:** `uncovered`
+- **Notes:** Coerces boxed pointer arrays into a generic `Con(0, ...)` structure. Semantic meaning depends on the wrapping Haskell constructor.
+
+## TAG_CON field decoding
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:160` (`heap_to_value_inner`)
+- **Reads:** `con_tag` (u64) at `layout::CON_TAG_OFFSET` (8); `num_fields` (u16) at `layout::CON_NUM_FIELDS_OFFSET` (16); pointers at `layout::CON_FIELDS_OFFSET + 8*i` (24+)
+- **Expected shape:** `TAG_CON` header, followed by DataConId, arity, and an array of pointers to other `HeapObject`s.
+- **Decoded into:** `Value::Con(DataConId(con_tag), fields)`
+- **Failure mode on shape mismatch:** `BridgeError::TooManyFields` (if arity > 1024) | `BridgeError` from recursive field decodes
+- **Bound checks:** `MAX_FIELDS` (1024), `MAX_DEPTH`
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:435`, `450`, `475`, `tidepool-codegen/tests/heap_bridge_tests.rs:27`
+- **Notes:** Fundamental assumption: every field of a `Con` is a valid 8-byte aligned `HeapObject` pointer. Unboxed fields in a `Con` will cause a crash/UB during recursive decoding.
+
+## TAG_THUNK evaluated (Indirection)
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:179` (`heap_to_value_inner`)
+- **Reads:** `THUNK_STATE_OFFSET` (8); `THUNK_INDIRECTION_OFFSET` (16)
+- **Expected shape:** `TAG_THUNK` with state `layout::THUNK_EVALUATED` (2). Offset 16 contains an indirection pointer to the result.
+- **Decoded into:** `Value` (via recursion into the target)
+- **Failure mode on shape mismatch:** `BridgeError` from recursion
+- **Bound checks:** `MAX_DEPTH`
+- **Mode:** `always-on`
+- **Test coverage:** `uncovered`
+- **Notes:** Follows the "D7" update pattern. Crucial for correctness when the bridge encounters an already-forced thunk.
+
+## TAG_THUNK forcing
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:186` (`heap_to_value_inner`)
+- **Reads:** `vmctx` parameter; calls `crate::host_fns::heap_force`
+- **Expected shape:** `TAG_THUNK` in any unevaluated state
+- **Decoded into:** `Value` (result of the forced computation)
+- **Failure mode on shape mismatch:** `BridgeError::UnevaluatedThunk` (if forcing fails to progress)
+- **Bound checks:** None
+- **Mode:** `mode-dependent: requires non-null vmctx`
+- **Test coverage:** `uncovered`
+- **Notes:** The bridge triggers side-effects (JIT execution) when `heap_to_value_forcing` is used.
+
+## TAG_THUNK failure states
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:195` (`heap_to_value_inner`)
+- **Reads:** `THUNK_STATE_OFFSET` (8)
+- **Expected shape:** `TAG_THUNK` with state `layout::THUNK_UNEVALUATED` (0) or `layout::THUNK_BLACKHOLE` (1)
+- **Decoded into:** N/A (error)
+- **Failure mode on shape mismatch:** `BridgeError::UnevaluatedThunk` | `BridgeError::BlackHole` | `BridgeError::UnknownThunkState`
+- **Bound checks:** None
+- **Mode:** `always-on` (when `vmctx` is null)
+- **Test coverage:** `uncovered`
+- **Notes:** `BlackHole` indicates a thunk that depends on its own result (infinite loop).
+
+## TAG_CLOSURE opaque representation
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:200` (`heap_to_value_inner`)
+- **Reads:** Tag only
+- **Expected shape:** `TAG_CLOSURE` header
+- **Decoded into:** `Value::Closure(Env::new(), VarId(0), dummy_expr)`
+- **Failure mode on shape mismatch:** `silent fallback: produces dummy opaque Closure`
+- **Bound checks:** None
+- **Mode:** `always-on`
+- **Test coverage:** `uncovered`
+- **Notes:** Closures are opaque to the bridge. They are represented as a dummy `Closure` to avoid failing the entire bridge traversal, allowing partially-evaluated structures (like `Array#` containing closures) to be inspected.
+
+## Unexpected heap tag
+
+- **Location:** `tidepool-codegen/src/heap_bridge.rs:211` (`heap_to_value_inner`)
+- **Reads:** `tag` byte at offset 0
+- **Expected shape:** One of `TAG_CLOSURE`, `TAG_THUNK`, `TAG_CON`, `TAG_LIT`
+- **Decoded into:** N/A (error)
+- **Failure mode on shape mismatch:** `BridgeError::UnexpectedHeapTag(tag)`
+- **Bound checks:** None
+- **Mode:** `always-on`
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs:563` (`test_invalid_heap_tag`)
+- **Notes:** Catch-all for memory corruption or unsynchronized `tidepool-heap` / `tidepool-codegen` layout constants.

--- a/docs/core-shapes/audit-heap-bridge.md
+++ b/docs/core-shapes/audit-heap-bridge.md
@@ -102,11 +102,11 @@
 - **Reads:** Tag only
 - **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_ADDR` (6)
 - **Decoded into:** `Value::Lit(Literal::LitString(vec![]))`
-- **Failure mode on shape mismatch:** `silent fallback: produces empty LitString`
+- **Failure mode on shape mismatch:** `intentional fallback: produces empty LitString`
 - **Bound checks:** None
-- **Mode:** `always-on`
+- **Mode:** `always-on` — `Addr#` is a legitimate intermediate runtime value emitted by primops (`PlusAddr`, `ShowDoubleAddr`; see `tidepool-codegen/src/emit/primop.rs` for `SsaVal::Raw(_, LIT_TAG_ADDR)` sites).
 - **Test coverage:** `uncovered`
-- **Notes:** `Addr#` is a raw machine address. The bridge suppresses it for safety, returning an empty string instead of risking UB from an opaque pointer.
+- **Notes:** Not a defensive guard against translator bugs. The bridge can't decode a raw pointer back to a typed Haskell value (no length, no type tag), so empty `LitString` is the safe display fallback when an `Addr#` is the top-level result. Programs that compose `Addr#` with `unpackCString#` etc. don't hit this path because they evaluate to a real string before reaching the bridge.
 
 ## LitTag::ByteArray
 

--- a/docs/core-shapes/audit-translate.md
+++ b/docs/core-shapes/audit-translate.md
@@ -1,0 +1,301 @@
+# Audit: Translate.hs
+
+## emitRuntimeUnpackCString
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:131` (`emitRuntimeUnpackCString`)
+- **Trigger shape:** `unpackCString# addr` where `addr` is not a static literal (e.g. `plusAddr# a 1#`)
+- **Normalized output:** `NLetRec` wrapping a recursive lambda using `IndexCharOffAddr` and `PlusAddr` primops to build a `(:)` chain
+- **Mode:** `always-on`
+- **Motivation:** GHC's `unpackCString#` unfolding relies on `Addr#` arithmetic which the JIT avoids; this provides a safe runtime implementation for dynamic strings.
+- **Test coverage:** `uncovered` (most strings in tests are static literals)
+- **Notes:** Used as a fallback for `isUnpackCStringVar` and `isShowDoubleVar` intercepts.
+
+## emitRuntimeUnpackAppendCString
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:172` (`emitRuntimeUnpackAppendCString`)
+- **Trigger shape:** `unpackAppendCString# addr suffix` where `addr` is not a static literal
+- **Normalized output:** `NLetRec` recursive loop similar to `emitRuntimeUnpackCString` but terminates with `suffix` instead of `[]`
+- **Mode:** `always-on`
+- **Motivation:** Handles dynamic strings in `(++)` or `show` that GHC optimizes into `unpackAppendCString#`.
+- **Test coverage:** `uncovered`
+- **Notes:** Used by `isShowDoubleSpecVar` to preserve the `ShowS` continuation.
+
+## emitShowDoubleSpecBody
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:210` (`emitShowDoubleSpecBody`)
+- **Trigger shape:** `$fShowDouble_$sshowSignedFloat` binder (GHC's specialized `show` for `Double`)
+- **Normalized output:** `NLam` chain wrapping `emitRuntimeUnpackAppendCString` using `ShowDoubleAddr` primop
+- **Mode:** `always-on`
+- **Motivation:** GHC's `floatToDigits` / `Integer` pipeline used in standard `show` for `Double` is too complex for the JIT and pulls in incompatible library code.
+- **Test coverage:** `showDoublePrelude` in `haskell/test/Suite.hs`, `test_show_double` in `tidepool-runtime/tests/repro_split.rs`
+- **Notes:** Cited in memory note #17. Essential for `Show` instances on `Double`.
+
+## reachableBinds
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:282` (`reachableBinds`)
+- **Trigger shape:** List of `CoreBind` during module translation
+- **Normalized output:** Filtered list of `CoreBind` containing only transitively reachable bindings
+- **Mode:** `always-on`
+- **Motivation:** Prevents single large `Rec` groups from pulling in the entire transitive closure of a module's bindings, reducing node count and avoiding resolution failures.
+- **Test coverage:** `prelude_length` in `haskell/test/Suite.hs` (exercises reachability into `Tidepool.Prelude`)
+- **Notes:** Uses fine-grained reachability by flattening `Rec` groups into individual pairs for analysis.
+
+## isShowDoubleVar intercept
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:484` (`translate`)
+- **Trigger shape:** `Var showDouble` (or `showDouble'`) applied to 0 or 1 args
+- **Normalized output:** `NPrimOp "ShowDoubleAddr"` followed by `emitRuntimeUnpackCString`
+- **Mode:** `always-on`
+- **Motivation:** Direct interception of `Double` to `String` conversion to bypass GHC's `Integer`-heavy pipeline.
+- **Test coverage:** `show_double` in `tidepool-eval/tests/haskell_suite.rs`, `showDouble` in `haskell/test/Suite.hs`
+- **Notes:** Memory #17. Handles both direct calls and eta-expanded variants.
+
+## isShowDoubleSpecVar intercept
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:503` (`translate`)
+- **Trigger shape:** `Var $fShowDouble_$sshowSignedFloat` (specialized `Double` show)
+- **Normalized output:** `NPrimOp "ShowDoubleAddr"` followed by `emitRuntimeUnpackAppendCString`
+- **Mode:** `always-on`
+- **Motivation:** Intercepts specialized versions produced by GHC -O2 that include the `ShowS` continuation.
+- **Test coverage:** `showDoublePrelude` in `haskell/test/Suite.hs`
+- **Notes:** Memory #17. Crucial for derived `Show` instances on types containing `Double`.
+
+## isUnpackCStringVar static desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:527` (`translate`)
+- **Trigger shape:** `unpackCString# "lit"#` or `unpackCStringUtf8# "lit"#`
+- **Normalized output:** Static `NCon` chain of `(:)` cells (cons-cells)
+- **Mode:** `always-on`
+- **Motivation:** Converts `Addr#` literals into uniform heap-allocated `[Char]` so that case matching and list functions work correctly.
+- **Test coverage:** `lit_char_a` (via character literals), `text_pack` in `haskell/test/TextSuite.hs`
+- **Notes:** Essential for all string literal handling in Core.
+
+## isUnpackCStringVar dynamic fallback
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:545` (`translate`)
+- **Trigger shape:** `unpackCString# addr` where `addr` is a variable
+- **Normalized output:** `emitRuntimeUnpackCString` call
+- **Mode:** `always-on`
+- **Motivation:** Handles non-static `Addr#` values (e.g. from pointer arithmetic) gracefully at runtime.
+- **Test coverage:** `uncovered`
+- **Notes:** Less common than the static version.
+
+## isUnpackAppendCStringVar dynamic fallback
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:554` (`translate`)
+- **Trigger shape:** `unpackAppendCString# addr suffix` where `addr` is dynamic
+- **Normalized output:** `emitRuntimeUnpackAppendCString` call
+- **Mode:** `always-on`
+- **Motivation:** Support for dynamic string concatenation/appending optimized by GHC.
+- **Test coverage:** `uncovered`
+- **Notes:** Memory note #13.
+
+## isUnpackAppendCStringVar partial/eta-reduced
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:564` (`translate`)
+- **Trigger shape:** `unpackAppendCString#` applied to 0 or 1 arguments
+- **Normalized output:** `NLam` wrapper around runtime or static unpack loop
+- **Mode:** `always-on`
+- **Motivation:** Handles eta-reduced applications of the builtin, common in specialized `Show` instances.
+- **Test coverage:** `showDoublePrelude` in `haskell/test/Suite.hs`
+- **Notes:** Line 591 handles the zero-arg case specifically.
+
+## isUnpackAppendCStringVar static prefix desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:604` (`translate`)
+- **Trigger shape:** `unpackAppendCString# "prefix"# suffix`
+- **Normalized output:** Static `NCon` chain of `(:)` cells ending in `suffix`
+- **Mode:** `always-on`
+- **Motivation:** Optimal conversion of static prefix strings with dynamic tails.
+- **Test coverage:** `showInt` in `haskell/test/Suite.hs` (specialized show often uses this)
+- **Notes:** Memory note #13.
+
+## isErrorVar intercept
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:619` (`translate`)
+- **Trigger shape:** `Var error` (and variants like `patError`, `recSelError`) applied to arguments
+- **Normalized output:** `NApp` to error handler node (VarId 0x45...02) with extracted message literal
+- **Mode:** `always-on`
+- **Motivation:** Preserves the error message string as a `LEString` literal so the JIT can report it, rather than just crashing.
+- **Test coverage:** PR #153, memory note #5.
+- **Notes:** Extracts message from `unpackCString#` or `PushCallStack` wrappers recursively.
+
+## isUnpackFoldrCStringVar static desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:638` (`translate`)
+- **Trigger shape:** `unpackFoldrCString# "lit"# f z`
+- **Normalized output:** Static application chain `f c1 (f c2 (... z))`
+- **Mode:** `always-on`
+- **Motivation:** Handles GHC's build/foldr fusion for string literals without requiring runtime `Addr#` arithmetic.
+- **Test coverage:** Memory note #11.
+- **Notes:** Avoids complex unfoldings of `unpackFoldrCString#`.
+
+## isAppendVar desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:654` (`translate`)
+- **Trigger shape:** `Var (++)` applied to 2 arguments
+- **Normalized output:** `NLetRec` recursive loop implementing list concatenation
+- **Mode:** `always-on`
+- **Motivation:** `GHC.Internal.Base.++` often has no unfolding in `.hi` files; this provides a reliable, JIT-friendly implementation.
+- **Test coverage:** `prelude_string_append` in `haskell/test/Suite.hs`, `tidepool-runtime/tests/text_spliton.rs`
+- **Notes:** Memory note #12.
+
+## isUnsafeTakeVar desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:686` (`translate`)
+- **Trigger shape:** `Var $wunsafeTake` or `unsafeTake` applied to 2 arguments
+- **Normalized output:** `NLetRec` recursive loop with unboxed `Int#` counter and `IntLe`/`IntSub` primops
+- **Mode:** `always-on`
+- **Motivation:** GHC worker-wrappers for `take` at -O2 result in `unsafeTake` calls whose unfoldings are often missing or rely on complex pointer logic.
+- **Test coverage:** `prelude_take` in `haskell/test/Suite.hs`
+- **Notes:** Memory note #16.
+
+## isUnsafeEqualityProofVar desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:752` (`translate`)
+- **Trigger shape:** `Var unsafeEqualityProof`
+- **Normalized output:** `NCon` unit value (`()`)
+- **Mode:** `always-on`
+- **Motivation:** GHC uses this for GADT equality evidence. Emitting a unit value allows it to be erased or matched against `UnsafeRefl` (unit constructor) safely.
+- **Test coverage:** PR #71, `tidepool-runtime/tests/multi_module_datacon.rs`
+- **Notes:** Memory note #1.
+
+## isRunRWVar desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:761` (`translate`)
+- **Trigger shape:** `runRW# f`
+- **Normalized output:** `NApp f ()` (state token erasure)
+- **Mode:** `always-on`
+- **Motivation:** `runRW#` is the underlying primop for `unsafePerformIO`. Erasing the state token allows pure JIT execution of IO-based initialization.
+- **Test coverage:** Memory note #14.
+- **Notes:** Handles both direct application and eta-reduced variants.
+
+## tagToEnum# desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:778` (`translate`)
+- **Trigger shape:** `tagToEnum# @T arg`
+- **Normalized output:** `NCase` on `arg` with one `FLitAlt` per constructor of type `T`
+- **Mode:** `always-on`
+- **Motivation:** `tagToEnum#` is a magical primop that requires type information erased at runtime; desugaring to a `Case` preserves the mapping.
+- **Test coverage:** Memory note #2.
+- **Notes:** Requires resolvable type argument `T` to identify the target `TyCon`.
+
+## isRuntimeErrorVar / isErrorVar handling
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:832` (`translateHead`)
+- **Trigger shape:** `divZeroError`, `overflowError`, or general `error` / `undefined`
+- **Normalized output:** `NVar` with special error tag `0x45...`
+- **Mode:** `always-on`
+- **Motivation:** Converts known GHC error sentinels into JIT-native error nodes that trigger safe traps.
+- **Test coverage:** Memory note #5, #15.
+- **Notes:** Includes `undefined` (kind 3) and `divZeroError` (kind 0).
+
+## isRealWorldVar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:837` (`translateHead`)
+- **Trigger shape:** `Var realWorld#`
+- **Normalized output:** `NLit (LEInt 0)` (dummy literal)
+- **Mode:** `always-on`
+- **Motivation:** Erases the `RealWorld#` state token which has no runtime representation in the JIT.
+- **Test coverage:** `uncovered`
+- **Notes:** Part of state-token erasure pipeline.
+
+## isTypeMetadataVar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:839` (`translateHead`)
+- **Trigger shape:** Variables starting with `$trModule`, `$krep`, `$tc`, etc.
+- **Normalized output:** `NVar` with error tag (kind 4 - type metadata)
+- **Mode:** `always-on`
+- **Motivation:** GHC generates massive amounts of Typeable metadata that have no runtime use in Tidepool; emitting error nodes avoids resolving useless unfoldings.
+- **Test coverage:** Memory note #9.
+- **Notes:** These vars are skipped by the resolver but can appear in inlined code.
+
+## jumpCrossesLam (Join Point conversion)
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:854` (`translateHead`)
+- **Trigger shape:** `Let (NonRec b rhs) body` where `b` is a join point used inside a lambda in `body`
+- **Normalized output:** `NLetNonRec` wrapping a lambda (regular function) instead of `NJoin`
+- **Mode:** `always-on`
+- **Motivation:** Cranelift blocks (used for `NJoin`) cannot be jumped to from separate lambda functions; this promotes them to full closures.
+- **Test coverage:** Memory note #10.
+- **Notes:** Also applies to `Let (Rec ...)` joinrec binders at line 863.
+
+## splitMultiReturnPrimOp desugar
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:902` (`translateHead`)
+- **Trigger shape:** `Case (op a b) of (# q, r #) -> body` where `op` is `quotRemInt#`, etc.
+- **Normalized output:** Nested `NCase` nodes each calling a single-return version of the primop (e.g. `IntQuot` and `IntRem`)
+- **Mode:** `always-on`
+- **Motivation:** The JIT backend prefers single-result primops for simplicity; this ensures shared arguments and correct forcing.
+- **Test coverage:** PR #71, `prim_quot_rem_int` in `haskell/test/Suite.hs`
+- **Notes:** Also handles unary (`decodeDouble_Int64#`) and triple-return (`timesInt2#`) variants.
+
+## Stateful primop state erasure
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:960` (`translateHead`)
+- **Trigger shape:** `Case (op args... s) of (# s', results... #) -> body`
+- **Normalized output:** `NPrimOp` with `s` dropped, results bound via `NCase`, `s'` bound to dummy
+- **Mode:** `always-on`
+- **Motivation:** Supports stateful primops (like `readSmallArray#`) by stripping the `State#` tokens that Tidepool does not represent at runtime.
+- **Test coverage:** Memory note #14.
+- **Notes:** Crucial for all mutable state / IO operations in the JIT.
+
+## isUnboxedTupleDataCon (general)
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:1022` (`translateHead`)
+- **Trigger shape:** `Case scrut of (# binders #) -> body`
+- **Normalized output:** `NCase` with `FDataAlt` for multi-element or `FDefault` for single-element/void
+- **Mode:** `always-on`
+- **Motivation:** Uniform handling of unboxed tuples as ephemeral heap boxes or literals.
+- **Test coverage:** `case_pair` in `haskell/test/Suite.hs`
+- **Notes:** Handles zero, single, and multiple binders.
+
+## isUnsafeEqualityCase elision
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:1047` (`translateHead`)
+- **Trigger shape:** `case unsafeEqualityProof of UnsafeRefl -> body`
+- **Normalized output:** Direct translation of `body` (case elided)
+- **Mode:** `always-on`
+- **Motivation:** PR #272. Inlined `unsafeEqualityProof` cases survive GHC's optimizer; eliding them prevents tag mismatch (CASE TRAP) with unit-represented evidence.
+- **Test coverage:** PR #272, `tidepool-runtime/tests/multi_module_datacon.rs`
+- **Notes:** Memory note #1. Cited as a major cross-module bug fix.
+
+## Coercion placeholder
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:1059` (`translateHead`)
+- **Trigger shape:** `Coercion _` in expression position
+- **Normalized output:** `NLit (LEInt 0)` (dummy literal)
+- **Mode:** `defensive (no known triggering source)`
+- **Motivation:** Coercions are zero-cost; if they survive to expression position (rare), we provide a dummy value to avoid crashing the translator.
+- **Test coverage:** `uncovered`
+- **Notes:** Linked to GHC inlining through vendored code.
+
+## localVarId hash disambiguation
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:1090` (`localVarId`)
+- **Trigger shape:** Non-external `Var`
+- **Normalized output:** 64-bit ID hashed from `OccName` + GHC `Unique`
+- **Mode:** `always-on`
+- **Motivation:** Raw GHC uniques collide across modules when inlining; hashing with `OccName` disambiguates them and prevents "binder shadow" bugs.
+- **Test coverage:** `tidepool-runtime/tests/text_spliton.rs` (complex multi-module test)
+- **Notes:** Uses the lower 56 bits for the hash.
+
+## stableVarId
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:1113` (`stableVarId`)
+- **Trigger shape:** External `Name`
+- **Normalized output:** 64-bit ID with tag `0xFE`, hashed from `ModuleName:OccName`
+- **Mode:** `always-on`
+- **Motivation:** Ensures that external references (like `base:GHC.Base.map`) have identical IDs regardless of which module they are referenced from.
+- **Test coverage:** All cross-module tests.
+- **Notes:** Crucial for linking JIT-compiled modules with the runtime's wired-in DataCon table.
+
+## valueRepArity
+
+- **Location:** `haskell/src/Tidepool/Translate.hs:1446` (`valueRepArity`)
+- **Trigger shape:** `DataCon` arity calculation
+- **Normalized output:** `dataConRepArity` minus length of `EqSpec`
+- **Mode:** `always-on`
+- **Motivation:** GADT constructors include equality evidence in `dataConRepArity`, but Core passes these as `Coercion` args which are erased; this adjustment aligns the JIT arity with the Core application.
+- **Test coverage:** Memory note #8.
+- **Notes:** Prevents arity mismatch on GADT constructors in `freer-simple`.

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -9,6 +9,16 @@ use tidepool_repr::{DataConId, DataConTable, Literal};
 
 /// Check if a DataConId matches a known boxing constructor name (I#, W#, D#, C#).
 fn is_boxing_con(name: &str, id: DataConId, table: &DataConTable) -> bool {
+    #[cfg(debug_assertions)]
+    if matches!(name, "I#" | "W#" | "D#" | "C#") {
+        let matches = table.get_all_by_name(name);
+        debug_assert!(
+            matches.len() <= 1,
+            "core-shapes.md §10: ambiguous unqualified DataCon name '{}' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+            name,
+            matches
+        );
+    }
     table.get_by_name(name) == Some(id)
 }
 
@@ -145,6 +155,15 @@ impl FromCore for i64 {
 
 impl ToCore for i64 {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("I#");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name 'I#' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let id = table
             .get_by_name("I#")
             .ok_or_else(|| BridgeError::UnknownDataConName("I#".into()))?;
@@ -175,6 +194,15 @@ impl FromCore for u64 {
 
 impl ToCore for u64 {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("W#");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name 'W#' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let id = table
             .get_by_name("W#")
             .ok_or_else(|| BridgeError::UnknownDataConName("W#".into()))?;
@@ -327,6 +355,16 @@ impl ToCoreSealed for String {}
 
 impl FromCore for String {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
+        #[cfg(debug_assertions)]
+        for name in ["Text", "ByteArray", "[]"] {
+            let matches = table.get_all_by_name(name);
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '{}' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                name,
+                matches
+            );
+        }
         match value {
             // Text constructor: Text ByteArray# off len
             Value::Con(id, fields)
@@ -417,6 +455,15 @@ impl FromCore for String {
 
 impl ToCore for String {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("Text");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name 'Text' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let text_id = table
             .get_by_name("Text")
             .ok_or_else(|| BridgeError::UnknownDataConName("Text".into()))?;
@@ -508,6 +555,15 @@ impl<T> ToCoreSealed for Vec<T> {}
 
 impl<T: FromCore> FromCore for Vec<T> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("[]");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '[]' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let nil_id = table
             .get_by_name("[]")
             .ok_or(BridgeError::UnknownDataConName("[]".into()))?;
@@ -556,6 +612,15 @@ impl<T: FromCore> FromCore for Vec<T> {
 
 impl<T: ToCore> ToCore for Vec<T> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        {
+            let matches = table.get_all_by_name("[]");
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '[]' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                matches
+            );
+        }
         let nil_id = table
             .get_by_name("[]")
             .ok_or_else(|| BridgeError::UnknownDataConName("[]".into()))?;
@@ -576,6 +641,16 @@ impl<T, E> ToCoreSealed for Result<T, E> {}
 
 impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
     fn from_value(value: &Value, table: &DataConTable) -> Result<Self, BridgeError> {
+        #[cfg(debug_assertions)]
+        for name in ["Right", "Ok", "Left", "Err"] {
+            let matches = table.get_all_by_name(name);
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '{}' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                name,
+                matches
+            );
+        }
         match value {
             Value::Con(id, fields) => {
                 let right_id = table
@@ -618,6 +693,16 @@ impl<T: FromCore, E: FromCore> FromCore for Result<T, E> {
 
 impl<T: ToCore, E: ToCore> ToCore for Result<T, E> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
+        #[cfg(debug_assertions)]
+        for name in ["Right", "Ok", "Left", "Err"] {
+            let matches = table.get_all_by_name(name);
+            debug_assert!(
+                matches.len() <= 1,
+                "core-shapes.md §10: ambiguous unqualified DataCon name '{}' in cross-module compilation context; matches = {:?}. This impl should be migrated to get_by_name_arity or get_by_qualified_name.",
+                name,
+                matches
+            );
+        }
         match self {
             Ok(x) => {
                 let id = table

--- a/tidepool-bridge/tests/ambiguity_assert.rs
+++ b/tidepool-bridge/tests/ambiguity_assert.rs
@@ -1,0 +1,75 @@
+//! Cross-module unqualified-name ambiguity must fire the dossier-cited
+//! debug_assert in dev/test builds.
+//!
+//! The hand-written `FromCore`/`ToCore` impls in `tidepool-bridge/src/impls.rs`
+//! still call `table.get_by_name("I#")` (and similar) without arity or module
+//! qualification. PR #291 added `cfg(debug_assertions)` blocks that scan
+//! `get_all_by_name` and panic when more than one constructor shares the
+//! unqualified name — a guard against the cross-module collision class fixed
+//! in PR #272's derive but not yet migrated in the hand-written impls.
+//!
+//! Without this regression test the assertions could be silently weakened
+//! (e.g. by replacing `get_all_by_name` with `get_by_name` in the matches
+//! check) and the existing roundtrip / proptest suites would not notice —
+//! they all build tables with unique names.
+
+use tidepool_bridge::ToCore;
+use tidepool_repr::{DataCon, DataConId, DataConTable};
+
+/// Build a table containing two `I#` entries at distinct `DataConId`s,
+/// simulating cross-module compilation where the same unqualified name
+/// is introduced by independently-compiled modules.
+fn ambiguous_i_hash_table() -> DataConTable {
+    let mut t = DataConTable::new();
+    t.insert(DataCon {
+        id: DataConId(100),
+        name: "I#".into(),
+        tag: 1,
+        rep_arity: 1,
+        field_bangs: vec![],
+        qualified_name: Some("GHC.Internal.Types.I#".into()),
+    });
+    t.insert(DataCon {
+        id: DataConId(200),
+        name: "I#".into(),
+        tag: 1,
+        rep_arity: 1,
+        field_bangs: vec![],
+        qualified_name: Some("UserDefined.I#".into()),
+    });
+    t
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "core-shapes.md §10")]
+fn i_hash_ambiguity_trips_debug_assert() {
+    let table = ambiguous_i_hash_table();
+    // The i64 ToCore impl looks up "I#" via get_by_name; the cfg(debug_assertions)
+    // guard above the lookup scans get_all_by_name and panics on >1 match.
+    // Triggering the impl with any value is sufficient — the assertion fires
+    // before the lookup result is used.
+    let _ = 42i64.to_value(&table);
+}
+
+/// Sanity check that the assertion does NOT fire when the table is
+/// well-formed (single entry per name) — guards against false positives
+/// where the assert would trip on legitimate single-module compilation.
+#[test]
+fn unambiguous_i_hash_does_not_trip_assert() {
+    let mut t = DataConTable::new();
+    t.insert(DataCon {
+        id: DataConId(100),
+        name: "I#".into(),
+        tag: 1,
+        rep_arity: 1,
+        field_bangs: vec![],
+        qualified_name: Some("GHC.Internal.Types.I#".into()),
+    });
+    let result = 42i64.to_value(&t).expect("unambiguous I# must encode cleanly");
+    if let tidepool_eval::Value::Con(id, _) = result {
+        assert_eq!(id, DataConId(100));
+    } else {
+        panic!("expected Value::Con");
+    }
+}

--- a/tidepool-codegen/src/effect_machine.rs
+++ b/tidepool-codegen/src/effect_machine.rs
@@ -290,6 +290,15 @@ impl CompiledEffectMachine {
             }
             // SAFETY: current is non-null (checked above) and points to a valid heap object.
             let tag = unsafe { *current };
+            // core-shapes.md §9: pointer must have a valid heap tag before forcing or returning
+            debug_assert!(
+                matches!(
+                    tag,
+                    layout::TAG_THUNK | layout::TAG_CON | layout::TAG_LIT | layout::TAG_CLOSURE
+                ),
+                "core-shapes.md §9: unexpected heap tag {} in force_ptr",
+                tag
+            );
             if tag == layout::TAG_THUNK {
                 let vmctx = &mut self.vmctx as *mut VMContext;
                 current = crate::host_fns::heap_force(vmctx, current);
@@ -360,6 +369,12 @@ impl CompiledEffectMachine {
                         k = k1;
                         continue;
                     } else {
+                        // core-shapes.md §7: continuation must be Leaf or Node
+                        debug_assert!(
+                            false,
+                            "core-shapes.md §7: apply_cont_heap unexpected continuation con_tag {}",
+                            con_tag
+                        );
                         crate::host_fns::push_diagnostic(format!(
                             "apply_cont_heap: unexpected continuation con_tag {} (expected Leaf or Node)",
                             con_tag
@@ -387,15 +402,31 @@ impl CompiledEffectMachine {
 
             // We have a result from call_closure. Compose with pending k2s.
             if result.is_null() {
+                // core-shapes.md §7: closure application must return a valid result
+                debug_assert!(
+                    false,
+                    "core-shapes.md §7: apply_cont_heap closure returned null"
+                );
                 return std::ptr::null_mut();
             }
             let result = self.force_ptr(result);
             if result.is_null() {
+                // core-shapes.md §7: forced result must be non-null
+                debug_assert!(
+                    false,
+                    "core-shapes.md §7: apply_cont_heap forced result is null"
+                );
                 return std::ptr::null_mut();
             }
 
             let result_tag = *result;
             if result_tag != layout::TAG_CON {
+                // core-shapes.md §7: Eff result must be TAG_CON
+                debug_assert!(
+                    result_tag == layout::TAG_CON,
+                    "core-shapes.md §7: apply_cont_heap result has unexpected tag {}",
+                    result_tag
+                );
                 crate::host_fns::push_diagnostic(format!(
                     "apply_cont_heap: result has unexpected tag {} (expected TAG_CON)",
                     result_tag
@@ -428,6 +459,12 @@ impl CompiledEffectMachine {
                 }
                 return self.alloc_con(self.tags.e, &[union_val, k_prime]);
             } else {
+                // core-shapes.md §7: Eff result must be Val or E
+                debug_assert!(
+                    result_con_tag == self.tags.val || result_con_tag == self.tags.e,
+                    "core-shapes.md §7: apply_cont_heap result con_tag {} is neither Val nor E",
+                    result_con_tag
+                );
                 crate::host_fns::push_diagnostic(format!(
                     "apply_cont_heap: result con_tag {} is neither Val nor E",
                     result_con_tag

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -89,9 +89,16 @@ unsafe fn heap_to_value_inner(
             match lit_tag {
                 x if x == LIT_TAG_INT => Ok(Value::Lit(Literal::LitInt(raw_value))),
                 x if x == LIT_TAG_WORD => Ok(Value::Lit(Literal::LitWord(raw_value as u64))),
-                x if x == LIT_TAG_CHAR => Ok(Value::Lit(Literal::LitChar(
-                    char::from_u32(raw_value as u32).unwrap_or('\0'),
-                ))),
+                x if x == LIT_TAG_CHAR => {
+                    // core-shapes.md §1: Char lit must hold valid Unicode codepoint
+                    debug_assert!(
+                        char::from_u32(raw_value as u32).is_some(),
+                        "core-shapes.md §1: Char lit must hold valid Unicode codepoint"
+                    );
+                    Ok(Value::Lit(Literal::LitChar(
+                        char::from_u32(raw_value as u32).unwrap_or('\0'),
+                    )))
+                }
                 x if x == LIT_TAG_FLOAT => Ok(Value::Lit(Literal::LitFloat(raw_value as u64))),
                 x if x == LIT_TAG_DOUBLE => Ok(Value::Lit(Literal::LitDouble(raw_value as u64))),
                 x if x == LIT_TAG_STRING => {
@@ -110,6 +117,11 @@ unsafe fn heap_to_value_inner(
                     Ok(Value::Lit(Literal::LitString(bytes)))
                 }
                 x if x == LIT_TAG_ADDR => {
+                    // core-shapes.md §1: LIT_TAG_ADDR should not survive translation
+                    debug_assert!(
+                        false,
+                        "core-shapes.md §1: LIT_TAG_ADDR should not survive translation; got at heap_bridge.rs"
+                    );
                     // Addr# — intermediate value, shouldn't normally be a final result.
                     // Wrap as empty LitString as graceful fallback.
                     Ok(Value::Lit(Literal::LitString(vec![])))

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -117,13 +117,13 @@ unsafe fn heap_to_value_inner(
                     Ok(Value::Lit(Literal::LitString(bytes)))
                 }
                 x if x == LIT_TAG_ADDR => {
-                    // core-shapes.md §1: LIT_TAG_ADDR should not survive translation
-                    debug_assert!(
-                        false,
-                        "core-shapes.md §1: LIT_TAG_ADDR should not survive translation; got at heap_bridge.rs"
-                    );
-                    // Addr# — intermediate value, shouldn't normally be a final result.
-                    // Wrap as empty LitString as graceful fallback.
+                    // Addr# is a legitimate intermediate runtime value: primops like
+                    // PlusAddr / ShowDoubleAddr (see emit/primop.rs) emit
+                    // SsaVal::Raw(_, LIT_TAG_ADDR), and any program that returns the
+                    // raw address through the bridge surfaces here. We can't decode
+                    // it back to a typed Haskell value (it's a raw pointer with no
+                    // length), so we render an empty LitString as the safe fallback.
+                    // See core-shapes.md §1.
                     Ok(Value::Lit(Literal::LitString(vec![])))
                 }
                 x if x == LIT_TAG_BYTEARRAY => {


### PR DESCRIPTION
## Summary

Architecture-level response to the recurring "GHC Core post-optimizer shape varies across compilation modes" bug class identified after PR #272 (multi-module DataCon mismatch + boxed Union tag + UnsafeRefl elision). 6 leaves total: 4 parallel audits → synthesis dossier → encoded preconditions.

## What landed

- **`docs/core-shapes/audit-translate.md`** — 30 entries: every special-case branch in `haskell/src/Tidepool/Translate.hs` (intercepts, desugar paths, IsXVar predicates, GADT-evidence handling, etc.).
- **`docs/core-shapes/audit-effect-machine.md`** — 19 entries: Con-tag dispatch + heap reads + cancellation safepoints in `tidepool-codegen/src/effect_machine.rs`.
- **`docs/core-shapes/audit-heap-bridge.md`** — 17 entries: heap → Value decoding paths in `tidepool-codegen/src/heap_bridge.rs`, including silent-fallback flags.
- **`docs/core-shapes/audit-bridge.md`** — 16 entries: hand-written `FromCore`/`ToCore` primitives in `tidepool-bridge/src/{impls,json}.rs` and their unqualified-name lookup risks.
- **`docs/core-shapes.md`** — normative dossier reorganized by Core construct (Lit / Con / Case / Lam-App-Tail / Let / Join / Effects / Bridge / Heap / Cross-module / Cancellation), each section linking back to its source audit entries. Includes a Coverage Gaps section enumerating uncovered branches, silent fallbacks, and high-collision-risk lookups.
- **`tidepool-codegen/src/effect_machine.rs`**, **`heap_bridge.rs`**, **`tidepool-bridge/src/impls.rs`** — debug_assert! preconditions at hot-path read sites flagged in Coverage Gaps. Each carries a `// core-shapes.md §N` cross-reference. Zero release-mode cost (cfg-gated).

## Why this matters

The dossier reframes the long "GHC Core Translation Gotchas" memory from incident reports into a normative spec. Future contributors:
1. Have a navigable index of which Core shapes the JIT must accept at each stage.
2. Can find a regression's root section by pasting the panic message (`core-shapes.md §10` shows the constraint and points at the audit).
3. Get a punch list of work items in the Coverage Gaps section (uncovered tests, silent fallbacks, deferred `get_by_name_arity`/`get_by_qualified_name` migrations).

## Commits

```
f7309ff feat: audit tidepool-bridge primitive impls and core shapes (#275)
c46afa1 docs: audit effect_machine.rs for Con-tag shape assumptions (#277)
0bc23f7 docs: add heap_bridge.rs shape assumption audit (#276)
f84f2a8 docs: audit special-case translation branches in Translate.hs (#278)
b21af5f docs: consolidate core shapes audit into normative dossier (#288)
29aa0f9 feat: encode core-shapes invariants as debug_assert preconditions (#290)
```

## Test plan

- [x] `cargo test --workspace` (in `nix develop`) — all green
- [x] Each child PR's CI individually
- [x] All four audits at the entry-count thresholds specified by their specs (≥12)
- [x] Dossier has all 11 numbered sections + Coverage Gaps + cross-references
- [x] Encoded preconditions: `cargo build --release --workspace` clean, `cargo clippy` clean

## Deferred / out of scope

- Haskell-side encoding of `Translate.hs` invariants (no live test infra; deferred).
- Migrating hand-written bridge impls from `get_by_name` to `get_by_name_arity` / `get_by_qualified_name`. The new debug_assert flags ambiguity at runtime; migration is a separate PR.
- Cross-mode test coverage and Core normalization land via parallel TLs (`main.cross-mode-coverage-claude`, `main.core-normalization-claude`).
