### PR TITLE
feat: Add verified-generator proptest templates for Data.Map and Data.Set

### DIFF
--- a/tidepool-testing/tests/haskell_verified/map_set.rs
+++ b/tidepool-testing/tests/haskell_verified/map_set.rs
@@ -8,6 +8,115 @@
 
 #![allow(unused_imports)]
 
-use crate::{arb_int, run_template};
+use crate::{arb_int, run_template, run_template_with_imports};
 use proptest::prelude::*;
 use serde_json::json;
+use std::collections::{HashMap, HashSet};
+
+fn arb_map_kvs() -> impl Strategy<Value = HashMap<i64, i64>> {
+    proptest::collection::hash_map(arb_int(), arb_int(), 0..=8)
+}
+
+fn arb_set_ks() -> impl Strategy<Value = HashSet<i64>> {
+    proptest::collection::hash_set(arb_int(), 0..=8)
+}
+
+#[test]
+fn map_fromlist_lookup() {
+    let strat = (arb_int(), arb_map_kvs()).prop_map(|(k, kvs)| {
+        let pairs: Vec<_> = kvs
+            .iter()
+            .map(|(key, val)| format!("({}, {})", key, val))
+            .collect();
+        let pairs_str = pairs.join(", ");
+        let src = format!(
+            "Map.lookup ({}) (Map.fromList [{}] :: Map Int Int) :: Maybe Int",
+            k, pairs_str
+        );
+        let expected = match kvs.get(&k) {
+            Some(v) => json!(v),
+            None => json!(null),
+        };
+        (src, expected)
+    });
+    run_template_with_imports(50, strat, &["import qualified Data.Map.Strict as Map"]);
+}
+
+#[test]
+fn map_insert_lookup() {
+    let strat = (arb_int(), arb_int(), arb_map_kvs()).prop_map(|(k, v, kvs)| {
+        let pairs: Vec<_> = kvs
+            .iter()
+            .map(|(key, val)| format!("({}, {})", key, val))
+            .collect();
+        let pairs_str = pairs.join(", ");
+        let src = format!(
+            "Map.lookup ({}) (Map.insert ({}) ({}) (Map.fromList [{}] :: Map Int Int)) :: Maybe Int",
+            k, k, v, pairs_str
+        );
+        let expected = json!(v);
+        (src, expected)
+    });
+    run_template_with_imports(50, strat, &["import qualified Data.Map.Strict as Map"]);
+}
+
+#[test]
+fn map_union() {
+    let strat = (arb_int(), arb_map_kvs(), arb_map_kvs()).prop_map(|(k, left, right)| {
+        let l_pairs: Vec<_> = left
+            .iter()
+            .map(|(key, val)| format!("({}, {})", key, val))
+            .collect();
+        let r_pairs: Vec<_> = right
+            .iter()
+            .map(|(key, val)| format!("({}, {})", key, val))
+            .collect();
+        let l_str = l_pairs.join(", ");
+        let r_str = r_pairs.join(", ");
+        let src = format!(
+            "Map.lookup ({}) (Map.union (Map.fromList [{}] :: Map Int Int) (Map.fromList [{}] :: Map Int Int)) :: Maybe Int",
+            k, l_str, r_str
+        );
+
+        let expected_val = left.get(&k).or_else(|| right.get(&k));
+        let expected = match expected_val {
+            Some(v) => json!(v),
+            None => json!(null),
+        };
+        (src, expected)
+    });
+    run_template_with_imports(50, strat, &["import qualified Data.Map.Strict as Map"]);
+}
+
+#[test]
+fn set_fromlist_member() {
+    let strat = (arb_int(), arb_set_ks()).prop_map(|(k, ks)| {
+        let elems: Vec<_> = ks.iter().map(|key| format!("{}", key)).collect();
+        let elems_str = elems.join(", ");
+        let src = format!(
+            "Set.member ({}) (Set.fromList [{}] :: Set Int) :: Bool",
+            k, elems_str
+        );
+        let expected = json!(ks.contains(&k));
+        (src, expected)
+    });
+    run_template_with_imports(50, strat, &["import qualified Data.Set as Set"]);
+}
+
+#[test]
+fn set_union() {
+    let strat = (arb_int(), arb_set_ks(), arb_set_ks()).prop_map(|(k, left, right)| {
+        let l_elems: Vec<_> = left.iter().map(|key| format!("{}", key)).collect();
+        let r_elems: Vec<_> = right.iter().map(|key| format!("{}", key)).collect();
+        let l_str = l_elems.join(", ");
+        let r_str = r_elems.join(", ");
+        let src = format!(
+            "Set.member ({}) (Set.union (Set.fromList [{}] :: Set Int) (Set.fromList [{}] :: Set Int)) :: Bool",
+            k, l_str, r_str
+        );
+
+        let expected = json!(left.contains(&k) || right.contains(&k));
+        (src, expected)
+    });
+    run_template_with_imports(50, strat, &["import qualified Data.Set as Set"]);
+}

--- a/tidepool-testing/tests/haskell_verified/map_set.rs
+++ b/tidepool-testing/tests/haskell_verified/map_set.rs
@@ -6,19 +6,17 @@
 //! `fmap.rs` / `text.rs` / `cousins.rs`. ASCII-only, Int-only, pinned types,
 //! `ProptestConfig::with_cases(50)` per template.
 
-#![allow(unused_imports)]
-
-use crate::{arb_int, run_template, run_template_with_imports};
+use crate::{arb_int, run_template_with_imports};
 use proptest::prelude::*;
 use serde_json::json;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
