### PR TITLE
test: fix spliton_repro using compile_and_run (#296)

### DIFF
--- a/tidepool-mcp/tests/spliton_repro.rs
+++ b/tidepool-mcp/tests/spliton_repro.rs
@@ -5,7 +5,6 @@
 use std::path::Path;
 use tidepool_effect::DispatchEffect;
 use tidepool_eval::value::Value;
-use tidepool_repr::Literal;
 use tidepool_runtime::compile_and_run;
 
 fn prelude_dir() -> &'static Path {
@@ -29,11 +28,11 @@ struct MockDispatcher;
 impl DispatchEffect<()> for MockDispatcher {
     fn dispatch(
         &mut self,
-        _tag: u64,
+        tag: u64,
         _request: &Value,
         _cx: &tidepool_effect::EffectContext<'_, ()>,
     ) -> Result<Value, tidepool_effect::error::EffectError> {
-        Ok(Value::Lit(Literal::LitInt(0)))
+        Err(tidepool_effect::error::EffectError::UnhandledEffect { tag })
     }
 }
 

--- a/tidepool-mcp/tests/spliton_repro.rs
+++ b/tidepool-mcp/tests/spliton_repro.rs
@@ -48,10 +48,10 @@ fn repro_spliton_full_mcp() {
     let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, None);
 
     let ulp = user_lib_dir();
-    if !ulp.join("Library.hs").exists() {
-        eprintln!("Skipping: .tidepool/lib/Library.hs not found");
-        return;
-    }
+    assert!(
+        ulp.join("Library.hs").exists(),
+        "Required test fixture .tidepool/lib/Library.hs not found"
+    );
 
     let pp = prelude_dir();
     let include = [pp, ulp];

--- a/tidepool-mcp/tests/spliton_repro.rs
+++ b/tidepool-mcp/tests/spliton_repro.rs
@@ -3,6 +3,10 @@
 //! collisions when multiple external unfoldings share local binder names.
 
 use std::path::Path;
+use tidepool_effect::DispatchEffect;
+use tidepool_eval::value::Value;
+use tidepool_repr::Literal;
+use tidepool_runtime::compile_and_run;
 
 fn prelude_dir() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -20,14 +24,29 @@ fn user_lib_dir() -> &'static Path {
         .leak()
 }
 
+struct MockDispatcher;
+
+impl DispatchEffect<()> for MockDispatcher {
+    fn dispatch(
+        &mut self,
+        _tag: u64,
+        _request: &Value,
+        _cx: &tidepool_effect::EffectContext<'_, ()>,
+    ) -> Result<Value, tidepool_effect::error::EffectError> {
+        Ok(Value::Lit(Literal::LitInt(0)))
+    }
+}
+
 #[test]
-#[ignore = "exposes #296 — test evaluates Eff purely and hits TAG_CLOSURE"]
 fn repro_spliton_full_mcp() {
+    // Per #296: rewrite uses compile_and_run with stub dispatcher (option 1).
+    // Earlier versions used compile_and_run_pure, which silently returned the
+    // unevaluated Eff closure; the test passed without exercising T.splitOn at all.
     let decls = tidepool_mcp::standard_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, true);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
     let code = r#"pure (T.splitOn "," "a,b,c")"#;
-    let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, Some(4096));
+    let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, None);
 
     let ulp = user_lib_dir();
     if !ulp.join("Library.hs").exists() {
@@ -37,37 +56,49 @@ fn repro_spliton_full_mcp() {
 
     let pp = prelude_dir();
     let include = [pp, ulp];
-    let result = tidepool_runtime::compile_and_run_pure(&source, "result", &include);
+
+    let mut dispatcher = MockDispatcher;
+    let result = compile_and_run(&source, "result", &include, &mut dispatcher, &());
+
     match &result {
         Ok(val) => eprintln!("OK: {:?}", val.to_json()),
         Err(e) => eprintln!("ERROR: {}", e),
     }
-    assert!(
-        result.is_ok(),
-        "T.splitOn in full MCP context should work: {:?}",
-        result.err()
+
+    let val = result.expect("T.splitOn in full MCP context should work");
+    assert_eq!(
+        val.to_json(),
+        serde_json::json!(["a", "b", "c"]),
+        "T.splitOn output mismatch"
     );
 }
 
 #[test]
-#[ignore = "exposes #296 — test evaluates Eff purely and hits TAG_CLOSURE"]
 fn repro_spliton_no_user_library() {
+    // Per #296: rewrite uses compile_and_run with stub dispatcher (option 1).
+    // Earlier versions used compile_and_run_pure, which silently returned the
+    // unevaluated Eff closure; the test passed without exercising T.splitOn at all.
     let decls = tidepool_mcp::standard_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false); // no Library
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
     let code = r#"pure (T.splitOn "," "a,b,c")"#;
-    let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, Some(4096));
+    let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, None);
 
     let pp = prelude_dir();
     let include = [pp];
-    let result = tidepool_runtime::compile_and_run_pure(&source, "result", &include);
+
+    let mut dispatcher = MockDispatcher;
+    let result = compile_and_run(&source, "result", &include, &mut dispatcher, &());
+
     match &result {
         Ok(val) => eprintln!("OK: {:?}", val.to_json()),
         Err(e) => eprintln!("ERROR: {}", e),
     }
-    assert!(
-        result.is_ok(),
-        "T.splitOn without Library should work: {:?}",
-        result.err()
+
+    let val = result.expect("T.splitOn without Library should work");
+    assert_eq!(
+        val.to_json(),
+        serde_json::json!(["a", "b", "c"]),
+        "T.splitOn output mismatch"
     );
 }


### PR DESCRIPTION
Fixes #296 by rewriting `tidepool-mcp/tests/spliton_repro.rs` to use `compile_and_run` with a stub dispatcher. Removes `#[ignore]` and strengthens assertions to verify the JSON output directly.

Addressed Copilot feedback:
- Made `MockDispatcher` fail-fast on unhandled effects.
- Asserted the existence of `Library.hs` instead of silently skipping the test.