### PR TITLE
harden(wave-2): heap_bridge array nulls + bridge PhantomData / Text diagnostics

### DIFF
--- a/docs/core-shapes.md
+++ b/docs/core-shapes.md
@@ -175,6 +175,7 @@ The JIT includes safepoints where long-running or infinite computations can be i
 - `audit-effect-machine § force_ptr: Thunk tag check` — returns poison pointer and sets `YieldError::UserErrorMsg` on unexpected tag (Hardened).
 - `audit-effect-machine § apply_cont_heap` — now surfaces `YieldError::UserErrorMsg` via `runtime_error_with_msg` on shape mismatch instead of returning `null_mut` silently (Hardened).
 - `audit-heap-bridge § TAG_CLOSURE opaque representation` — now returns `BridgeError::UnexpectedHeapTag(TAG_CLOSURE)` instead of a dummy opaque `Closure` (Hardened).
+- `audit-heap-bridge § LitTag::Array / LitTag::SmallArray` — now returns `BridgeError::NullPointer` on null pointer instead of a dummy empty array (Hardened).
 
 ### Cross-module collision risk: High
 - `audit-bridge § String (Text)` — uses multiple unqualified `get_by_name` lookups for `Text`, `ByteArray`, and `[]`; highly susceptible to arity or name collisions.

--- a/docs/core-shapes/audit-heap-bridge.md
+++ b/docs/core-shapes/audit-heap-bridge.md
@@ -122,15 +122,15 @@
 
 ## LitTag::Array / LitTag::SmallArray
 
-- **Location:** `tidepool-codegen/src/heap_bridge.rs:135` (`heap_to_value_inner`)
+- **Location:** `tidepool-codegen/src/heap_bridge.rs` (match arm `LIT_TAG_SMALLARRAY` / `LIT_TAG_ARRAY` in `heap_to_value_inner`)
 - **Reads:** `raw_value` as `*const u8` pointer; length from `arr_ptr`; field pointers from `arr_ptr.add(8 + 8*i)`
 - **Expected shape:** `TAG_LIT` with `lit_tag = LIT_TAG_SMALLARRAY` (8) or `LIT_TAG_ARRAY` (9). Pointer targets: `[len: u64][ptr0][ptr1]...`
 - **Decoded into:** `Value::Con(DataConId(0), elems)`
-- **Failure mode on shape mismatch:** `silent fallback: Value::Con(DataConId(0), vec![])` if pointer is null | `BridgeError::DataTooLarge`
+- **Failure mode on shape mismatch:** `BridgeError::NullPointer` if pointer is null (Hardened) | `BridgeError::DataTooLarge`
 - **Bound checks:** `MAX_DATA_SIZE` (64MB), `MAX_DEPTH` (via recursion)
 - **Mode:** `always-on`
-- **Test coverage:** `uncovered`
-- **Notes:** Coerces boxed pointer arrays into a generic `Con(0, ...)` structure. Semantic meaning depends on the wrapping Haskell constructor.
+- **Test coverage:** `tidepool-codegen/tests/heap_bridge_tests.rs:111` (`test_heap_to_value_lit_smallarray_null`), `130` (`test_heap_to_value_lit_array_null`)
+- **Notes:** Coerces boxed pointer arrays into a generic `Con(0, ...)` structure. Semantic meaning depends on the wrapping Haskell constructor. DataConId(0) is a deliberate sentinel meaning "raw boxed-pointer array".
 
 ## TAG_CON field decoding
 

--- a/docs/core-shapes/audit-heap-bridge.md
+++ b/docs/core-shapes/audit-heap-bridge.md
@@ -129,7 +129,7 @@
 - **Failure mode on shape mismatch:** `BridgeError::NullPointer` if pointer is null (Hardened) | `BridgeError::DataTooLarge`
 - **Bound checks:** `MAX_DATA_SIZE` (64MB), `MAX_DEPTH` (via recursion)
 - **Mode:** `always-on`
-- **Test coverage:** `tidepool-codegen/tests/heap_bridge_tests.rs:111` (`test_heap_to_value_lit_smallarray_null`), `130` (`test_heap_to_value_lit_array_null`)
+- **Test coverage:** `tidepool-codegen/tests/heap_bridge_tests.rs::test_heap_to_value_lit_smallarray_null`, `tidepool-codegen/tests/heap_bridge_tests.rs::test_heap_to_value_lit_array_null`
 - **Notes:** Coerces boxed pointer arrays into a generic `Con(0, ...)` structure. Semantic meaning depends on the wrapping Haskell constructor. DataConId(0) is a deliberate sentinel meaning "raw boxed-pointer array".
 
 ## TAG_CON field decoding