-fn arb_map_kvs() -> impl Strategy<Value = HashMap<i64, i64>> {
-    proptest::collection::hash_map(arb_int(), arb_int(), 0..=8)
+fn arb_map_kvs() -> impl Strategy<Value = BTreeMap<i64, i64>> {
+    proptest::collection::btree_map(arb_int(), arb_int(), 0..=8)
 }
 
-fn arb_set_ks() -> impl Strategy<Value = HashSet<i64>> {
-    proptest::collection::hash_set(arb_int(), 0..=8)
+fn arb_set_ks() -> impl Strategy<Value = BTreeSet<i64>> {
+    proptest::collection::btree_set(arb_int(), 0..=8)
 }
 
 #[test]

--- a/tidepool-testing/tests/haskell_verified/mod.rs
+++ b/tidepool-testing/tests/haskell_verified/mod.rs
@@ -16,20 +16,25 @@ fn prelude_path() -> PathBuf {
 }
 
 pub fn compile_run_pure(src: &str) -> serde_json::Value {
+    compile_run_pure_with_imports(src, &[])
+}
+
+pub fn compile_run_pure_with_imports(src: &str, extra_imports: &[&str]) -> serde_json::Value {
     let pp = prelude_path();
     let include = [pp.as_path()];
 
-    // We wrap the src in a basic module template
+    let imports = extra_imports.join("\n");
     let full_src = format!(
         r#"{{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, PartialTypeSignatures #-}}
 module Test where
 import Tidepool.Prelude
 import qualified Data.Text as T
+{}
 
 result :: _
 result = {}
 "#,
-        src
+        imports, src
     );
 
     let val =
@@ -52,9 +57,17 @@ pub fn compare_json(jit_value: &serde_json::Value, expected_value: &serde_json::
 }
 
 pub fn run_template<S: Strategy<Value = (String, serde_json::Value)>>(cases: u32, strategy: S) {
+    run_template_with_imports(cases, strategy, &[])
+}
+
+pub fn run_template_with_imports<S: Strategy<Value = (String, serde_json::Value)>>(
+    cases: u32,
+    strategy: S,
+    extra_imports: &[&str],
+) {
     let mut runner = TestRunner::new(Config::with_cases(cases));
     let res = runner.run(&strategy, |(src, expected)| {
-        let actual = compile_run_pure(&src);
+        let actual = compile_run_pure_with_imports(&src, extra_imports);
         compare_json(&actual, &expected, &src);
         Ok(())
     });

--- a/tidepool-testing/tests/haskell_verified/mod.rs
+++ b/tidepool-testing/tests/haskell_verified/mod.rs
@@ -16,14 +16,13 @@ fn prelude_path() -> PathBuf {
 }
 
 pub fn compile_run_pure(src: &str) -> serde_json::Value {
-    compile_run_pure_with_imports(src, &[])
+    compile_run_pure_with_imports(src, "")
 }
 
-pub fn compile_run_pure_with_imports(src: &str, extra_imports: &[&str]) -> serde_json::Value {
+pub fn compile_run_pure_with_imports(src: &str, extra_imports: &str) -> serde_json::Value {
     let pp = prelude_path();
     let include = [pp.as_path()];
 
-    let imports = extra_imports.join("\n");
     let full_src = format!(
         r#"{{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, PartialTypeSignatures #-}}
 module Test where
@@ -34,7 +33,7 @@ import qualified Data.Text as T
 result :: _
 result = {}
 "#,
-        imports, src
+        extra_imports, src
     );
 
     let val =
@@ -65,9 +64,10 @@ pub fn run_template_with_imports<S: Strategy<Value = (String, serde_json::Value)
     strategy: S,
     extra_imports: &[&str],
 ) {
+    let imports_str = extra_imports.join("\n");
     let mut runner = TestRunner::new(Config::with_cases(cases));
     let res = runner.run(&strategy, |(src, expected)| {
-        let actual = compile_run_pure_with_imports(&src, extra_imports);
+        let actual = compile_run_pure_with_imports(&src, &imports_str);
         compare_json(&actual, &expected, &src);
         Ok(())
     });


### PR DESCRIPTION
This PR implements verified-generator proptest templates for `Data.Map` and `Data.Set` operations (`Map.fromList`, `Map.lookup`, `Map.insert`, `Map.union`, `Set.fromList`, `Set.member`, `Set.union`) over `Int` keys and values in `tidepool-testing/tests/haskell_verified/map_set.rs`.

Changes made:
- Added `compile_run_pure_with_imports` and `run_template_with_imports` helpers in `mod.rs` to allow testing code requiring qualified module imports (`Data.Map.Strict as Map`, `Data.Set as Set`).
- Implemented tests using `HashMap` and `HashSet` state directly mapped to explicit `.fromList [...]` calls.
- Enforced `:: Map Int Int` and `:: Set Int` signatures to avoid `Integer` defaulting issues and missing GHC bignum FFI calls.
- Mapped explicit `null` expectations to `Maybe Int` translating `Nothing` as `null` and `Just v` as `v` in Tidepool's JSON conversion.
- Verified test compliance using `pre-push` hooks. All tests successfully run and pass.

Update based on review:
- Used `BTreeMap` and `BTreeSet` instead of `HashMap` and `HashSet` to ensure deterministic generated Haskell source expressions for Map and Set operations.
- Updated `compile_run_pure_with_imports` to accept a single `extra_imports` string and pre-joined it in `run_template_with_imports` to avoid multiple allocations per iteration.
- Removed unused `#![allow(unused_imports)]` and `run_template` from `map_set.rs`.