### PR TITLE
fix(#296): rewrite spliton_repro tests to use compile_and_run with stub dispatcher

### DIFF
--- a/tidepool-mcp/tests/spliton_repro.rs
+++ b/tidepool-mcp/tests/spliton_repro.rs
@@ -3,6 +3,9 @@
 //! collisions when multiple external unfoldings share local binder names.
 
 use std::path::Path;
+use tidepool_effect::DispatchEffect;
+use tidepool_eval::value::Value;
+use tidepool_runtime::compile_and_run;
 
 fn prelude_dir() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -20,54 +23,81 @@ fn user_lib_dir() -> &'static Path {
         .leak()
 }
 
+struct MockDispatcher;
+
+impl DispatchEffect<()> for MockDispatcher {
+    fn dispatch(
+        &mut self,
+        tag: u64,
+        _request: &Value,
+        _cx: &tidepool_effect::EffectContext<'_, ()>,
+    ) -> Result<Value, tidepool_effect::error::EffectError> {
+        Err(tidepool_effect::error::EffectError::UnhandledEffect { tag })
+    }
+}
+
 #[test]
-#[ignore = "exposes #296 — test evaluates Eff purely and hits TAG_CLOSURE"]
 fn repro_spliton_full_mcp() {
+    // Per #296: rewrite uses compile_and_run with stub dispatcher (option 1).
+    // Earlier versions used compile_and_run_pure, which silently returned the
+    // unevaluated Eff closure; the test passed without exercising T.splitOn at all.
     let decls = tidepool_mcp::standard_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, true);
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
     let code = r#"pure (T.splitOn "," "a,b,c")"#;
-    let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, Some(4096));
+    let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, None);
 
     let ulp = user_lib_dir();
-    if !ulp.join("Library.hs").exists() {
-        eprintln!("Skipping: .tidepool/lib/Library.hs not found");
-        return;
-    }
+    assert!(
+        ulp.join("Library.hs").exists(),
+        "Required test fixture .tidepool/lib/Library.hs not found"
+    );
 
     let pp = prelude_dir();
     let include = [pp, ulp];
-    let result = tidepool_runtime::compile_and_run_pure(&source, "result", &include);
+
+    let mut dispatcher = MockDispatcher;
+    let result = compile_and_run(&source, "result", &include, &mut dispatcher, &());
+
     match &result {
         Ok(val) => eprintln!("OK: {:?}", val.to_json()),
         Err(e) => eprintln!("ERROR: {}", e),
     }
-    assert!(
-        result.is_ok(),
-        "T.splitOn in full MCP context should work: {:?}",
-        result.err()
+
+    let val = result.expect("T.splitOn in full MCP context should work");
+    assert_eq!(
+        val.to_json(),
+        serde_json::json!(["a", "b", "c"]),
+        "T.splitOn output mismatch"
     );
 }
 
 #[test]
-#[ignore = "exposes #296 — test evaluates Eff purely and hits TAG_CLOSURE"]
 fn repro_spliton_no_user_library() {
+    // Per #296: rewrite uses compile_and_run with stub dispatcher (option 1).
+    // Earlier versions used compile_and_run_pure, which silently returned the
+    // unevaluated Eff closure; the test passed without exercising T.splitOn at all.
     let decls = tidepool_mcp::standard_decls();
     let preamble = tidepool_mcp::build_preamble(&decls, false); // no Library
     let stack = tidepool_mcp::build_effect_stack_type(&decls);
     let code = r#"pure (T.splitOn "," "a,b,c")"#;
-    let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, Some(4096));
+    let source = tidepool_mcp::template_haskell(&preamble, &stack, code, "", "", None, None);
 
     let pp = prelude_dir();
     let include = [pp];
-    let result = tidepool_runtime::compile_and_run_pure(&source, "result", &include);
+
+    let mut dispatcher = MockDispatcher;
+    let result = compile_and_run(&source, "result", &include, &mut dispatcher, &());
+
     match &result {
         Ok(val) => eprintln!("OK: {:?}", val.to_json()),
         Err(e) => eprintln!("ERROR: {}", e),
     }
-    assert!(
-        result.is_ok(),
-        "T.splitOn without Library should work: {:?}",
-        result.err()
+
+    let val = result.expect("T.splitOn without Library should work");
+    assert_eq!(
+        val.to_json(),
+        serde_json::json!(["a", "b", "c"]),
+        "T.splitOn output mismatch"
     );
 }


### PR DESCRIPTION
Resolves #296.

## What

The `tidepool-mcp/tests/spliton_repro.rs` tests were authored as `compile_and_run_pure` on Eff-wrapped code. PR #295's silent-fallback hardening surfaced that they were passing for the wrong reason: pre-#295, `Ok(Closure(...))` satisfied `result.is_ok()` without ever exercising the actual `T.splitOn` evaluation. Tests were tautologies.

Per #296 option (1): rewrite to use `tidepool_runtime::compile_and_run` with a stub `DispatchEffect<()>` that satisfies the type-checker but is never actually invoked (the test program `pure (T.splitOn "," "a,b,c")` is purely-pure inside `Eff`, dispatches no effects). Strengthen the assertion to compare the rendered JSON output against `["a", "b", "c"]` directly, ensuring the test catches any regression that would've previously slipped through as `Ok(Closure)`.

## Changes

- `tidepool-mcp/tests/spliton_repro.rs`:
  - Drop both `#[ignore]` attributes
  - Define a local `MockDispatcher` impl matching the existing pattern at `tidepool-mcp/src/lib.rs:2569`
  - Switch from `compile_and_run_pure` → `compile_and_run`
  - Strengthen assertions to `.to_json() == json!(["a", "b", "c"])` end-to-end
  - Update inline comments to reference the rewrite per #296 option 1

## Verification

```
cargo test -p tidepool-mcp --test spliton_repro
running 2 tests
test repro_spliton_no_user_library ... ok
test repro_spliton_full_mcp ... ok
test result: ok. 2 passed; 0 failed; 0 ignored
```

Workspace tests, fmt, clippy all clean.

## Test plan

- [x] `cargo test -p tidepool-mcp --test spliton_repro` — 2 passed
- [x] `cargo test --workspace` — no regressions
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)