### PR TITLE
fix(pipeline): bytecode-provision TH/QQ splices (unbreaks aarch64-darwin)

### DIFF
--- a/haskell/src/Tidepool/GhcPipeline.hs
+++ b/haskell/src/Tidepool/GhcPipeline.hs
@@ -96,6 +96,12 @@ runPipeline path includes = do
     -- they never re-enter the fresh EPS, and typechecking fails with e.g.
     -- "No instance for Monad (Eff '[Console, …])".
     modGraphRaw <- depanal [] False
+    -- unpoison: keep the EPS healthy under the TH/QQ downgrade by unsetting
+    -- Opt_IgnoreInterfacePragmas on every summary (see the depanal/load'
+    -- haddock above). The bytecode-vs-object provisioning choice is made
+    -- session-wide in canonicalizeDFlags (Opt_UseBytecodeRatherThanObjects) —
+    -- it has to be set before downsweep, since 'load' re-derives each module's
+    -- backend and ignores a field patched onto a summary here.
     let unpoison ms =
           ms { ms_hspp_opts = gopt_unset (ms_hspp_opts ms) Opt_IgnoreInterfacePragmas }
     _ <- load' Nothing LoadAllTargets mkUnknownDiagnostic (Just batchMsg)
@@ -173,6 +179,17 @@ canonicalizeDFlags dflags =
   -- Trim machine-channel noise: typed-hole "Valid hole fits include …" lists
   -- are enormous (dozens of candidates) and useless to an LLM caller; the
   -- "Perhaps you meant …" similar-name hints are a separate mechanism and stay.
+  -- -fprefer-byte-code (session-wide): when enableCodeGenForTH must provision
+  -- a splice's home-module dependencies, provision them as BYTECODE, not native
+  -- object code. Set at session init (NOT just per-summary) so GHC's downsweep
+  -- — which re-derives each module's backend inside 'load' and ignores a
+  -- backend field we patch onto a summary afterwards — chooses the interpreter.
+  -- Object-code provisioning emits a .s and shells to the assembler; under the
+  -- genericPlatform spoof that .s is x86_64/ELF and the macOS Mach-O assembler
+  -- rejects it (`.type …, @object`; x86 mnemonics on aarch64). Bytecode is
+  -- architecture-neutral, so the spoof stays confined to extracted Core while
+  -- splices run host-agnostically. (Was the OSX/aarch64 hang.)
+  (`gopt_set` Opt_UseBytecodeRatherThanObjects) $
   (`gopt_unset` Opt_ShowValidHoleFits) $
   gopt_set (gopt_set (gopt_unset (gopt_unset (updOptLevel 2 $ dflags
         { backend = noBackend

--- a/haskell/src/Tidepool/GhcPipeline.hs
+++ b/haskell/src/Tidepool/GhcPipeline.hs
@@ -188,7 +188,8 @@ canonicalizeDFlags dflags =
   -- genericPlatform spoof that .s is x86_64/ELF and the macOS Mach-O assembler
   -- rejects it (`.type …, @object`; x86 mnemonics on aarch64). Bytecode is
   -- architecture-neutral, so the spoof stays confined to extracted Core while
-  -- splices run host-agnostically. (Was the OSX/aarch64 hang.)
+  -- splices run host-agnostically. (Was the aarch64-darwin assembler failure
+  -- that broke every eval on Apple Silicon.)
   (`gopt_set` Opt_UseBytecodeRatherThanObjects) $
   (`gopt_unset` Opt_ShowValidHoleFits) $
   gopt_set (gopt_set (gopt_unset (gopt_unset (updOptLevel 2 $ dflags


### PR DESCRIPTION
## What

Makes the tidepool MCP eval server work on **aarch64-darwin (Apple Silicon)**. Previously every eval died in the assembler.

## The bug

On aarch64-darwin, every eval failed with:

```
.type TidepoolziDataziText_takeWhileEnd_closure, @object
                                                 ^ error: unknown directive
'cc' failed in phase 'Assembler'
```

GHC was emitting **x86_64/ELF assembly** (`.type …, @object`, `movq %rbx`, `jmp stg_ap_p_fast`) and handing it to the macOS **Mach-O assembler**, which rejects both the ELF directives and the x86 mnemonics.

## Root cause

An interaction of two pre-existing, individually-correct decisions:

1. **`build_preamble` puts `QuasiQuotes` always-on** in the LANGUAGE pragma. GHC's `needsTemplateHaskellOrQQ` keys on extension *presence*, so `enableCodeGenForTH` compiles the splice-needed home modules (`Tidepool.Data.Text`, …) through **native codegen** to provision splice bytecode — on *every* eval. (Already documented as a known cost in `tidepool-mcp/src/lib.rs`.)
2. **`GhcPipeline.hs` spoofs `targetPlatform = genericPlatform`** (x86_64-linux) for deterministic Core IR.

Together: that codegen emits **x86_64/ELF object code**. It assembles fine on an x86_64-linux host (host == spoofed target — which is why it "works on Linux"), but the aarch64-darwin Mach-O assembler rejects it.

The old GC-frame-walker hypothesis in `docs/aarch64-port-audit.md` was a red herring — those paths are already fixed and their tests (`gc_frame_walker`, `signal_safety`, `stack_safety`) pass on arm64.

## The fix

Set **`-fprefer-byte-code`** (`Opt_UseBytecodeRatherThanObjects`) **session-wide** in `canonicalizeDFlags`, so splices provision via the **bytecode interpreter** instead of native object code. Bytecode is architecture-neutral — no `.s`, no assembler, no platform dependence — so the `genericPlatform` spoof stays confined to the Core we serialize while splices run host-agnostically.

Must be session-wide (before `depanal`): `load'` re-derives each module's backend internally and ignores a `backend` field patched onto a summary afterward. With the flag, every home module compiles `backend=Interpreter`.

17 lines, one flag + explanatory comments. No change to the spoof, the EPS-unpoison, or any extraction logic.

## Validation (aarch64-darwin)

Full workspace was **11 failing → all green**:

- `tidepool` MCP binary suite: **48/48**
- `haskell_suite`: **218/218**
- `haskell_suite_differential`, all `proptest_*`, GC, signal-safety, stack-safety: green
- `bignum_native`: **16/16** ¹

Verified end-to-end through the default `tidepool-extract` deployment path with **no env overrides**.

¹ `bignum_native` also required deploying the native-bignum `patchedGhc` from `flake.nix` (the deployed binary predated that patch and still pulled GMP) — an orthogonal toolchain/deploy gap, not part of this code change. The native-bignum GHC is now built and cached in the nix store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)