@@ -180,17 +180,17 @@
 - **Test coverage:** `uncovered`
 - **Notes:** `BlackHole` indicates a thunk that depends on its own result (infinite loop).
 
-## TAG_CLOSURE opaque representation
+## TAG_CLOSURE rejected as top-level bridge result (Hardened)
 
-- **Location:** `tidepool-codegen/src/heap_bridge.rs:200` (`heap_to_value_inner`)
+- **Location:** `tidepool-codegen/src/heap_bridge.rs` (match arm `TAG_CLOSURE` in `heap_to_value_inner`)
 - **Reads:** Tag only
 - **Expected shape:** `TAG_CLOSURE` header
-- **Decoded into:** `Value::Closure(Env::new(), VarId(0), dummy_expr)`
-- **Failure mode on shape mismatch:** `silent fallback: produces dummy opaque Closure`
+- **Decoded into:** N/A — surfaced as error
+- **Failure mode on shape mismatch:** `BridgeError::UnexpectedHeapTag(TAG_CLOSURE)` (Hardened by PR #295)
 - **Bound checks:** None
 - **Mode:** `always-on`
-- **Test coverage:** `uncovered`
-- **Notes:** Closures are opaque to the bridge. They are represented as a dummy `Closure` to avoid failing the entire bridge traversal, allowing partially-evaluated structures (like `Array#` containing closures) to be inspected.
+- **Test coverage:** `tidepool-codegen/src/heap_bridge.rs::tests::test_unexpected_heap_tag` (covers the surfaced-error path; prior dummy-closure fallback removed)
+- **Notes:** Closures are opaque to the bridge and must not appear as a top-level decode result. A `TAG_CLOSURE` reaching this site indicates an unforced thunk leaked through to the bridge, which is a JIT bug. Previously masked by a dummy `Value::Closure(_, _, _)` fallback; now surfaces immediately. See `core-shapes.md §8`.
 
 ## Unexpected heap tag
 

--- a/tidepool-bridge/src/impls.rs
+++ b/tidepool-bridge/src/impls.rs
@@ -83,10 +83,9 @@ impl<T> FromCore for std::marker::PhantomData<T> {
 
 impl<T> ToCore for std::marker::PhantomData<T> {
     fn to_value(&self, table: &DataConTable) -> Result<Value, BridgeError> {
-        // We use a dummy id since PhantomData has no representation in Core
-        // but we need some Con to represent it if it's a field.
-        let id = get_resilient(table, "()", 0)
-            .or_else(|| table.iter().find(|dc| dc.rep_arity == 0).map(|dc| dc.id))
+        // PhantomData has no Core representation; we still need an arity-0 Con as a placeholder when it appears as a derived field. We require "()" specifically rather than picking any arity-0 constructor, since a wrong choice (e.g. False, Nothing) silently corrupts downstream decode.
+        let id = table
+            .get_by_name_arity("()", 0)
             .ok_or_else(|| BridgeError::UnknownDataConName("()".into()))?;
         Ok(Value::Con(id, vec![]))
     }
@@ -373,6 +372,13 @@ impl FromCore for String {
                                 return Err(type_mismatch("ByteArray# in ByteArray", &ba_fields[0]))
                             }
                         }
+                    }
+                    Value::Con(other_id, _) => {
+                        let name = table.name_of(*other_id).unwrap_or("<unknown>");
+                        return Err(BridgeError::TypeMismatch {
+                            expected: "ByteArray or ByteArray# in Text".to_string(),
+                            got: format!("Con({})", name),
+                        });
                     }
                     _ => return Err(type_mismatch("ByteArray or ByteArray# in Text", &fields[0])),
                 };

--- a/tidepool-bridge/tests/error_cases.rs
+++ b/tidepool-bridge/tests/error_cases.rs
@@ -182,3 +182,44 @@ fn test_edge_empty_vec() {
     let back = Vec::<i64>::from_value(&value, &table).unwrap();
     assert_eq!(val, back);
 }
