### PR TITLE
harden(bridge): drop PhantomData arity-0 fallback + Text decode diagnostics

### DIFF
--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -84,7 +84,8 @@ impl<T> FromCore for std::marker::PhantomData<T> {
 impl<T> ToCore for std::marker::PhantomData<T> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
         // PhantomData has no Core representation; we still need an arity-0 Con as a placeholder when it appears as a derived field. We require "()" specifically rather than picking any arity-0 constructor, since a wrong choice (e.g. False, Nothing) silently corrupts downstream decode.
-        let id = table.get_by_name_arity("()", 0)
+        let id = table
+            .get_by_name_arity("()", 0)
             .ok_or_else(|| BridgeError::UnknownDataConName("()".into()))?;
         Ok(Value::Con(id, vec![]))
     }

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -84,7 +84,7 @@ impl<T> FromCore for std::marker::PhantomData<T> {
 impl<T> ToCore for std::marker::PhantomData<T> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
         // PhantomData has no Core representation; we still need an arity-0 Con as a placeholder when it appears as a derived field. We require "()" specifically rather than picking any arity-0 constructor, since a wrong choice (e.g. False, Nothing) silently corrupts downstream decode.
-        let id = get_resilient(table, "()", 0)
+        let id = table.get_by_name_arity("()", 0)
             .ok_or_else(|| BridgeError::UnknownDataConName("()".into()))?;
         Ok(Value::Con(id, vec![]))
     }

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -83,10 +83,8 @@ impl<T> FromCore for std::marker::PhantomData<T> {
 
 impl<T> ToCore for std::marker::PhantomData<T> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
-        // We use a dummy id since PhantomData has no representation in Core
-        // but we need some Con to represent it if it's a field.
+        // PhantomData has no Core representation; we still need an arity-0 Con as a placeholder when it appears as a derived field. We require "()" specifically rather than picking any arity-0 constructor, since a wrong choice (e.g. False, Nothing) silently corrupts downstream decode.
         let id = get_resilient(table, "()", 0)
-            .or_else(|| table.iter().find(|dc| dc.rep_arity == 0).map(|dc| dc.id))
             .ok_or_else(|| BridgeError::UnknownDataConName("()".into()))?;
         Ok(Value::Con(id, vec![]))
     }
@@ -373,6 +371,13 @@ impl FromCore for String {
                                 return Err(type_mismatch("ByteArray# in ByteArray", &ba_fields[0]))
                             }
                         }
+                    }
+                    Value::Con(other_id, _) => {
+                        let name = table.name_of(*other_id).unwrap_or("<unknown>");
+                        return Err(BridgeError::TypeMismatch {
+                            expected: "ByteArray or ByteArray# in Text".to_string(),
+                            got: format!("Con({})", name),
+                        });
                     }
                     _ => return Err(type_mismatch("ByteArray or ByteArray# in Text", &fields[0])),
                 };

--- a/tidepool-bridge/tests/error_cases.rs
+++ b/tidepool-bridge/tests/error_cases.rs
@@ -189,9 +189,7 @@ fn test_phantom_data_missing_unit() {
     let table = get_table(); // has False, True, but no "()"
     let val: PhantomData<()> = PhantomData;
     let res = val.to_value(&table);
-    if !matches!(res, Err(BridgeError::UnknownDataConName(ref s)) if s == "()") {
-        panic!("Expected UnknownDataConName(\"()\"), got {:?}", res);
-    }
+    assert!(matches!(res, Err(BridgeError::UnknownDataConName(ref s)) if s == "()"));
 }
 
 #[test]

--- a/tidepool-bridge/tests/error_cases.rs
+++ b/tidepool-bridge/tests/error_cases.rs
@@ -182,3 +182,46 @@ fn test_edge_empty_vec() {
     let back = Vec::<i64>::from_value(&value, &table).unwrap();
     assert_eq!(val, back);
 }
+
+#[test]
+fn test_phantom_data_missing_unit() {
+    use std::marker::PhantomData;
+    let table = get_table(); // has False, True, but no "()"
+    let val: PhantomData<()> = PhantomData;
+    let res = val.to_value(&table);
+    if !matches!(res, Err(BridgeError::UnknownDataConName(ref s)) if s == "()") {
+        panic!("Expected UnknownDataConName(\"()\"), got {:?}", res);
+    }
+}
+
+#[test]
+fn test_text_decode_wrong_shape() {
+    let mut table = get_table();
+    let text_id = DataConId(14);
+    table.insert(DataCon {
+        id: text_id,
+        name: "Text".to_string(),
+        tag: 1,
+        rep_arity: 3,
+        field_bangs: vec![SrcBang::NoSrcBang, SrcBang::NoSrcBang, SrcBang::NoSrcBang],
+        qualified_name: None,
+    });
+
+    let false_id = table.get_by_name("False").unwrap();
+    let val = Value::Con(
+        text_id,
+        vec![
+            Value::Con(false_id, vec![]), // the wrong shape
+            Value::Lit(Literal::LitInt(0)),
+            Value::Lit(Literal::LitInt(0)),
+        ],
+    );
+    let res = String::from_value(&val, &table);
+    match res {
+        Err(BridgeError::TypeMismatch { expected, got }) => {
+            assert!(expected.contains("ByteArray"));
+            assert_eq!(got, "Con(False)");
+        }
+        _ => panic!("Expected TypeMismatch with Con(False), got {:?}", res),
+    }
+}


### PR DESCRIPTION
This PR addresses wave-2 of silent-fallback hardening.

- **PhantomData ToCore**: Drops the silent `.or_else(|| ...)` fallback that would pick any arity-0 constructor when "()" is missing, converting it to an explicit requirement and surfacing `BridgeError::UnknownDataConName` if missing.
- **Text FromCore diagnostics**: Improves the `type_mismatch` error message to include the actual encountered constructor name when decoding Text fails due to shape mismatch instead of silently omitting it.
- **Tests**: Adds tests in `error_cases.rs` covering both paths to verify the new behaviors.