### PR TITLE
feat: harden(heap-bridge): surface array null pointer as BridgeError

### DIFF
--- a/docs/core-shapes.md
+++ b/docs/core-shapes.md
@@ -175,6 +175,7 @@ The JIT includes safepoints where long-running or infinite computations can be i
 - `audit-effect-machine § force_ptr: Thunk tag check` — returns poison pointer and sets `YieldError::UserErrorMsg` on unexpected tag (Hardened).
 - `audit-effect-machine § apply_cont_heap` — now surfaces `YieldError::UserErrorMsg` via `runtime_error_with_msg` on shape mismatch instead of returning `null_mut` silently (Hardened).
 - `audit-heap-bridge § TAG_CLOSURE opaque representation` — now returns `BridgeError::UnexpectedHeapTag(TAG_CLOSURE)` instead of a dummy opaque `Closure` (Hardened).
+- `audit-heap-bridge § LitTag::Array / LitTag::SmallArray` — now returns `BridgeError::NullPointer` on null pointer instead of a dummy empty array (Hardened).
 
 ### Cross-module collision risk: High
 - `audit-bridge § String (Text)` — uses multiple unqualified `get_by_name` lookups for `Text`, `ByteArray`, and `[]`; highly susceptible to arity or name collisions.

--- a/docs/core-shapes/audit-heap-bridge.md
+++ b/docs/core-shapes/audit-heap-bridge.md
@@ -126,11 +126,11 @@
 - **Reads:** `raw_value` as `*const u8` pointer; length from `arr_ptr`; field pointers from `arr_ptr.add(8 + 8*i)`
 - **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_SMALLARRAY` (8) or `LIT_TAG_ARRAY` (9). Pointer targets: `[len: u64][ptr0][ptr1]...`
 - **Decoded into:** `Value::Con(DataConId(0), elems)`
-- **Failure mode on shape mismatch:** `silent fallback: Value::Con(DataConId(0), vec![])` if pointer is null | `BridgeError::DataTooLarge`
+- **Failure mode on shape mismatch:** `BridgeError::NullPointer` if pointer is null (Hardened) | `BridgeError::DataTooLarge`
 - **Bound checks:** `MAX_DATA_SIZE` (64MB), `MAX_DEPTH` (via recursion)
 - **Mode:** `always-on`
 - **Test coverage:** `uncovered`
-- **Notes:** Coerces boxed pointer arrays into a generic `Con(0, ...)` structure. Semantic meaning depends on the wrapping Haskell constructor.
+- **Notes:** Coerces boxed pointer arrays into a generic `Con(0, ...)` structure. Semantic meaning depends on the wrapping Haskell constructor. DataConId(0) is a deliberate sentinel meaning "raw boxed-pointer array".
 
 ## TAG_CON field decoding
 

--- a/docs/core-shapes/audit-heap-bridge.md
+++ b/docs/core-shapes/audit-heap-bridge.md
@@ -122,14 +122,14 @@
 
 ## LitTag::Array / LitTag::SmallArray
 
-- **Location:** `tidepool-codegen/src/heap_bridge.rs:135` (`heap_to_value_inner`)
+- **Location:** `tidepool-codegen/src/heap_bridge.rs` (match arm `LIT_TAG_SMALLARRAY` / `LIT_TAG_ARRAY` in `heap_to_value_inner`)
 - **Reads:** `raw_value` as `*const u8` pointer; length from `arr_ptr`; field pointers from `arr_ptr.add(8 + 8*i)`
 - **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_SMALLARRAY` (8) or `LIT_TAG_ARRAY` (9). Pointer targets: `[len: u64][ptr0][ptr1]...`
 - **Decoded into:** `Value::Con(DataConId(0), elems)`
 - **Failure mode on shape mismatch:** `BridgeError::NullPointer` if pointer is null (Hardened) | `BridgeError::DataTooLarge`
 - **Bound checks:** `MAX_DATA_SIZE` (64MB), `MAX_DEPTH` (via recursion)
 - **Mode:** `always-on`