+
+#[test]
+fn test_phantom_data_missing_unit() {
+    use std::marker::PhantomData;
+    let table = get_table(); // has False, True, but no "()"
+    let val: PhantomData<()> = PhantomData;
+    let res = val.to_value(&table);
+    assert!(matches!(res, Err(BridgeError::UnknownDataConName(ref s)) if s == "()"));
+}
+
+#[test]
+fn test_text_decode_wrong_shape() {
+    let mut table = get_table();
+    let text_id = DataConId(14);
+    table.insert(DataCon {
+        id: text_id,
+        name: "Text".to_string(),
+        tag: 1,
+        rep_arity: 3,
+        field_bangs: vec![SrcBang::NoSrcBang, SrcBang::NoSrcBang, SrcBang::NoSrcBang],
+        qualified_name: None,
+    });
+
+    let false_id = table.get_by_name("False").unwrap();
+    let val = Value::Con(
+        text_id,
+        vec![
+            Value::Con(false_id, vec![]), // the wrong shape
+            Value::Lit(Literal::LitInt(0)),
+            Value::Lit(Literal::LitInt(0)),
+        ],
+    );
+    let res = String::from_value(&val, &table);
+    match res {
+        Err(BridgeError::TypeMismatch { expected, got }) => {
+            assert!(expected.contains("ByteArray"));
+            assert_eq!(got, "Con(False)");
+        }
+        _ => panic!("Expected TypeMismatch with Con(False), got {:?}", res),
+    }
+}

