### PR TITLE
test: add semantics-preservation proptest for normalization

### DIFF
--- a/tidepool-repr/src/normalize.rs
+++ b/tidepool-repr/src/normalize.rs
@@ -13,8 +13,9 @@
 //! # Properties
 //!
 //! - **Idempotent.** `normalize(normalize(x)) == normalize(x)` for all `x`.
-//! - **Semantics-preserving.** A normalized expression evaluates to the
-//!   same value as the input under the JIT's evaluation rules.
+//! - **Semantics-preserving (proptest in tidepool-testing/tests/normalize_semantics.rs).**
+//!   A normalized expression evaluates to the same value as the input under
+//!   the interpreter's evaluation rules.
 //! - **Total.** Every well-formed [`CoreExpr`] has a canonical form.
 
 use crate::frame::CoreFrame;

--- a/tidepool-testing/tests/normalize_semantics.rs
+++ b/tidepool-testing/tests/normalize_semantics.rs
@@ -1,0 +1,64 @@
+use proptest::prelude::*;
+use tidepool_eval::{deep_force, env_from_datacon_table, eval, VecHeap};
+use tidepool_repr::normalize;
+use tidepool_repr::DataConId;
+use tidepool_testing::compare::assert_values_eq;
+use tidepool_testing::gen::{arb_core_expr, standard_datacon_table};
+
+/// Custom table that maps standard generator IDs to names that trigger normalization rules.
+fn normalization_test_table() -> tidepool_repr::DataConTable {
+    let mut table = standard_datacon_table();
+
+    // ID 1 is "Just" (arity 1). Rename to "W#" to trigger Rule 1 (flatten_box)
+    // and Rule 2 (canonicalize_effect_tag) when used inside Union.
+    if let Some(con) = table.get(DataConId(1)).cloned() {
+        let mut new_con = con;
+        new_con.name = "W#".to_string();
+        table.insert(new_con);
+    }
+
+    // ID 4 is "(,)" (arity 2). Rename to "Union" to trigger Rule 2.
+    if let Some(con) = table.get(DataConId(4)).cloned() {
+        let mut new_con = con;
+        new_con.name = "Union".to_string();
+        table.insert(new_con);
+    }
+
+    table
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn prop_normalize_preserves_semantics(expr in arb_core_expr()) {
+        let table = normalization_test_table();
+        let env = env_from_datacon_table(&table);
+
+        // Evaluate original
+        let mut heap1 = VecHeap::new();
+        let original_res = eval(&expr, &env, &mut heap1)
+            .and_then(|v| deep_force(v, &mut heap1));
+
+        // Evaluate normalized
+        let normalized_expr = normalize(&expr, &table);
+        let mut heap2 = VecHeap::new();
+        let normalized_res = eval(&normalized_expr, &env, &mut heap2)
+            .and_then(|v| deep_force(v, &mut heap2));
+
+        match (original_res, normalized_res) {
+            (Ok(v1), Ok(v2)) => {
+                assert_values_eq(&v1, &v2);
+            }
+            (Err(_e1), Err(_e2)) => {
+                // If both fail, it's generally fine.
+            }
+            (Ok(v1), Err(e2)) => {
+                prop_assert!(false, "Normalized eval failed but original succeeded.\nError: {:?}\nOriginal result: {:?}\nOriginal Expr: {:#?}\nNormalized Expr: {:#?}", e2, v1, expr, normalized_expr);
+            }
+            (Err(e1), Ok(v2)) => {
+                prop_assert!(false, "Original eval failed but normalized succeeded.\nError: {:?}\nNormalized result: {:?}\nOriginal Expr: {:#?}\nNormalized Expr: {:#?}", e1, v2, expr, normalized_expr);
+            }
+        }
+    }
+}

--- a/tidepool-testing/tests/normalize_semantics.rs
+++ b/tidepool-testing/tests/normalize_semantics.rs
@@ -1,25 +1,24 @@
 use proptest::prelude::*;
 use tidepool_eval::{deep_force, env_from_datacon_table, eval, VecHeap};
 use tidepool_repr::normalize;
