### PR TITLE
test: verified-generator proptest framework (fmap + text + cousins)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,11 +3624,13 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "proptest",
+ "serde_json",
  "tidepool-codegen",
  "tidepool-eval",
  "tidepool-heap",
  "tidepool-optimize",
  "tidepool-repr",
+ "tidepool-runtime",
 ]
 
 [[package]]

--- a/tidepool-testing/Cargo.toml
+++ b/tidepool-testing/Cargo.toml
@@ -17,6 +17,8 @@ tidepool-optimize = { version = "0.1.0", path = "../tidepool-optimize" }
 tidepool-codegen = { version = "0.1.0", path = "../tidepool-codegen" }
 proptest = "1.10.0"
 criterion = { version = "0.5", features = ["html_reports"] }
+serde_json = "1.0.149"
+tidepool-runtime = { version = "0.1.0", path = "../tidepool-runtime" }
 
 [[bench]]
 name = "eval"
@@ -33,3 +35,8 @@ harness = false
 [[bench]]
 name = "codegen"
 harness = false
+
+[[test]]
+name = "haskell_verified"
+path = "tests/haskell_verified/mod.rs"
+

--- a/tidepool-testing/tests/haskell_verified/README.md
+++ b/tidepool-testing/tests/haskell_verified/README.md
@@ -1,0 +1,37 @@
+# Haskell Verified Proptests
+
+This directory contains a property-testing framework that cross-validates Tidepool's JIT compilation and execution against Rust's native evaluation. It generates random, valid Haskell source snippets paired with their expected `serde_json::Value` (computed natively in Rust), then compiles and runs the Haskell source via the `compile_and_run_pure` engine to ensure the outputs match identically.
+
+## Architecture
+
+The framework relies on the `proptest` crate for generating inputs. Each template uses the following structure:
+1.  **Generator:** A function returning `impl Strategy<Value = (String, serde_json::Value)>`. The generator produces tuples of `(haskell_source_code, expected_json_value)`.
+2.  **Runner:** A `#[test]` function that invokes `run_template(cases, generator)`. This runner spins up the `compile_and_run_pure` environment, feeds it the generated source, and asserts structural equality between the JIT's JSON-serialized output and the expected JSON value.
+
+Example:
+```rust
+fn gen_fmap_maybe() -> impl Strategy<Value = (String, serde_json::Value)> {
+    (arb_int(), proptest::option::of(arb_int())).prop_map(|(n, maybe_m)| {
+        let src = match maybe_m {
+            Some(m) => format!("(fmap (+({})) (Just ({}) :: Maybe Int))", n, m),
+            None => format!("(fmap (+({})) (Nothing :: Maybe Int))", n),
+        };
+        let expected = match maybe_m {
+            Some(m) => json!(m + n),
+            None => json!(null),
+        };
+        (src, expected)
+    })
+}
+```
+
+## Adding a New Template
+
+1.  **Create a generator:** Write an `impl Strategy` function in the appropriate category module (`fmap.rs`, `text.rs`, etc.).
+2.  **Compute the expected value natively:** The expected value MUST be computed by standard Rust operations (e.g., `iterator.sum()`, `string.to_ascii_uppercase()`), not via `tidepool_eval` or tree-walking. This ensures an independent oracle.
+3.  **Avoid problematic bounds:** Do not use `f32`/`f64` because precision and `Show` differences lead to false positives. Restrict text characters to ASCII to bypass Unicode case-folding divergence between `std::char` and GHC's `Data.Char`.
+4.  **Register the test:** Provide a standard `#[test]` function wrapping the generator with `run_template(50, ...)` inside your module.
+
+## Cache Strategy
+
+The underlying test harness relies heavily on Tidepool's CBOR caching layer. Because GHC compilation is expensive, we rely on bounded parameters to improve cache hit rates. By constraining integers to `[-100, 100]`, limiting lists to small lengths, and picking from specific separator chars, the proptests achieve overlapping cache keys. Consequently, the first execution of the suite warms the cache (taking minutes), but subsequent runs execute rapidly.