-- **Test coverage:** `uncovered`
+- **Test coverage:** `tidepool-codegen/tests/heap_bridge_tests.rs:111` (`test_heap_to_value_lit_smallarray_null`), `130` (`test_heap_to_value_lit_array_null`)
 - **Notes:** Coerces boxed pointer arrays into a generic `Con(0, ...)` structure. Semantic meaning depends on the wrapping Haskell constructor. DataConId(0) is a deliberate sentinel meaning "raw boxed-pointer array".
 
 ## TAG_CON field decoding

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -129,6 +129,8 @@ unsafe fn heap_to_value_inner(
                     // ByteArray# — raw pointer to [len: u64][bytes...]
                     let ba_ptr = raw_value as *const u8;
                     if ba_ptr.is_null() {
+                        // ByteArray# legitimately can be empty/null in some Haskell programs;
+                        // returning empty is correct. See core-shapes.md §1.
                         return Ok(Value::ByteArray(std::sync::Arc::new(
                             std::sync::Mutex::new(vec![]),
                         )));
@@ -148,7 +150,7 @@ unsafe fn heap_to_value_inner(
                     // Layout: [u64 length][ptr0][ptr1]...[ptrN-1]
                     let arr_ptr = raw_value as *const u8;
                     if arr_ptr.is_null() {
-                        return Ok(Value::Con(DataConId(0), vec![]));
+                        return Err(BridgeError::NullPointer);
                     }
                     let len = std::ptr::read_unaligned(arr_ptr as *const u64) as usize;
                     if len > MAX_DATA_SIZE {
@@ -159,9 +161,10 @@ unsafe fn heap_to_value_inner(
                         let elem_ptr = *(arr_ptr.add(8 + 8 * i) as *const *const u8);
                         elems.push(heap_to_value_inner(elem_ptr, depth + 1, vmctx)?);
                     }
-                    // Return as a generic Con with fields — the renderer will
-                    // see the constructor names from the wrapping Con objects
-                    // (e.g., Vector's Array constructor wraps this)
+                    // SmallArray#/Array# carry no per-array DataConId. The wrapping Con (e.g.
+                    // Vector's Array constructor) supplies type context to downstream consumers.
+                    // DataConId(0) here is a deliberate sentinel meaning "raw boxed-pointer array".
+                    // This is the contract documented in core-shapes.md §1.
                     Ok(Value::Con(DataConId(0), elems))
                 }
                 other => Err(BridgeError::UnexpectedLitTag(other as u8)),

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -130,7 +130,7 @@ unsafe fn heap_to_value_inner(
                     let ba_ptr = raw_value as *const u8;
                     if ba_ptr.is_null() {
                         // ByteArray# legitimately can be empty/null in some Haskell programs;
-                        // returning empty is correct. See core-shapes.md §1.
+                        // returning empty is correct. See docs/core-shapes/audit-heap-bridge.md#littagbytearray.
                         return Ok(Value::ByteArray(std::sync::Arc::new(
                             std::sync::Mutex::new(vec![]),
                         )));
@@ -164,7 +164,7 @@ unsafe fn heap_to_value_inner(
                     // SmallArray#/Array# carry no per-array DataConId. The wrapping Con (e.g.
                     // Vector's Array constructor) supplies type context to downstream consumers.
                     // DataConId(0) here is a deliberate sentinel meaning "raw boxed-pointer array".
-                    // This is the contract documented in core-shapes.md §1.
+                    // This is the contract documented in docs/core-shapes/audit-heap-bridge.md#littagarray--littagsmallarray.
                     Ok(Value::Con(DataConId(0), elems))
                 }
                 other => Err(BridgeError::UnexpectedLitTag(other as u8)),

--- a/tidepool-codegen/src/lib.rs
+++ b/tidepool-codegen/src/lib.rs
@@ -13,7 +13,7 @@ pub mod gc;
 pub mod heap_bridge;
 pub mod host_fns;
 pub mod jit_machine;
-pub(crate) mod layout;
+pub mod layout;
 pub mod nursery;
 pub mod pipeline;
 pub mod signal_safety;

--- a/tidepool-codegen/tests/heap_bridge_tests.rs
+++ b/tidepool-codegen/tests/heap_bridge_tests.rs
@@ -1,10 +1,13 @@
-use tidepool_codegen::heap_bridge::heap_to_value;
+use tidepool_codegen::heap_bridge::{heap_to_value, BridgeError};
 use tidepool_eval::value::Value;
 use tidepool_heap::layout;
 use tidepool_repr::*;
 
 #[repr(align(8))]
 struct AlignedBuf<const N: usize>([u8; N]);
+
+const LIT_TAG_SMALLARRAY: u8 = 8;
+const LIT_TAG_ARRAY: u8 = 9;
 
 #[test]
 fn test_heap_to_value_lit_int() {
@@ -101,5 +104,43 @@ fn test_heap_to_value_deeply_nested_cons() {
         let Value::Lit(Literal::LitInt(0)) = v else {
             panic!("Expected terminal LitInt(0), got {:?}", v);
         };
+    }
+}
+
+#[test]
+fn test_heap_to_value_lit_smallarray_null() {
+    let mut buf_data = AlignedBuf::<{ layout::LIT_SIZE }>([0u8; layout::LIT_SIZE]);
+    let ptr = buf_data.0.as_mut_ptr();
+    unsafe {
+        layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(ptr.add(layout::LIT_TAG_OFFSET)) = LIT_TAG_SMALLARRAY;
+        // Null pointer for the array data
+        *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut *const u8) = std::ptr::null();
+
+        let res = heap_to_value(ptr);
+        assert!(
+            matches!(res, Err(BridgeError::NullPointer)),
+            "Expected NullPointer error, got {:?}",
+            res
+        );
+    }
+}
+
+#[test]
+fn test_heap_to_value_lit_array_null() {
+    let mut buf_data = AlignedBuf::<{ layout::LIT_SIZE }>([0u8; layout::LIT_SIZE]);
+    let ptr = buf_data.0.as_mut_ptr();
+    unsafe {
+        layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(ptr.add(layout::LIT_TAG_OFFSET)) = LIT_TAG_ARRAY;
+        // Null pointer for the array data
+        *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut *const u8) = std::ptr::null();
+
+        let res = heap_to_value(ptr);
+        assert!(
+            matches!(res, Err(BridgeError::NullPointer)),
+            "Expected NullPointer error, got {:?}",
+            res
+        );
     }
 }

--- a/tidepool-codegen/tests/heap_bridge_tests.rs
+++ b/tidepool-codegen/tests/heap_bridge_tests.rs
@@ -1,13 +1,11 @@
 use tidepool_codegen::heap_bridge::{heap_to_value, BridgeError};
+use tidepool_codegen::layout::{LIT_TAG_ARRAY, LIT_TAG_SMALLARRAY};
 use tidepool_eval::value::Value;
 use tidepool_heap::layout;
 use tidepool_repr::*;
 
 #[repr(align(8))]
 struct AlignedBuf<const N: usize>([u8; N]);
-
-const LIT_TAG_SMALLARRAY: u8 = 8;
-const LIT_TAG_ARRAY: u8 = 9;
 
 #[test]
 fn test_heap_to_value_lit_int() {
@@ -113,7 +111,7 @@ fn test_heap_to_value_lit_smallarray_null() {
     let ptr = buf_data.0.as_mut_ptr();
     unsafe {
         layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-        *(ptr.add(layout::LIT_TAG_OFFSET)) = LIT_TAG_SMALLARRAY;
+        *(ptr.add(layout::LIT_TAG_OFFSET)) = LIT_TAG_SMALLARRAY as u8;
         // Null pointer for the array data
         *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut *const u8) = std::ptr::null();
 
@@ -132,7 +130,7 @@ fn test_heap_to_value_lit_array_null() {
     let ptr = buf_data.0.as_mut_ptr();
     unsafe {
         layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
-        *(ptr.add(layout::LIT_TAG_OFFSET)) = LIT_TAG_ARRAY;
+        *(ptr.add(layout::LIT_TAG_OFFSET)) = LIT_TAG_ARRAY as u8;
         // Null pointer for the array data
         *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut *const u8) = std::ptr::null();
 


### PR DESCRIPTION
Hardens the silent fallbacks for `SmallArray#` and `Array#` null pointers in `heap_bridge.rs`.

Sites touched:
- `tidepool-codegen/src/heap_bridge.rs`: Updated `LIT_TAG_SMALLARRAY` and `LIT_TAG_ARRAY` match arm to return `Err(BridgeError::NullPointer)` on null pointer. Added comments clarifying the `DataConId(0)` sentinel on successful array decode and the intentional fallback for `ByteArray#`.
- `tidepool-codegen/tests/heap_bridge_tests.rs`: Added `test_heap_to_value_lit_smallarray_null` and `test_heap_to_value_lit_array_null` to cover the new `BridgeError::NullPointer` error paths.
- `docs/core-shapes.md`: Added the newly hardened fallback to the "Hardened" coverage gaps section.
- `docs/core-shapes/audit-heap-bridge.md`: Updated the `LitTag::Array / LitTag::SmallArray` section to reflect the surfaced error.

No new bugs were surfaced by this hardening during workspace tests.