--- a/tidepool-codegen/src/heap_bridge.rs
+++ b/tidepool-codegen/src/heap_bridge.rs
@@ -129,6 +129,8 @@ unsafe fn heap_to_value_inner(
                     // ByteArray# — raw pointer to [len: u64][bytes...]
                     let ba_ptr = raw_value as *const u8;
                     if ba_ptr.is_null() {
+                        // ByteArray# legitimately can be empty/null in some Haskell programs;
+                        // returning empty is correct. See docs/core-shapes/audit-heap-bridge.md#littagbytearray.
                         return Ok(Value::ByteArray(std::sync::Arc::new(
                             std::sync::Mutex::new(vec![]),
                         )));
@@ -148,7 +150,7 @@ unsafe fn heap_to_value_inner(
                     // Layout: [u64 length][ptr0][ptr1]...[ptrN-1]
                     let arr_ptr = raw_value as *const u8;
                     if arr_ptr.is_null() {
-                        return Ok(Value::Con(DataConId(0), vec![]));
+                        return Err(BridgeError::NullPointer);
                     }
                     let len = std::ptr::read_unaligned(arr_ptr as *const u64) as usize;
                     if len > MAX_DATA_SIZE {
@@ -159,9 +161,10 @@ unsafe fn heap_to_value_inner(
                         let elem_ptr = *(arr_ptr.add(8 + 8 * i) as *const *const u8);
                         elems.push(heap_to_value_inner(elem_ptr, depth + 1, vmctx)?);
                     }
-                    // Return as a generic Con with fields — the renderer will
-                    // see the constructor names from the wrapping Con objects
-                    // (e.g., Vector's Array constructor wraps this)
+                    // SmallArray#/Array# carry no per-array DataConId. The wrapping Con (e.g.
+                    // Vector's Array constructor) supplies type context to downstream consumers.
+                    // DataConId(0) here is a deliberate sentinel meaning "raw boxed-pointer array".
+                    // This is the contract documented in docs/core-shapes/audit-heap-bridge.md#littagarray--littagsmallarray.
                     Ok(Value::Con(DataConId(0), elems))
                 }
                 other => Err(BridgeError::UnexpectedLitTag(other as u8)),

--- a/tidepool-codegen/src/lib.rs
+++ b/tidepool-codegen/src/lib.rs
@@ -13,7 +13,7 @@ pub mod gc;
 pub mod heap_bridge;
 pub mod host_fns;
 pub mod jit_machine;
-pub(crate) mod layout;
+pub mod layout;
 pub mod nursery;
 pub mod pipeline;
 pub mod signal_safety;

--- a/tidepool-codegen/tests/heap_bridge_tests.rs
+++ b/tidepool-codegen/tests/heap_bridge_tests.rs
@@ -1,4 +1,5 @@
-use tidepool_codegen::heap_bridge::heap_to_value;
+use tidepool_codegen::heap_bridge::{heap_to_value, BridgeError};
+use tidepool_codegen::layout::{LIT_TAG_ARRAY, LIT_TAG_SMALLARRAY};
 use tidepool_eval::value::Value;
 use tidepool_heap::layout;
 use tidepool_repr::*;
@@ -101,5 +102,43 @@ fn test_heap_to_value_deeply_nested_cons() {
         let Value::Lit(Literal::LitInt(0)) = v else {
             panic!("Expected terminal LitInt(0), got {:?}", v);
         };
+    }
+}
+
+#[test]
+fn test_heap_to_value_lit_smallarray_null() {
+    let mut buf_data = AlignedBuf::<{ layout::LIT_SIZE }>([0u8; layout::LIT_SIZE]);
+    let ptr = buf_data.0.as_mut_ptr();
+    unsafe {
+        layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(ptr.add(layout::LIT_TAG_OFFSET)) = LIT_TAG_SMALLARRAY as u8;
+        // Null pointer for the array data
+        *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut *const u8) = std::ptr::null();
+
+        let res = heap_to_value(ptr);
+        assert!(
+            matches!(res, Err(BridgeError::NullPointer)),
+            "Expected NullPointer error, got {:?}",
+            res
+        );
+    }
+}
+
+#[test]
+fn test_heap_to_value_lit_array_null() {
+    let mut buf_data = AlignedBuf::<{ layout::LIT_SIZE }>([0u8; layout::LIT_SIZE]);
+    let ptr = buf_data.0.as_mut_ptr();
+    unsafe {
+        layout::write_header(ptr, layout::TAG_LIT, layout::LIT_SIZE as u16);
+        *(ptr.add(layout::LIT_TAG_OFFSET)) = LIT_TAG_ARRAY as u8;
+        // Null pointer for the array data
+        *(ptr.add(layout::LIT_VALUE_OFFSET) as *mut *const u8) = std::ptr::null();
+
+        let res = heap_to_value(ptr);
+        assert!(
+            matches!(res, Err(BridgeError::NullPointer)),
+            "Expected NullPointer error, got {:?}",
+            res
+        );
     }
 }


### PR DESCRIPTION
Wave-2 silent-fallback hardening, sibling to PR #295 (wave-1). Two leaves merged into this branch:

## Folded leaves

- **#297** `harden(bridge): drop PhantomData arity-0 fallback + Text decode diagnostics`
  - `PhantomData::to_value` no longer falls back to `table.iter().find(arity-0)` if `()` is missing — silently picking `Nothing`/`False`/`Tip` etc. as a phantom placeholder masked downstream decode bugs. Now errors with `BridgeError::UnknownDataConName("()")`.
  - `String::from_value` Text decode diagnostics now name the actual constructor encountered when shape mismatches, instead of the generic "ByteArray or ByteArray# in Text" message.
  - Adds 2 regression tests in `tidepool-bridge/tests/error_cases.rs`.

- **#299** `feat: harden(heap-bridge): surface array null pointer as BridgeError`
  - `LIT_TAG_SMALLARRAY` / `LIT_TAG_ARRAY` null payload pointers were silently decoded as `Ok(Value::Con(DataConId(0), vec![]))`. They now return `Err(BridgeError::NullPointer)` — a null where an array header is expected is unambiguously a JIT bug, not valid program output.
  - Successful array decodes still return `Value::Con(DataConId(0), elems)`; comment tightened to document the intentional sentinel contract per `core-shapes.md §1` (the wrapping Con provides type context).
  - `tidepool-codegen/src/lib.rs`: `pub(crate) mod layout` widened to `pub mod layout` so external tests can build worst-case-shape fixtures.
  - Adds 2 regression tests in `tidepool-codegen/tests/heap_bridge_tests.rs`.
  - Updates `docs/core-shapes/audit-heap-bridge.md` and `docs/core-shapes.md` to move the array-null entry from "silent fallbacks" to "hardened".

## Pattern (continues PR #295)

Each site converts a wrong-but-valid silent return to a structured `BridgeError`. Surfaced behavior is unchanged for valid programs; bugs that were previously masked now produce diagnostic errors instead of corrupted downstream state.

## Locked-in principle

debug_assert is for unreachable-by-invariant only. Silent fallbacks that mask shape mismatches must surface as errors. If hardening exposes a real bug (like #295 → #296), the bug gets filed and tracked, not silenced.

## Verification

- `cargo test --workspace` — 104 test suites green, 0 failures (matches pre-wave-2 baseline)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Test plan

- [x] `cargo test -p tidepool-bridge` covers PhantomData missing-`()` + Text wrong-shape diagnostic
- [x] `cargo test -p tidepool-codegen --test heap_bridge_tests` covers SmallArray/Array null-pointer error paths
- [x] `cargo test --workspace` regression sweep
- [x] No newly-surfaced bugs to file (none of the hardening exposed a downstream silent failure this round)