--- a/tidepool-testing/tests/haskell_verified/cousins.rs
+++ b/tidepool-testing/tests/haskell_verified/cousins.rs
@@ -1,0 +1,86 @@
+use crate::{arb_int, run_template};
+use proptest::prelude::*;
+use serde_json::json;
+
+// Template 12 (list-comprehension)
+fn gen_list_comprehension() -> impl Strategy<Value = (String, serde_json::Value)> {
+    (arb_int(), proptest::collection::vec(arb_int(), 0..=8)).prop_map(|(n, xs): (i64, Vec<i64>)| {
+        let xs_str = xs
+            .iter()
+            .map(|x: &i64| x.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let src = format!("([ x * ({}) | x <- [{}], even x ] :: [Int])", n, xs_str);
+        let expected_list: Vec<i64> = xs.iter().filter(|x| *x % 2 == 0).map(|x| x * n).collect();
+        (src, json!(expected_list))
+    })
+}
+
+#[test]
+fn test_list_comprehension() {
+    run_template(50, gen_list_comprehension());
+}
+
+// Template 13 (maybe-monadic)
+fn gen_maybe_monadic() -> impl Strategy<Value = (String, serde_json::Value)> {
+    (
+        proptest::option::of(arb_int()),
+        proptest::option::of(arb_int()),
+    )
+        .prop_map(|(maybe_x, maybe_y): (Option<i64>, Option<i64>)| {
+            let x_src = match maybe_x {
+                Some(x) => format!("(Just ({}) :: Maybe Int)", x),
+                None => "(Nothing :: Maybe Int)".to_string(),
+            };
+            let y_src = match maybe_y {
+                Some(y) => format!("(Just ({}) :: Maybe Int)", y),
+                None => "(Nothing :: Maybe Int)".to_string(),
+            };
+            let src = format!(
+                "(do {{ x <- {}; y <- {}; pure (x + y) }} :: Maybe Int)",
+                x_src, y_src
+            );
+
+            let expected = match (maybe_x, maybe_y) {
+                (Some(x), Some(y)) => json!(x + y),
+                _ => json!(null),
+            };
+            (src, expected)
+        })
+}
+
+#[test]
+fn test_maybe_monadic() {
+    run_template(50, gen_maybe_monadic());
+}
+
+// Template 14 (list-fold)
+fn gen_list_fold() -> impl Strategy<Value = (String, serde_json::Value)> {
+    prop_oneof![
+        proptest::collection::vec(arb_int(), 0..=8).prop_map(|xs: Vec<i64>| {
+            let xs_str = xs
+                .iter()
+                .map(|x: &i64| x.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let src = format!("(foldl' (+) 0 [{}] :: Int)", xs_str);
+            let expected: i64 = xs.iter().sum();
+            (src, json!(expected))
+        }),
+        proptest::collection::vec(arb_int(), 0..=8).prop_map(|xs: Vec<i64>| {
+            let xs_str = xs
+                .iter()
+                .map(|x: &i64| x.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let src = format!("(foldr (+) 0 [{}] :: Int)", xs_str);
+            let expected: i64 = xs.iter().sum();
+            (src, json!(expected))
+        })
+    ]
+}
+
+#[test]
+fn test_list_fold() {
+    run_template(50, gen_list_fold());
+}

--- a/tidepool-testing/tests/haskell_verified/fmap.rs
+++ b/tidepool-testing/tests/haskell_verified/fmap.rs
@@ -2,19 +2,21 @@ use crate::{arb_int, arb_text, run_template};
 use proptest::prelude::*;
 use serde_json::json;
 
-// Template 1 (fmap-maybe): `pure (fmap (+{n}) ({maybe} :: Maybe Int))`
+// Template 1 (fmap-maybe): `(fmap (+{n}) ({maybe} :: Maybe Int))`
+//
+// In the `Nothing` arm the function is never applied, so `n` is fixed at 0
+// to avoid burning compile-cache slots on semantically-identical sources.
 fn gen_fmap_maybe() -> impl Strategy<Value = (String, serde_json::Value)> {
-    (arb_int(), proptest::option::of(arb_int())).prop_map(|(n, maybe_m): (i64, Option<i64>)| {
-        let src = match maybe_m {
-            Some(m) => format!("(fmap (+({})) (Just ({}) :: Maybe Int))", n, m),
-            None => format!("(fmap (+({})) (Nothing :: Maybe Int))", n),
-        };
-        let expected = match maybe_m {
-            Some(m) => json!(m + n),
-            None => json!(null),
-        };
-        (src, expected)
-    })
+    prop_oneof![
+        (arb_int(), arb_int()).prop_map(|(n, m): (i64, i64)| {
+            let src = format!("(fmap (+({})) (Just ({}) :: Maybe Int))", n, m);
+            (src, json!(m + n))
+        }),
+        Just(()).prop_map(|()| {
+            let src = "(fmap (+(0)) (Nothing :: Maybe Int))".to_string();
+            (src, json!(null))
+        })
+    ]
 }
 
 #[test]
@@ -41,16 +43,19 @@ fn test_fmap_list() {
     run_template(50, gen_fmap_list());
 }
 
-// Template 3 (fmap-either): `pure (fmap (+{n}) (Right {m} :: Either Text Int))`
-// and `pure (fmap (+{n}) (Left "{s}" :: Either Text Int))`
+// Template 3 (fmap-either): `(fmap (+{n}) (Right {m} :: Either Text Int))`
+// and `(fmap (+0) (Left "{s}" :: Either Text Int))`
+//
+// In the `Left` arm the function is never applied; `n` is fixed at 0 to
+// keep distinct sources count proportional to actual coverage.
 fn gen_fmap_either() -> impl Strategy<Value = (String, serde_json::Value)> {
     prop_oneof![
         (arb_int(), arb_int()).prop_map(|(n, m): (i64, i64)| {
             let src = format!("(fmap (+({})) (Right ({}) :: Either T.Text Int))", n, m);
             (src, json!({"constructor": "Right", "fields": [m + n]}))
         }),
-        (arb_int(), arb_text()).prop_map(|(n, s): (i64, String)| {
-            let src = format!("(fmap (+({})) (Left {:?} :: Either T.Text Int))", n, s);
+        arb_text().prop_map(|s: String| {
+            let src = format!("(fmap (+(0)) (Left {:?} :: Either T.Text Int))", s);
             (src, json!({"constructor": "Left", "fields": [s]}))
         })
     ]
@@ -61,31 +66,41 @@ fn test_fmap_either() {
     run_template(50, gen_fmap_either());
 }
 
-// Template 4 (fmap-nested): `pure (fmap (fmap (+{n})) (Just (Just {m} :: Maybe Int) :: Maybe (Maybe Int)))`
+// Template 4 (fmap-nested): `(fmap (fmap (+{n})) (Just (Just {m} :: Maybe Int) :: Maybe (Maybe Int)))`
+// and `(fmap (fmap (+{n})) (Just [{xs}] :: Maybe [Int]))`.
+//
+// Nested-Maybe stacks like `Maybe (Maybe Int)` collapse `Just Nothing` and
+// `Nothing` to the same JSON `null` (the Haskell-to-JSON rendering convention
+// for `Maybe`), so the JSON oracle cannot tell those two apart. We only
+// exercise the unambiguous `Just (Just m)` case here. To preserve coverage of
+// structural distinguishing — outer-Just-vs-Nothing AND inner-empty-vs-full —
+// the second arm uses `Maybe [Int]` which renders as `[…]` vs `null` and
+// distinguishes `Just []` from `Nothing`.
 fn gen_fmap_nested() -> impl Strategy<Value = (String, serde_json::Value)> {
-    (
-        arb_int(),
-        proptest::option::of(proptest::option::of(arb_int())),
-    )
-        .prop_map(|(n, maybe_maybe_m): (i64, Option<Option<i64>>)| {
-            let src = match maybe_maybe_m {
-                Some(Some(m)) => format!(
-                    "(fmap (fmap (+({}))) (Just (Just ({}) :: Maybe Int) :: Maybe (Maybe Int)))",
-                    n, m
-                ),
-                Some(None) => format!(
-                    "(fmap (fmap (+({}))) (Just (Nothing :: Maybe Int) :: Maybe (Maybe Int)))",
-                    n
-                ),
-                None => format!("(fmap (fmap (+({}))) (Nothing :: Maybe (Maybe Int)))", n),
-            };
-            let expected = match maybe_maybe_m {
-                Some(Some(m)) => json!(m + n),
-                Some(None) => json!(null),
-                None => json!(null),
-            };
-            (src, expected)
+    prop_oneof![
+        (arb_int(), arb_int()).prop_map(|(n, m): (i64, i64)| {
+            let src = format!(
+                "(fmap (fmap (+({}))) (Just (Just ({}) :: Maybe Int) :: Maybe (Maybe Int)))",
+                n, m
+            );
+            (src, json!(m + n))
+        }),
+        (arb_int(), proptest::collection::vec(arb_int(), 0..=8)).prop_map(
+            |(n, xs): (i64, Vec<i64>)| {
+                let xs_str = xs.iter().map(i64::to_string).collect::<Vec<_>>().join(", ");
+                let src = format!(
+                    "(fmap (fmap (+({}))) (Just [{}] :: Maybe [Int]))",
+                    n, xs_str
+                );
+                let expected: Vec<i64> = xs.iter().map(|x| x + n).collect();
+                (src, json!(expected))
+            }
+        ),
+        Just(()).prop_map(|()| {
+            let src = "(fmap (fmap (+(0))) (Nothing :: Maybe [Int]))".to_string();
+            (src, json!(null))
         })
+    ]
 }
 
 #[test]

--- a/tidepool-testing/tests/haskell_verified/fmap.rs
+++ b/tidepool-testing/tests/haskell_verified/fmap.rs
@@ -1,0 +1,108 @@
+use crate::{arb_int, arb_text, run_template};
+use proptest::prelude::*;
+use serde_json::json;
+
+// Template 1 (fmap-maybe): `pure (fmap (+{n}) ({maybe} :: Maybe Int))`
+fn gen_fmap_maybe() -> impl Strategy<Value = (String, serde_json::Value)> {
+    (arb_int(), proptest::option::of(arb_int())).prop_map(|(n, maybe_m): (i64, Option<i64>)| {
+        let src = match maybe_m {
+            Some(m) => format!("(fmap (+({})) (Just ({}) :: Maybe Int))", n, m),
+            None => format!("(fmap (+({})) (Nothing :: Maybe Int))", n),
+        };
+        let expected = match maybe_m {
+            Some(m) => json!(m + n),
+            None => json!(null),
+        };
+        (src, expected)
+    })
+}
+
+#[test]
+fn test_fmap_maybe() {
+    run_template(50, gen_fmap_maybe());
+}
+
+// Template 2 (fmap-list): `pure (fmap (* {n}) ([{xs}] :: [Int]))`
+fn gen_fmap_list() -> impl Strategy<Value = (String, serde_json::Value)> {
+    (arb_int(), proptest::collection::vec(arb_int(), 0..=8)).prop_map(|(n, xs): (i64, Vec<i64>)| {
+        let xs_str = xs
+            .iter()
+            .map(|x: &i64| x.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let src = format!("(fmap (* ({})) ([{}] :: [Int]))", n, xs_str);
+        let expected_list: Vec<i64> = xs.iter().map(|x: &i64| x * n).collect();
+        (src, json!(expected_list))
+    })
+}
+
+#[test]
+fn test_fmap_list() {
+    run_template(50, gen_fmap_list());
+}
+
+// Template 3 (fmap-either): `pure (fmap (+{n}) (Right {m} :: Either Text Int))`
+// and `pure (fmap (+{n}) (Left "{s}" :: Either Text Int))`
+fn gen_fmap_either() -> impl Strategy<Value = (String, serde_json::Value)> {
+    prop_oneof![
+        (arb_int(), arb_int()).prop_map(|(n, m): (i64, i64)| {
+            let src = format!("(fmap (+({})) (Right ({}) :: Either T.Text Int))", n, m);
+            (src, json!({"constructor": "Right", "fields": [m + n]}))
+        }),
+        (arb_int(), arb_text()).prop_map(|(n, s): (i64, String)| {
+            let src = format!("(fmap (+({})) (Left {:?} :: Either T.Text Int))", n, s);
+            (src, json!({"constructor": "Left", "fields": [s]}))
+        })
+    ]
+}
+
+#[test]
+fn test_fmap_either() {
+    run_template(50, gen_fmap_either());
+}
+
+// Template 4 (fmap-nested): `pure (fmap (fmap (+{n})) (Just (Just {m} :: Maybe Int) :: Maybe (Maybe Int)))`
+fn gen_fmap_nested() -> impl Strategy<Value = (String, serde_json::Value)> {
+    (
+        arb_int(),
+        proptest::option::of(proptest::option::of(arb_int())),
+    )
+        .prop_map(|(n, maybe_maybe_m): (i64, Option<Option<i64>>)| {
+            let src = match maybe_maybe_m {
+                Some(Some(m)) => format!(
+                    "(fmap (fmap (+({}))) (Just (Just ({}) :: Maybe Int) :: Maybe (Maybe Int)))",
+                    n, m
+                ),
+                Some(None) => format!(
+                    "(fmap (fmap (+({}))) (Just (Nothing :: Maybe Int) :: Maybe (Maybe Int)))",
+                    n
+                ),
+                None => format!("(fmap (fmap (+({}))) (Nothing :: Maybe (Maybe Int)))", n),
+            };
+            let expected = match maybe_maybe_m {
+                Some(Some(m)) => json!(m + n),
+                Some(None) => json!(null),
+                None => json!(null),
+            };
+            (src, expected)
+        })
+}
+
+#[test]
+fn test_fmap_nested() {
+    run_template(50, gen_fmap_nested());
+}
+
+// Template 5 (fmap-tuple): `pure (fmap (+{n}) (("{s}", {m}) :: (Text, Int)))`
+fn gen_fmap_tuple() -> impl Strategy<Value = (String, serde_json::Value)> {
+    (arb_int(), arb_text(), arb_int()).prop_map(|(n, s, m): (i64, String, i64)| {
+        let src = format!("(fmap (+({})) (({:?}, {}) :: (T.Text, Int)))", n, s, m);
+        let expected = json!([s, m + n]);
+        (src, expected)
+    })
+}
+
+#[test]
+fn test_fmap_tuple() {
+    run_template(50, gen_fmap_tuple());
+}

--- a/tidepool-testing/tests/haskell_verified/mod.rs
+++ b/tidepool-testing/tests/haskell_verified/mod.rs
@@ -1,0 +1,68 @@
+use proptest::strategy::Strategy;
+use proptest::test_runner::{Config, TestRunner};
+use std::path::{Path, PathBuf};
+
+pub mod cousins;
+pub mod fmap;
+pub mod text;
+
+fn prelude_path() -> PathBuf {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest.parent().unwrap().join("haskell").join("lib")
+}
+
+pub fn compile_run_pure(src: &str) -> serde_json::Value {
+    let pp = prelude_path();
+    let include = [pp.as_path()];
+
+    // We wrap the src in a basic module template
+    let full_src = format!(
+        r#"{{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, PartialTypeSignatures #-}}
+module Test where
+import Tidepool.Prelude
+import qualified Data.Text as T
+
+result :: _
+result = {}
+"#,
+        src
+    );
+
+    let val =
+        tidepool_runtime::compile_and_run_pure(&full_src, "result", &include).unwrap_or_else(|e| {
+            panic!(
+                "compile_and_run_pure failed: {:?}\nSource:\n{}",
+                e, full_src
+            )
+        });
+    val.to_json()
+}
+
+pub fn compare_json(jit_value: &serde_json::Value, expected_value: &serde_json::Value, src: &str) {
+    if jit_value != expected_value {
+        panic!(
+            "Mismatch!\nSource:\n{}\nExpected:\n{}\nActual:\n{}\n",
+            src, expected_value, jit_value
+        );
+    }
+}
+
+pub fn run_template<S: Strategy<Value = (String, serde_json::Value)>>(cases: u32, strategy: S) {
+    let mut runner = TestRunner::new(Config::with_cases(cases));
+    let res = runner.run(&strategy, |(src, expected)| {
+        let actual = compile_run_pure(&src);
+        compare_json(&actual, &expected, &src);
+        Ok(())
+    });
+    if let Err(e) = res {
+        panic!("Proptest failed: {:?}", e);
+    }
+}
+
+pub fn arb_int() -> impl Strategy<Value = i64> {
+    -100i64..=100
+}
+
+pub fn arb_text() -> impl Strategy<Value = String> {
+    proptest::string::string_regex(r"[a-zA-Z0-9 \.,!]{0,30}").unwrap()
+}

--- a/tidepool-testing/tests/haskell_verified/text.rs
+++ b/tidepool-testing/tests/haskell_verified/text.rs
@@ -85,23 +85,43 @@ fn test_text_pred() {
 }
 
 // Template 8 (text-case)
+//
+// The empty-string fast path triggers #302 (T.toUpper/T.toLower on "" yield
+// UnresolvedVar). We filter empty inputs from the active template to preserve
+// non-empty coverage and keep a separate, explicit regression test below for
+// the empty-string case. When #302 is fixed, drop the filter and remove the
+// regression test (or convert it to assert success).
 fn gen_text_case() -> impl Strategy<Value = (String, serde_json::Value)> {
     prop_oneof![
-        arb_text().prop_map(|s: String| {
-            let src = format!("(T.toUpper {:?})", s);
-            (src, json!(s.to_ascii_uppercase()))
-        }),
-        arb_text().prop_map(|s: String| {
-            let src = format!("(T.toLower {:?})", s);
-            (src, json!(s.to_ascii_lowercase()))
-        })
+        arb_text()
+            .prop_filter("non-empty (#302)", |s| !s.is_empty())
+            .prop_map(|s: String| {
+                let src = format!("(T.toUpper {:?})", s);
+                (src, json!(s.to_ascii_uppercase()))
+            }),
+        arb_text()
+            .prop_filter("non-empty (#302)", |s| !s.is_empty())
+            .prop_map(|s: String| {
+                let src = format!("(T.toLower {:?})", s);
+                (src, json!(s.to_ascii_lowercase()))
+            })
     ]
 }
 
 #[test]
-#[ignore = "exposes #302 — T.toUpper/T.toLower on empty Text yields UnresolvedVar"]
 fn test_text_case() {
     run_template(50, gen_text_case());
+}
+
+/// Targeted regression for #302 — T.toUpper/T.toLower on empty Text yields
+/// UnresolvedVar. Re-enable (and assert success) when #302 lands.
+#[test]
+#[ignore = "exposes #302 — T.toUpper/T.toLower on empty Text yields UnresolvedVar"]
+fn test_text_case_empty_string_regression() {
+    let upper = crate::compile_run_pure(r#"(T.toUpper "")"#);
+    assert_eq!(upper, json!(""));
+    let lower = crate::compile_run_pure(r#"(T.toLower "")"#);
+    assert_eq!(lower, json!(""));
 }
 
 // Template 9 (text-split-join)

--- a/tidepool-testing/tests/haskell_verified/text.rs
+++ b/tidepool-testing/tests/haskell_verified/text.rs
@@ -1,0 +1,176 @@
+use crate::{arb_text, run_template};
+use proptest::prelude::*;
+use serde_json::json;
+
+fn arb_nat() -> impl Strategy<Value = usize> {
+    0usize..=40
+}
+
+fn arb_sep() -> impl Strategy<Value = String> {
+    proptest::sample::select(vec![
+        ",".to_string(),
+        " ".to_string(),
+        "-".to_string(),
+        ";".to_string(),
+    ])
+}
+
+// Template 6 (text-slice)
+fn gen_text_slice() -> impl Strategy<Value = (String, serde_json::Value)> {
+    prop_oneof![
+        (arb_nat(), arb_text()).prop_map(|(n, s): (usize, String)| {
+            let src = format!("(T.take {} {:?})", n, s);
+            let expected = s.chars().take(n).collect::<String>();
+            (src, json!(expected))
+        }),
+        (arb_nat(), arb_text()).prop_map(|(n, s): (usize, String)| {
+            let src = format!("(T.drop {} {:?})", n, s);
+            let expected = s.chars().skip(n).collect::<String>();
+            (src, json!(expected))
+        }),
+        (arb_nat(), arb_text()).prop_map(|(n, s): (usize, String)| {
+            let src = format!("(T.splitAt {} {:?})", n, s);
+            let left = s.chars().take(n).collect::<String>();
+            let right = s.chars().skip(n).collect::<String>();
+            (src, json!([left, right]))
+        }),
+        arb_text().prop_map(|s: String| {
+            let src = format!("(T.length {:?})", s);
+            let expected = s.chars().count();
+            (src, json!(expected))
+        }),
+        arb_text().prop_map(|s: String| {
+            let src = format!("(T.null {:?})", s);
+            let expected = s.is_empty();
+            (src, json!(expected))
+        })
+    ]
+}
+
+#[test]
+fn test_text_slice() {
+    run_template(50, gen_text_slice());
+}
+
+// Template 7 (text-pred)
+fn gen_text_pred() -> impl Strategy<Value = (String, serde_json::Value)> {
+    prop_oneof![
+        arb_text().prop_map(|s: String| {
+            // isAlpha
+            let src = format!(
+                "(T.takeWhile (\\c -> (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {:?})",
+                s
+            );
+            let expected = s
+                .chars()
+                .take_while(|c: &char| c.is_ascii_alphabetic())
+                .collect::<String>();
+            (src, json!(expected))
+        }),
+        arb_text().prop_map(|s: String| {
+            // dropWhile isDigit
+            let src = format!("(T.dropWhile (\\c -> c >= '0' && c <= '9') {:?})", s);
+            let expected = s
+                .chars()
+                .skip_while(|c: &char| c.is_ascii_digit())
+                .collect::<String>();
+            (src, json!(expected))
+        })
+    ]
+}
+
+#[test]
+fn test_text_pred() {
+    run_template(50, gen_text_pred());
+}
+
+// Template 8 (text-case)
+fn gen_text_case() -> impl Strategy<Value = (String, serde_json::Value)> {
+    prop_oneof![
+        arb_text().prop_map(|s: String| {
+            let src = format!("(T.toUpper {:?})", s);
+            (src, json!(s.to_ascii_uppercase()))
+        }),
+        arb_text().prop_map(|s: String| {
+            let src = format!("(T.toLower {:?})", s);
+            (src, json!(s.to_ascii_lowercase()))
+        })
+    ]
+}
+
+#[test]
+#[ignore = "exposes #302 — T.toUpper/T.toLower on empty Text yields UnresolvedVar"]
+fn test_text_case() {
+    run_template(50, gen_text_case());
+}
+
+// Template 9 (text-split-join)
+fn gen_text_split_join() -> impl Strategy<Value = (String, serde_json::Value)> {
+    prop_oneof![
+        (arb_sep(), arb_text()).prop_map(|(sep, s): (String, String)| {
+            let src = format!("(T.splitOn {:?} {:?})", sep, s);
+            let expected: Vec<&str> = s.split(&sep).collect();
+            (src, json!(expected))
+        }),
+        (arb_sep(), arb_text(), arb_text(), arb_text()).prop_map(
+            |(sep, a, b, c): (String, String, String, String)| {
+                let src = format!("(T.intercalate {:?} [{:?}, {:?}, {:?}])", sep, a, b, c);
+                let expected = [a.as_str(), b.as_str(), c.as_str()].join(&sep);
+                (src, json!(expected))
+            }
+        )
+    ]
+}
+
+#[test]
+fn test_text_split_join() {
+    run_template(50, gen_text_split_join());
+}
+
+// Template 10 (text-strip-replace)
+fn gen_text_strip_replace() -> impl Strategy<Value = (String, serde_json::Value)> {
+    prop_oneof![
+        (proptest::string::string_regex(r" {0,3}[a-zA-Z0-9, \.!]{0,20} {0,3}").unwrap()).prop_map(
+            |s: String| {
+                let src = format!("(T.strip {:?})", s);
+                let expected = s.trim();
+                (src, json!(expected))
+            }
+        ),
+        (arb_sep(), arb_sep(), arb_text()).prop_map(
+            |(needle, repl, s): (String, String, String)| {
+                let src = format!("(T.replace {:?} {:?} {:?})", needle, repl, s);
+                let expected = s.replace(&needle, &repl);
+                (src, json!(expected))
+            }
+        )
+    ]
+}
+
+#[test]
+fn test_text_strip_replace() {
+    run_template(50, gen_text_strip_replace());
+}
+
+// Template 11 (text-prefix-checks)
+fn gen_text_prefix_checks() -> impl Strategy<Value = (String, serde_json::Value)> {
+    prop_oneof![
+        (arb_text(), arb_text()).prop_map(|(p, s): (String, String)| {
+            let src = format!("(T.isPrefixOf {:?} {:?})", p, s);
+            (src, json!(s.starts_with(&p)))
+        }),
+        (arb_text(), arb_text()).prop_map(|(p, s): (String, String)| {
+            let src = format!("(T.isSuffixOf {:?} {:?})", p, s);
+            (src, json!(s.ends_with(&p)))
+        }),
+        (arb_text(), arb_text()).prop_map(|(p, s): (String, String)| {
+            let src = format!("(T.isInfixOf {:?} {:?})", p, s);
+            (src, json!(s.contains(&p)))
+        })
+    ]
+}
+
+#[test]
+fn test_text_prefix_checks() {
+    run_template(50, gen_text_prefix_checks());
+}


### PR DESCRIPTION
Layer 1B from a confidence-pitch discussion. 14 proptest templates (13 active + 1 \`#[ignore]\`'d on a surfaced bug) that emit Haskell source paired with the expected \`Value\` computed independently in Rust. JIT and Rust agreeing is independent evidence.

## Framework (\`tidepool-testing/tests/haskell_verified/\`)

- \`mod.rs\` — \`compile_run_pure\` helper, \`run_template\` runner, shared generators
- \`fmap.rs\` — 5 templates exercising Functor instances
- \`text.rs\` — 6 active + 1 ignored, exercising the Tidepool Text surface
- \`cousins.rs\` — 3 templates (list comprehension, Maybe monadic, fold)
- \`README.md\` — how-to-add-a-new-template guide

\`ProptestConfig::with_cases(50)\` per template; bounded ASCII Text + Int in [-100, 100] for cache-friendly CBOR re-use.

## Boundary contracts honored

- ASCII-only Text (no Unicode case-folding edge cases)
- Int-only arithmetic (no Float display formatting divergence)
- Pinned types via \`::\` annotations (no polymorphic typeclass dispatch)
- No \`read\`/\`reads\`, no floats, no Unicode

## Bug surfaced

\`T.toUpper ""\` / \`T.toLower ""\` yield \`UnresolvedVar\` instead of returning empty Text. Filed as **#302**; \`test_text_case\` is \`#[ignore]\`'d with a reference. Non-empty input works correctly.

## Test plan

- \`cargo test -p tidepool-testing --test haskell_verified\` \u2014 13 pass, 1 ignored, 0 failed (~270s cold, faster warm)
- \`cargo test --workspace\` \u2014 clean
- \`cargo clippy --workspace --all-targets -- -D warnings\` \u2014 clean
- \`cargo fmt --all -- --check\` \u2014 clean
- Pre-push hook \u2014 passes

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)