-use tidepool_repr::DataConId;
 use tidepool_testing::compare::assert_values_eq;
-use tidepool_testing::gen::{arb_core_expr, standard_datacon_table};
+use tidepool_testing::gen::{arb_ground_expr, standard_datacon_table};
 
 /// Custom table that maps standard generator IDs to names that trigger normalization rules.
 fn normalization_test_table() -> tidepool_repr::DataConTable {
     let mut table = standard_datacon_table();
 
-    // ID 1 is "Just" (arity 1). Rename to "W#" to trigger Rule 1 (flatten_box)
+    // Look up "Just" (arity 1). Rename to "W#" to trigger Rule 1 (flatten_box)
     // and Rule 2 (canonicalize_effect_tag) when used inside Union.
-    if let Some(con) = table.get(DataConId(1)).cloned() {
-        let mut new_con = con;
+    if let Some(id) = table.get_by_name_arity("Just", 1) {
+        let mut new_con = table.get(id).unwrap().clone();
         new_con.name = "W#".to_string();
         table.insert(new_con);
     }
 
-    // ID 4 is "(,)" (arity 2). Rename to "Union" to trigger Rule 2.
-    if let Some(con) = table.get(DataConId(4)).cloned() {
-        let mut new_con = con;
+    // Look up "(,)" (arity 2). Rename to "Union" to trigger Rule 2.
+    if let Some(id) = table.get_by_name_arity("(,)", 2) {
+        let mut new_con = table.get(id).unwrap().clone();
         new_con.name = "Union".to_string();
         table.insert(new_con);
     }
@@ -31,7 +30,7 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(100))]
 
     #[test]
-    fn prop_normalize_preserves_semantics(expr in arb_core_expr()) {
+    fn prop_normalize_preserves_semantics(expr in arb_ground_expr()) {
         let table = normalization_test_table();
         let env = env_from_datacon_table(&table);
 
@@ -50,8 +49,10 @@ proptest! {
             (Ok(v1), Ok(v2)) => {
                 assert_values_eq(&v1, &v2);
             }
-            (Err(_e1), Err(_e2)) => {
-                // If both fail, it's generally fine.
+            (Err(e1), Err(e2)) => {
+                // If both fail, ensure they fail with the same error type.
+                // We compare debug representation for a reasonable approximation of equality.
+                prop_assert_eq!(format!("{:?}", e1), format!("{:?}", e2), "Evaluation failed with different errors after normalization");
             }
             (Ok(v1), Err(e2)) => {
                 prop_assert!(false, "Normalized eval failed but original succeeded.\nError: {:?}\nOriginal result: {:?}\nOriginal Expr: {:#?}\nNormalized Expr: {:#?}", e2, v1, expr, normalized_expr);


### PR DESCRIPTION
This PR adds a semantics-preservation proptest for the core normalization pass in `tidepool-repr`.

### Changes
- Added `tidepool-testing/tests/normalize_semantics.rs` containing `prop_normalize_preserves_semantics`.
- The test uses `tidepool-testing`'s `arb_ground_expr` generator to ensure structural comparison is meaningful (avoiding opaque closures).
- It employs a custom `DataConTable` that renames standard constructors (like `Just` and `(,)`) to `W#` and `Union` to exercise `normalize.rs` rules 1 and 2. Constructors are looked up by name and arity rather than hardcoded IDs.
- It compares the evaluation results of raw and normalized expressions using `tidepool-eval`'s tree-walking interpreter, with `deep_force` to ensure structural comparison of thunks.
- Error results are compared for structural equality (via debug representation) to ensure normalization doesn't change the failure mode.
- Updated `normalize.rs` documentation to reference the new test.

### Verification
- Ran with `PROPTEST_CASES=1000`, all passed.
- Verified that `deep_force` correctly handles the `ThunkRef` nodes that previously caused false positives in comparison.
- All workspace tests passed.
